### PR TITLE
Check signature nonces for validity

### DIFF
--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -56,9 +56,13 @@ int secp256k1_ecdsa_sign(const unsigned char *message, int messagelen, unsigned 
     secp256k1_num_set_bin(&sec, seckey, 32);
     secp256k1_num_set_bin(&non, nonce, 32);
     secp256k1_num_set_bin(&msg, message, messagelen);
+    int ret = !secp256k1_num_is_zero(&non) &&
+              (secp256k1_num_cmp(&non, &secp256k1_ge_consts->order) < 0);
     secp256k1_ecdsa_sig_t sig;
     secp256k1_ecdsa_sig_init(&sig);
-    int ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, NULL);
+    if (ret) {
+        ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, NULL);
+    }
     if (ret) {
         secp256k1_ecdsa_sig_serialize(signature, signaturelen, &sig);
     }
@@ -77,9 +81,13 @@ int secp256k1_ecdsa_sign_compact(const unsigned char *message, int messagelen, u
     secp256k1_num_set_bin(&sec, seckey, 32);
     secp256k1_num_set_bin(&non, nonce, 32);
     secp256k1_num_set_bin(&msg, message, messagelen);
+    int ret = !secp256k1_num_is_zero(&non) &&
+              (secp256k1_num_cmp(&non, &secp256k1_ge_consts->order) < 0);
     secp256k1_ecdsa_sig_t sig;
     secp256k1_ecdsa_sig_init(&sig);
-    int ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, recid);
+    if (ret) {
+        ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, recid);
+    }
     if (ret) {
         secp256k1_num_get_bin(sig64, 32, &sig.r);
         secp256k1_num_get_bin(sig64 + 32, 32, &sig.s);


### PR DESCRIPTION
The documentation implies that this check is happening, so make it so.
Without this check, passing an invalid nonce will trigger an internal assertion.

I ran into this when I was unit-testing my C++ wrapper - the library threw an assertion instead of returning false as my test was expecting.
