### PR TITLE
add pkg-config support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,8 @@ noinst_HEADERS += src/field_gmp_impl.h
 noinst_HEADERS += src/field.h
 noinst_HEADERS += src/field_impl.h
 
+pkgconfig_DATA = libsecp256k1.pc
+
 if USE_ASM
 libsecp256k1_la_SOURCES += src/field_5x52_asm.asm
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,11 @@ AC_PROG_INSTALL
 AC_PROG_SED
 PKG_PROG_PKG_CONFIG
 
+AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
+    [Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),
+    [pkgconfigdir="$withval"], [pkgconfigdir='${libdir}/pkgconfig'])
+AC_SUBST([pkgconfigdir])
+
 AC_PROG_CC_C99
 if test x"$ac_cv_prog_cc_c99" == x"no"; then
   AC_MSG_ERROR([c99 compiler support required])
@@ -284,7 +289,7 @@ AC_MSG_NOTICE([Using field implementation: $set_field])
 AC_MSG_NOTICE([Using bignum implementation: $set_bignum])
 
 AC_CONFIG_HEADERS([src/libsecp256k1-config.h])
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile libsecp256k1.pc])
 AC_SUBST(SECP_INCLUDES)
 AC_SUBST(SECP_LIBS)
 AC_SUBST(SECP_TEST_LIBS)

--- a/libsecp256k1.pc.in
+++ b/libsecp256k1.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libsecp256k1
+Description: Optimized C library for EC operations on curve secp256k1
+URL: https://github.com/bitcoin/secp256k1
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir}
+


### PR DESCRIPTION
congrats on taking the initiative to create such a useful and needed library that can enable the migration away from openssl.

this patch adds pkg-config support which is useful if you say install to non-standard locations (like when installing as a non-root user), and enables easy detection in other configure files using the macro:

PKG_CHECK_MODULES([libsecp256k1], [libsecp256k1])
