### PR TITLE
Implement batch inversion of field elements

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -94,6 +94,14 @@ void static secp256k1_fe_inv(secp256k1_fe_t *r, const secp256k1_fe_t *a);
 /** Potentially faster version of secp256k1_fe_inv, without constant-time guarantee. */
 void static secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a);
 
+/** Calculate the (modular) inverses of a batch of field elements. Requires the inputs' magnitudes to be
+ *  at most 8. The output magnitudes are 1 (but not guaranteed to be normalized). The inputs and
+ *  outputs must not overlap in memory. */
+void static secp256k1_fe_inv_all(size_t len, secp256k1_fe_t r[len], const secp256k1_fe_t a[len]);
+
+/** Potentially faster version of secp256k1_fe_inv_all, without constant-time guarantee. */
+void static secp256k1_fe_inv_all_var(size_t len, secp256k1_fe_t r[len], const secp256k1_fe_t a[len]);
+
 
 /** Convert a field element to a hexadecimal string. */
 void static secp256k1_fe_get_hex(char *r, int *rlen, const secp256k1_fe_t *a);

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -214,6 +214,54 @@ void static secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 #endif
 }
 
+void static secp256k1_fe_inv_all(size_t len, secp256k1_fe_t r[len], const secp256k1_fe_t a[len]) {
+    if (len < 1)
+        return;
+
+    assert((r + len <= a) || (a + len <= r));
+
+    r[0] = a[0];
+
+    int i = 0;
+    while (++i < len) {
+        secp256k1_fe_mul(&r[i], &r[i - 1], &a[i]);
+    }
+
+    secp256k1_fe_t u; secp256k1_fe_inv(&u, &r[--i]);
+
+    while (i > 0) {
+        int j = i--;
+        secp256k1_fe_mul(&r[j], &r[i], &u);
+        secp256k1_fe_mul(&u, &u, &a[j]);
+    }
+
+    r[0] = u;
+}
+
+void static secp256k1_fe_inv_all_var(size_t len, secp256k1_fe_t r[len], const secp256k1_fe_t a[len]) {
+    if (len < 1)
+        return;
+
+    assert((r + len <= a) || (a + len <= r));
+
+    r[0] = a[0];
+
+    int i = 0;
+    while (++i < len) {
+        secp256k1_fe_mul(&r[i], &r[i - 1], &a[i]);
+    }
+
+    secp256k1_fe_t u; secp256k1_fe_inv_var(&u, &r[--i]);
+
+    while (i > 0) {
+        int j = i--;
+        secp256k1_fe_mul(&r[j], &r[i], &u);
+        secp256k1_fe_mul(&u, &u, &a[j]);
+    }
+
+    r[0] = u;
+}
+
 void static secp256k1_fe_start(void) {
     static const unsigned char secp256k1_fe_consts_p[] = {
         0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,

--- a/src/group.h
+++ b/src/group.h
@@ -68,6 +68,9 @@ void static secp256k1_ge_get_hex(char *r, int *rlen, const secp256k1_ge_t *a);
 /** Set a group element equal to another which is given in jacobian coordinates */
 void static secp256k1_ge_set_gej(secp256k1_ge_t *r, secp256k1_gej_t *a);
 
+/** Set a batch of group elements equal to the inputs given in jacobian coordinates */
+void static secp256k1_ge_set_all_gej(size_t len, secp256k1_ge_t r[len], const secp256k1_gej_t a[len]);
+
 
 /** Set a group element (jacobian) equal to the point at infinity. */
 void static secp256k1_gej_set_infinity(secp256k1_gej_t *r);

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -66,6 +66,31 @@ void static secp256k1_ge_set_gej(secp256k1_ge_t *r, secp256k1_gej_t *a) {
     r->y = a->y;
 }
 
+void static secp256k1_ge_set_all_gej(size_t len, secp256k1_ge_t r[len], const secp256k1_gej_t a[len]) {
+    int count = 0;
+    secp256k1_fe_t az[len];
+    for (int i=0; i<len; i++) {
+        if (!a[i].infinity) {
+            az[count++] = a[i].z;
+        }
+    }
+
+    secp256k1_fe_t azi[count];
+    secp256k1_fe_inv_all_var(count, azi, az);
+
+    count = 0;
+    for (int i=0; i<len; i++) {
+        r[i].infinity = a[i].infinity;
+        if (!a[i].infinity) {
+            secp256k1_fe_t *zi = &azi[count++];
+            secp256k1_fe_t zi2; secp256k1_fe_sqr(&zi2, zi);
+            secp256k1_fe_t zi3; secp256k1_fe_mul(&zi3, &zi2, zi);
+            secp256k1_fe_mul(&r[i].x, &a[i].x, &zi2);
+            secp256k1_fe_mul(&r[i].y, &a[i].y, &zi3);
+        }
+    }
+}
+
 void static secp256k1_gej_set_infinity(secp256k1_gej_t *r) {
     r->infinity = 1;
 }


### PR DESCRIPTION
Adds secp256k1_fe_inv_all and secp256k1_fe_inv_all_var methods for batch inversion of field elements, implemented using "Montgomery's Trick", which uses only one actual field inversion, trading off the others for 3 field multiplications each.

Includes randomised tests covering the new methods and also coverage for the existing inv/inv_var methods.
