### PR TITLE
Add MacPorts default include/lib paths for OSX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,13 @@ case $host in
      ;;
 esac
 
+case $host_os in
+  darwin*)
+     CPPFLAGS="$CPPFLAGS -I/opt/local/include"
+     LDFLAGS="$LDFLAGS -L/opt/local/lib"
+     ;;
+esac
+
 AC_ARG_ENABLE(benchmark,
     AS_HELP_STRING([--enable-benchmark],[compile benchmark (default is yes)]),
     [use_benchmark=$enableval],


### PR DESCRIPTION
I'm no expert on autoconf et. al., but with this change I can build on OSX 10.9 with MacPorts 2.2.1 (ports installed: autoconf, automake, gmp, libtool).
