### PR TITLE
Do not free endomorphism constants when disabled

### DIFF
--- a/src/group.h
+++ b/src/group.h
@@ -29,9 +29,11 @@ typedef struct {
     secp256k1_num_t half_order; // half the order of the curve (= order of its generator)
     secp256k1_ge_t g; // the generator point
 
+#ifdef USE_ENDOMORPHISM
     // constants related to secp256k1's efficiently computable endomorphism
     secp256k1_fe_t beta;
     secp256k1_num_t lambda, a1b2, b1, a2;
+#endif
 } secp256k1_ge_consts_t;
 
 static const secp256k1_ge_consts_t *secp256k1_ge_consts = NULL;

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -393,10 +393,12 @@ void static secp256k1_ge_stop(void) {
         secp256k1_ge_consts_t *c = (secp256k1_ge_consts_t*)secp256k1_ge_consts;
         secp256k1_num_free(&c->order);
         secp256k1_num_free(&c->half_order);
+#ifdef USE_ENDOMORPHISM
         secp256k1_num_free(&c->lambda);
         secp256k1_num_free(&c->a1b2);
         secp256k1_num_free(&c->a2);
         secp256k1_num_free(&c->b1);
+#endif
         free((void*)c);
         secp256k1_ge_consts = NULL;
     }


### PR DESCRIPTION
Closes #27.
