### PR TITLE
Test demonstrating discrepancy in sqr output

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -42,6 +42,10 @@ void static secp256k1_fe_start(void);
 /** Unload field element precomputation data. */
 void static secp256k1_fe_stop(void);
 
+#ifdef VERIFY
+int  static secp256k1_fe_verify(const secp256k1_fe_t * a);
+#endif
+
 /** Normalize a field element. */
 void static secp256k1_fe_normalize(secp256k1_fe_t *r);
 

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -33,6 +33,25 @@
 void static secp256k1_fe_inner_start(void) {}
 void static secp256k1_fe_inner_stop(void) {}
 
+#ifdef VERIFY
+int static secp256k1_fe_verify(const secp256k1_fe_t * a) {
+    const uint64_t *d = a->n;
+    int m = a->magnitude, r = 1;
+    r &= (d[0] <= 0xFFFFFFFFFFFFFULL * m);
+    r &= (d[1] <= 0xFFFFFFFFFFFFFULL * m);
+    r &= (d[2] <= 0xFFFFFFFFFFFFFULL * m);
+    r &= (d[3] <= 0xFFFFFFFFFFFFFULL * m);
+    r &= (d[4] <= 0x0FFFFFFFFFFFFULL * m);
+    if (a->normalized) {
+        r &= (m == 1);
+        if (r && (d[4] == 0x0FFFFFFFFFFFFULL) && ((d[3] & d[2] & d[1]) == 0xFFFFFFFFFFFFFULL)) {
+            r &= (d[0] < 0xFFFFEFFFFFC2FULL);
+        }
+    }
+    return r;
+}
+#endif
+
 void static secp256k1_fe_normalize(secp256k1_fe_t *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
 


### PR DESCRIPTION
Please refer to field_5x52_int128_impl.h, secp256k1_fe_sqr_inner method, the reduction part at the end (comments should also apply to secp256k1_fe_mul_inner, and the issue may exist for other field implementations, but here I discuss '64bit').

The docs/contract for secp256k1_fe_sqr say that the output will be magnitude 1, and other comments explain that the elements are therefore limited to M_(2^53-1) for all limbs except the first (M_(2^49-1)). Yet, by inspection the reduction in _sqr_inner appears insufficient (t1's value is unconstrained when "r[1] = t1 + c"). Indeed, inputs can be easily found to reveal the problem, as demonstrated in the test case with this PR.

(I emphasise that the output value is mathematically correct, but violates the limits for magnitude 1.)

e.g. sqr(-65537) leads to a carry into t1, which is already 0xFFFFFFFFFFFFF, and the carry does not propagate. Indeed, in this case, it would have to propagate all the way up to t4 and back to t0 again! The test case samples some other problematic inputs across a large range of bit lengths; it is not an isolated case, and the carry into t1(==0xFF....) can be larger than 1.

It's not clear whether this can actually cause higher-level failures. Negation uses (M+1), normalisation seems unaffected. In theory, mul_int(x, 4096) would overflow unexpectedly! mul_int(x, 8) could lead to a value that was in theory too large for mul/sqr input, but in practice those methods tolerate larger values. If there were a 9x29 field, there would definitely be problems, with only 3 bits to spare.

It would be unfortunate to have to add an entire extra reduction round in sqr/mul, but I think an earlier reduction of t9 might help (similar to the normalization changes from https://github.com/bitcoin/secp256k1/pull/24). Not sure if I'd be competent to attempt the asm version, assuming it is similarly affected.

I suppose it might be considered to "fix" this by adjusting the magnitude system or method contracts, so I await a discussion before proceeding.
