### PR TITLE
build: grab full paths to host tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,10 @@ AC_PROG_INSTALL
 AC_PROG_SED
 PKG_PROG_PKG_CONFIG
 
+AC_PATH_TOOL(AR, ar)
+AC_PATH_TOOL(RANLIB, ranlib)
+AC_PATH_TOOL(STRIP, strip)
+
 AC_PROG_CC_C99
 if test x"$ac_cv_prog_cc_c99" == x"no"; then
   AC_MSG_ERROR([c99 compiler support required])


### PR DESCRIPTION
This ensures that make will work even if PATH has changed after configure, which is often the
case when cross-compiling.

Fixes cross builds when integrated into Bitcoin's repo.
