### PR TITLE
Add secp256k1_num_eq and use it in tests

### DIFF
--- a/src/num.h
+++ b/src/num.h
@@ -45,6 +45,9 @@ void static secp256k1_num_mod_mul(secp256k1_num_t *r, const secp256k1_num_t *a, 
 /** Compare the absolute value of two numbers. */
 int  static secp256k1_num_cmp(const secp256k1_num_t *a, const secp256k1_num_t *b);
 
+/** Test whether two number are equal (including sign). */
+int  static secp256k1_num_eq(const secp256k1_num_t *a, const secp256k1_num_t *b);
+
 /** Add two (signed) numbers. */
 void static secp256k1_num_add(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b);
 

--- a/src/num_gmp_impl.h
+++ b/src/num_gmp_impl.h
@@ -161,6 +161,13 @@ int static secp256k1_num_cmp(const secp256k1_num_t *a, const secp256k1_num_t *b)
     return mpn_cmp(a->data, b->data, a->limbs);
 }
 
+int static secp256k1_num_eq(const secp256k1_num_t *a, const secp256k1_num_t *b) {
+    if (a->limbs > b->limbs) return 0;
+    if (a->limbs < b->limbs) return 0;
+    if ((a->neg && !secp256k1_num_is_zero(a)) != (b->neg && !secp256k1_num_is_zero(b))) return 0;
+    return mpn_cmp(a->data, b->data, a->limbs) == 0;
+}
+
 void static secp256k1_num_subadd(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b, int bneg) {
     if (!(b->neg ^ bneg ^ a->neg)) { // a and b have the same sign
         r->neg = a->neg;

--- a/src/num_openssl_impl.h
+++ b/src/num_openssl_impl.h
@@ -54,7 +54,11 @@ void static secp256k1_num_mod_mul(secp256k1_num_t *r, const secp256k1_num_t *a, 
 }
 
 int static secp256k1_num_cmp(const secp256k1_num_t *a, const secp256k1_num_t *b) {
-    return BN_cmp(&a->bn, &b->bn);
+    return BN_ucmp(&a->bn, &b->bn);
+}
+
+int static secp256k1_num_eq(const secp256k1_num_t *a, const secp256k1_num_t *b) {
+    return BN_cmp(&a->bn, &b->bn) == 0;
 }
 
 void static secp256k1_num_add(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b) {


### PR DESCRIPTION
The previously used secp256k1_num_cmp is not sufficient, because it doesn't compare sign.
