### PR TITLE
API BREAKAGE: add a lows flag to secp256k1_ecdsa_sign

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -39,6 +39,7 @@ int secp256k1_ecdsa_verify(const unsigned char *msg, int msglen,
  *           msglen: the length of the message being signed
  *           seckey: pointer to a 32-byte secret key (assumed to be valid)
  *           nonce:  pointer to a 32-byte nonce (generated with a cryptographic PRNG)
+ *           lows:   whether S values should be negated (modulo the order) if above order/2
  *  Out:     sig:    pointer to a 72-byte array where the signature will be placed.
  *           siglen: pointer to an int, which will be updated to the signature length (<=72).
  * Requires starting using SECP256K1_START_SIGN.
@@ -46,7 +47,8 @@ int secp256k1_ecdsa_verify(const unsigned char *msg, int msglen,
 int secp256k1_ecdsa_sign(const unsigned char *msg, int msglen,
                          unsigned char *sig, int *siglen,
                          const unsigned char *seckey,
-                         const unsigned char *nonce);
+                         const unsigned char *nonce,
+                         int lows);
 
 /** Create a compact ECDSA signature (64 byte + recovery id).
  *  Returns: 1: signature created

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -19,7 +19,7 @@ void static secp256k1_ecdsa_pubkey_serialize(secp256k1_ge_t *elem, unsigned char
 int static secp256k1_ecdsa_sig_parse(secp256k1_ecdsa_sig_t *r, const unsigned char *sig, int size);
 int static secp256k1_ecdsa_sig_serialize(unsigned char *sig, int *size, const secp256k1_ecdsa_sig_t *a);
 int static secp256k1_ecdsa_sig_verify(const secp256k1_ecdsa_sig_t *sig, const secp256k1_ge_t *pubkey, const secp256k1_num_t *message);
-int static secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_num_t *seckey, const secp256k1_num_t *message, const secp256k1_num_t *nonce, int *recid);
+int static secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_num_t *seckey, const secp256k1_num_t *message, const secp256k1_num_t *nonce, int *recid, int lows);
 int static secp256k1_ecdsa_sig_recover(const secp256k1_ecdsa_sig_t *sig, secp256k1_ge_t *pubkey, const secp256k1_num_t *message, int recid);
 void static secp256k1_ecdsa_sig_set_rs(secp256k1_ecdsa_sig_t *sig, const secp256k1_num_t *r, const secp256k1_num_t *s);
 int static secp256k1_ecdsa_privkey_parse(secp256k1_num_t *key, const unsigned char *privkey, int privkeylen);

--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -164,7 +164,7 @@ int static secp256k1_ecdsa_sig_verify(const secp256k1_ecdsa_sig_t *sig, const se
     return ret;
 }
 
-int static secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_num_t *seckey, const secp256k1_num_t *message, const secp256k1_num_t *nonce, int *recid) {
+int static secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_num_t *seckey, const secp256k1_num_t *message, const secp256k1_num_t *nonce, int *recid, int lows) {
     const secp256k1_ge_consts_t *c = secp256k1_ge_consts;
 
     secp256k1_gej_t rp;
@@ -192,7 +192,7 @@ int static secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_
     secp256k1_ge_clear(&r);
     if (secp256k1_num_is_zero(&sig->s))
         return 0;
-    if (secp256k1_num_cmp(&sig->s, &c->half_order) > 0) {
+    if (lows && secp256k1_num_cmp(&sig->s, &c->half_order) > 0) {
         secp256k1_num_sub(&sig->s, &c->order, &sig->s);
         if (recid)
             *recid ^= 1;

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -64,7 +64,7 @@ end:
     return ret;
 }
 
-int secp256k1_ecdsa_sign(const unsigned char *message, int messagelen, unsigned char *signature, int *signaturelen, const unsigned char *seckey, const unsigned char *nonce) {
+int secp256k1_ecdsa_sign(const unsigned char *message, int messagelen, unsigned char *signature, int *signaturelen, const unsigned char *seckey, const unsigned char *nonce, int lows) {
     DEBUG_CHECK(secp256k1_ecmult_gen_consts != NULL);
     DEBUG_CHECK(message != NULL);
     DEBUG_CHECK(messagelen <= 32);
@@ -85,7 +85,7 @@ int secp256k1_ecdsa_sign(const unsigned char *message, int messagelen, unsigned 
     secp256k1_ecdsa_sig_t sig;
     secp256k1_ecdsa_sig_init(&sig);
     if (ret) {
-        ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, NULL);
+        ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, NULL, lows);
     }
     if (ret) {
         secp256k1_ecdsa_sig_serialize(signature, signaturelen, &sig);
@@ -120,7 +120,7 @@ int secp256k1_ecdsa_sign_compact(const unsigned char *message, int messagelen, u
     secp256k1_ecdsa_sig_t sig;
     secp256k1_ecdsa_sig_init(&sig);
     if (ret) {
-        ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, recid);
+        ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, recid, 1);
     }
     if (ret) {
         secp256k1_num_get_bin(sig64, 32, &sig.r);

--- a/src/tests.c
+++ b/src/tests.c
@@ -512,7 +512,7 @@ void random_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_num_t *key, const s
     secp256k1_num_init(&nonce);
     do {
         random_num_order_test(&nonce);
-    } while(!secp256k1_ecdsa_sig_sign(sig, key, msg, &nonce, recid));
+    } while(!secp256k1_ecdsa_sig_sign(sig, key, msg, &nonce, recid, 1));
     secp256k1_num_free(&nonce);
 }
 
@@ -603,7 +603,7 @@ void test_ecdsa_end_to_end() {
     while(1) {
         unsigned char rnd[32];
         secp256k1_rand256_test(rnd);
-        if (secp256k1_ecdsa_sign(message, 32, signature, &signaturelen, privkey, rnd) == 1) {
+        if (secp256k1_ecdsa_sign(message, 32, signature, &signaturelen, privkey, rnd, 1) == 1) {
             break;
         }
     }


### PR DESCRIPTION
Not sure if tests are necessary here. I've probably oversimplified, but this was enough to get bitcoin's tests passing again with libsecp256k1.
