### PR TITLE
Fix interaction between magnitudes and negation

### DIFF
--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -188,16 +188,16 @@ void static inline secp256k1_fe_negate(secp256k1_fe_t *r, const secp256k1_fe_t *
     VERIFY_CHECK(a->magnitude <= m);
     secp256k1_fe_verify(a);
 #endif
-    r->n[0] = 0x3FFFC2FUL * (m + 1) - a->n[0];
-    r->n[1] = 0x3FFFFBFUL * (m + 1) - a->n[1];
-    r->n[2] = 0x3FFFFFFUL * (m + 1) - a->n[2];
-    r->n[3] = 0x3FFFFFFUL * (m + 1) - a->n[3];
-    r->n[4] = 0x3FFFFFFUL * (m + 1) - a->n[4];
-    r->n[5] = 0x3FFFFFFUL * (m + 1) - a->n[5];
-    r->n[6] = 0x3FFFFFFUL * (m + 1) - a->n[6];
-    r->n[7] = 0x3FFFFFFUL * (m + 1) - a->n[7];
-    r->n[8] = 0x3FFFFFFUL * (m + 1) - a->n[8];
-    r->n[9] = 0x03FFFFFUL * (m + 1) - a->n[9];
+    r->n[0] = 0x3FFFC2FUL * 2 * (m + 1) - a->n[0];
+    r->n[1] = 0x3FFFFBFUL * 2 * (m + 1) - a->n[1];
+    r->n[2] = 0x3FFFFFFUL * 2 * (m + 1) - a->n[2];
+    r->n[3] = 0x3FFFFFFUL * 2 * (m + 1) - a->n[3];
+    r->n[4] = 0x3FFFFFFUL * 2 * (m + 1) - a->n[4];
+    r->n[5] = 0x3FFFFFFUL * 2 * (m + 1) - a->n[5];
+    r->n[6] = 0x3FFFFFFUL * 2 * (m + 1) - a->n[6];
+    r->n[7] = 0x3FFFFFFUL * 2 * (m + 1) - a->n[7];
+    r->n[8] = 0x3FFFFFFUL * 2 * (m + 1) - a->n[8];
+    r->n[9] = 0x03FFFFFUL * 2 * (m + 1) - a->n[9];
 #ifdef VERIFY
     r->magnitude = m + 1;
     r->normalized = 0;

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -185,11 +185,11 @@ void static inline secp256k1_fe_negate(secp256k1_fe_t *r, const secp256k1_fe_t *
     VERIFY_CHECK(a->magnitude <= m);
     secp256k1_fe_verify(a);
 #endif
-    r->n[0] = 0xFFFFEFFFFFC2FULL * (m + 1) - a->n[0];
-    r->n[1] = 0xFFFFFFFFFFFFFULL * (m + 1) - a->n[1];
-    r->n[2] = 0xFFFFFFFFFFFFFULL * (m + 1) - a->n[2];
-    r->n[3] = 0xFFFFFFFFFFFFFULL * (m + 1) - a->n[3];
-    r->n[4] = 0x0FFFFFFFFFFFFULL * (m + 1) - a->n[4];
+    r->n[0] = 0xFFFFEFFFFFC2FULL * 2 * (m + 1) - a->n[0];
+    r->n[1] = 0xFFFFFFFFFFFFFULL * 2 * (m + 1) - a->n[1];
+    r->n[2] = 0xFFFFFFFFFFFFFULL * 2 * (m + 1) - a->n[2];
+    r->n[3] = 0xFFFFFFFFFFFFFULL * 2 * (m + 1) - a->n[3];
+    r->n[4] = 0x0FFFFFFFFFFFFULL * 2 * (m + 1) - a->n[4];
 #ifdef VERIFY
     r->magnitude = m + 1;
     r->normalized = 0;


### PR DESCRIPTION
Magnitude m means values are allowed to be up to 2 \* 0xFFF...FFF \* m, while the argument passed to secp256k1_fe_negate didn't take the 2 into account. Fix this.
