### PR TITLE
Add DETERMINISTIC to avoid line number/source dependent binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - if [ "$FIELD" = "64bit_asm" ]; then sudo apt-get install -qq yasm; fi
 env:
   global:
-    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  BUILD=check
+    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  BUILD=check  EXTRAFLAGS=
   matrix:
     - SCALAR=32bit
     - SCALAR=64bit
@@ -19,6 +19,7 @@ env:
     - FIELD=32bit
     - FIELD=32bit     ENDOMORPHISM=yes
     - BUILD=distcheck
+    - EXTRAFLAGS=CFLAGS=-DDETERMINISTIC
 before_script: ./autogen.sh
-script: ./configure --enable-endomorphism=$ENDOMORPHISM --with-field=$FIELD --with-bignum=$BIGNUM --with-scalar=$SCALAR && make -j2 $BUILD
+script: ./configure --enable-endomorphism=$ENDOMORPHISM --with-field=$FIELD --with-bignum=$BIGNUM --with-scalar=$SCALAR $EXTRAFLAGS && make -j2 $BUILD
 os: linux

--- a/src/util.h
+++ b/src/util.h
@@ -15,10 +15,17 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef DETERMINISTIC
+#define TEST_FAILURE(msg) do { \
+    fprintf(stderr, "%s\n", msg); \
+    abort(); \
+} while(0);
+#else
 #define TEST_FAILURE(msg) do { \
     fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, msg); \
     abort(); \
 } while(0)
+#endif
 
 #ifndef HAVE_BUILTIN_EXPECT
 #define EXPECT(x,c) __builtin_expect((x),(c))
@@ -26,11 +33,19 @@
 #define EXPECT(x,c) (x)
 #endif
 
+#ifdef DETERMINISTIC
+#define CHECK(cond) do { \
+    if (EXPECT(!(cond), 0)) { \
+        TEST_FAILURE("test condition failed"); \
+    } \
+} while(0)
+#else
 #define CHECK(cond) do { \
     if (EXPECT(!(cond), 0)) { \
         TEST_FAILURE("test condition failed: " #cond); \
     } \
 } while(0)
+#endif
 
 /* Like assert(), but safe to use on expressions with side effects. */
 #ifndef NDEBUG


### PR DESCRIPTION
This will make it easier to detect changes without semantic impact.
