### PR TITLE
Optimize doubling: secp256k1 has no y=0 point

### DIFF
--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -208,6 +208,9 @@ static int secp256k1_ge_is_valid(const secp256k1_ge_t *a) {
 }
 
 static void secp256k1_gej_double_var(secp256k1_gej_t *r, const secp256k1_gej_t *a) {
+    // For secp256k1, 2Q is infinity if and only if Q is infinity. This is because if 2Q = infinity,
+    // Q must equal -Q, or that Q.y == -(Q.y), or Q.y is 0. For a point on y^2 = x^3 + 7 to have
+    // y=0, x^3 must be -7 mod p. However, -7 has no cube root mod p.
     r->infinity = a->infinity;
     if (r->infinity) {
         return;


### PR DESCRIPTION
This gives a 1.5% verification improvement when using the endomorphism, 2.3% improvement when not.
