### PR TITLE
Fix a memory leak and add a number of small tests.

### DIFF
--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -48,7 +48,7 @@ static void secp256k1_ecdsa_stop(void) {
     if (secp256k1_ecdsa_consts == NULL)
         return;
 
-    secp256k1_ecdsa_consts_t *c = (secp256k1_ecdsa_consts_t*)secp256k1_ecmult_consts;
+    secp256k1_ecdsa_consts_t *c = (secp256k1_ecdsa_consts_t*)secp256k1_ecdsa_consts;
     secp256k1_ecdsa_consts = NULL;
     free(c);
 }


### PR DESCRIPTION
This fixes a simple copy and paste induced memory leak for the ecdsa init.

The tests are mostly just improving coverage and aren't interesting.
