### PR TITLE
Include time.h header for time().

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -11,6 +11,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <time.h>
+
 #include "secp256k1.c"
 #include "testrand_impl.h"
 


### PR DESCRIPTION
Prevents compiler warning:

```
src/tests.c: In function ‘main’:
src/tests.c:1139: warning: implicit declaration of function ‘time’
src/tests.c:1139: warning: nested extern declaration of ‘time’
```
