### PR TITLE
build: use subdir-objects for automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_CANONICAL_HOST
 AH_TOP([#ifndef LIBSECP256K1_CONFIG_H])
 AH_TOP([#define LIBSECP256K1_CONFIG_H])
 AH_BOTTOM([#endif //LIBSECP256K1_CONFIG_H])
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 LT_INIT
 
 dnl make the compilation flags quiet unless V=1 is used


### PR DESCRIPTION
Fixes #147. This does what it sounds like, putting objects in the subdir rather than root. Verified that it doesn't upset the current build, and doesn't cause problems when merged into bitcoin.
