### PR TITLE
Configure options reorganization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,20 @@ install:
   - if [ -n "$EXTRAPACKAGES" ]; then sudo apt-get update && sudo apt-get install --no-install-recommends --no-upgrade $EXTRAPACKAGES; fi
 env:
   global:
-    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  BUILD=check  EXTRAFLAGS= HOST= EXTRAPACKAGES=
+    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  ASM=no  BUILD=check  EXTRAFLAGS= HOST= EXTRAPACKAGES=
   matrix:
     - SCALAR=32bit
     - SCALAR=64bit
     - FIELD=gmp
     - FIELD=gmp       ENDOMORPHISM=yes
-    - FIELD=64bit_asm
-    - FIELD=64bit_asm ENDOMORPHISM=yes
     - FIELD=64bit
     - FIELD=64bit     ENDOMORPHISM=yes
+    - FIELD=64bit                       ASM=x86_64
+    - FIELD=64bit     ENDOMORPHISM=yes  ASM=x86_64
     - FIELD=32bit
     - FIELD=32bit     ENDOMORPHISM=yes
-    - BIGNUM=none
-    - BIGNUM=none     ENDOMORPHISM=yes
+    - BIGNUM=no
+    - BIGNUM=no       ENDOMORPHISM=yes
     - BUILD=distcheck
     - EXTRAFLAGS=CFLAGS=-DDETERMINISTIC
     - HOST=i686-linux-gnu EXTRAPACKAGES="gcc-multilib"

--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -1,12 +1,6 @@
 dnl libsecp25k1 helper checks
 AC_DEFUN([SECP_INT128_CHECK],[
 has_int128=$ac_cv_type___int128
-if test x"$has_int128" != x"yes" && test x"$set_field" = x"64bit"; then
-  AC_MSG_ERROR([$set_field field support explicitly requested but is not compatible with this host])
-fi
-if test x"$has_int128" != x"yes" && test x"$set_scalar" = x"64bit"; then
-  AC_MSG_ERROR([$set_scalar scalar support explicitly requested but is not compatible with this host])
-fi
 ])
 
 dnl 
@@ -18,11 +12,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   __asm__ __volatile__("movq $0x100000000,%1; mulq %%rsi" : "+a"(a) : "S"(tmp) : "cc", "%rdx");
   ]])],[has_64bit_asm=yes],[has_64bit_asm=no])
 AC_MSG_RESULT([$has_64bit_asm])
-if test x"$set_field" = x"64bit_asm"; then
-  if test x"$has_64bit_asm" = x"no"; then
-    AC_MSG_ERROR([$set_field field support explicitly requested but no x86_64 assembly available])
-  fi
-fi
 ])
 
 dnl
@@ -69,11 +58,4 @@ if test x"$has_gmp" != x"yes"; then
   CPPFLAGS="$CPPFLAGS_TEMP"
   LIBS="$LIBS_TEMP"
 fi
-if test x"$set_field" = x"gmp" && test x"$has_gmp" != x"yes"; then
-    AC_MSG_ERROR([$set_field field support explicitly requested but libgmp was not found])
-fi
-if test x"$set_bignum" = x"gmp" && test x"$has_gmp" != x"yes"; then
-    AC_MSG_ERROR([$set_bignum field support explicitly requested but libgmp was not found])
-fi
 ])
-

--- a/configure.ac
+++ b/configure.ac
@@ -96,14 +96,17 @@ AC_ARG_ENABLE(endomorphism,
     [use_endomorphism=$enableval],
     [use_endomorphism=no])
 
-AC_ARG_WITH([field], [AS_HELP_STRING([--with-field=gmp|64bit|64bit_asm|32bit|auto],
+AC_ARG_WITH([field], [AS_HELP_STRING([--with-field=gmp|64bit|32bit|auto],
 [Specify Field Implementation. Default is auto])],[req_field=$withval], [req_field=auto])
 
-AC_ARG_WITH([bignum], [AS_HELP_STRING([--with-bignum=gmp|none|auto],
+AC_ARG_WITH([bignum], [AS_HELP_STRING([--with-bignum=gmp|no|auto],
 [Specify Bignum Implementation. Default is auto])],[req_bignum=$withval], [req_bignum=auto])
 
 AC_ARG_WITH([scalar], [AS_HELP_STRING([--with-scalar=64bit|32bit|auto],
 [Specify scalar implementation. Default is auto])],[req_scalar=$withval], [req_scalar=auto])
+
+AC_ARG_WITH([asm], [AS_HELP_STRING([--with-asm=x86_64|no|auto]
+[Specify assembly optimizations to use. Default is auto])],[req_asm=$withval], [req_asm=auto])
 
 AC_CHECK_TYPES([__int128])
 
@@ -113,40 +116,66 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[void myfunc() {__builtin_expect(0,0);}]])],
     [ AC_MSG_RESULT([no])
     ])
 
-if test x"$req_field" = x"auto"; then
+if test x"$req_asm" = x"auto"; then
   SECP_64BIT_ASM_CHECK
   if test x"$has_64bit_asm" = x"yes"; then
-    set_field=64bit_asm
+    set_asm=x86_64
   fi
+  if test x"$set_asm" = x; then
+    set_asm=no
+  fi
+else
+  set_asm=$req_asm
+  case $set_asm in
+  x86_64)
+    SECP_64BIT_ASM_CHECK
+    if test x"$has_64bit_asm" != x"yes"; then
+      AC_MSG_ERROR([x86_64 assembly optimization requested but not available])
+    fi
+    ;;
+  no)
+    ;;
+  *)
+    AC_MSG_ERROR([invalid assembly optimization selection])
+    ;;
+  esac
+fi
 
+if test x"$req_field" = x"auto"; then
+  if test x"set_asm" = x"x86_64"; then
+    set_field=64bit
+  fi
   if test x"$set_field" = x; then
     SECP_INT128_CHECK
     if test x"$has_int128" = x"yes"; then
       set_field=64bit
     fi
   fi
-
   if test x"$set_field" = x; then
     SECP_GMP_CHECK
     if test x"$has_gmp" = x"yes"; then
       set_field=gmp
     fi
   fi
-
   if test x"$set_field" = x; then
     set_field=32bit
   fi
 else
   set_field=$req_field
   case $set_field in
-  64bit_asm)
-    SECP_64BIT_ASM_CHECK
-    ;;
   64bit)
-    SECP_INT128_CHECK
+    if test x"$set_asm" != x"x86_64"; then
+      SECP_INT128_CHECK
+      if test x"$has_int128" != x"yes"; then
+        AC_MSG_ERROR([64bit field explicitly requested but neither __int128 support or x86_64 assembly available])
+      fi
+    fi
     ;;
   gmp)
     SECP_GMP_CHECK
+    if test x"$has_gmp" != x"yes"; then
+      AC_MSG_ERROR([gmp field explicitly requested but libgmp not available])
+    fi
     ;;
   32bit)
     ;;
@@ -157,11 +186,9 @@ else
 fi
 
 if test x"$req_scalar" = x"auto"; then
-  if test x"$set_scalar" = x; then
-    SECP_INT128_CHECK
-    if test x"$has_int128" = x"yes"; then
-      set_scalar=64bit
-    fi
+  SECP_INT128_CHECK
+  if test x"$has_int128" = x"yes"; then
+    set_scalar=64bit
   fi
   if test x"$set_scalar" = x; then
     set_scalar=32bit
@@ -171,6 +198,9 @@ else
   case $set_scalar in
   64bit)
     SECP_INT128_CHECK
+    if test x"$has_int128" != x"yes"; then
+      AC_MSG_ERROR([64bit scalar explicitly requested but __int128 support not available])
+    fi
     ;;
   32bit)
     ;;
@@ -187,15 +217,18 @@ if test x"$req_bignum" = x"auto"; then
   fi
 
   if test x"$set_bignum" = x; then
-    set_bignum=none
+    set_bignum=no
   fi
 else
   set_bignum=$req_bignum
   case $set_bignum in
   gmp)
     SECP_GMP_CHECK
+    if test x"$has_gmp" != x"yes"; then
+      AC_MSG_ERROR([gmp bignum explicitly requested but libgmp not available])
+    fi
     ;;
-  none)
+  no)
     ;;
   *)
     AC_MSG_ERROR([invalid bignum implementation selection])
@@ -203,14 +236,21 @@ else
   esac
 fi
 
+# select assembly optimization
+case $set_asm in
+x86_64)
+  AC_DEFINE(USE_ASM_X86_64, 1, [Define this symbol to enable x86_64 assembly optimizations])
+  ;;
+no)
+  ;;
+*)
+  AC_MSG_ERROR([invalid assembly optimizations])
+  ;;
+esac
+
 # select field implementation
 case $set_field in
-64bit_asm)
-  AC_DEFINE(USE_FIELD_5X52_ASM, 1, [Define this symbol to use the assembly version for the 5x52 field implementation])
-  AC_DEFINE(USE_FIELD_5X52, 1, [Define this symbol to use the FIELD_5X52 implementation])
-  ;;
 64bit)
-  AC_DEFINE(USE_FIELD_5X52_INT128, 1, [Define this symbol to use the __int128 version for the 5x52 field implementation])
   AC_DEFINE(USE_FIELD_5X52, 1, [Define this symbol to use the FIELD_5X52 implementation])
   ;;
 gmp)
@@ -233,7 +273,7 @@ gmp)
   AC_DEFINE(USE_FIELD_INV_NUM, 1, [Define this symbol to use the num-based field inverse implementation])
   AC_DEFINE(USE_SCALAR_INV_NUM, 1, [Define this symbol to use the num-based scalar inverse implementation])
   ;;
-none)
+no)
   AC_DEFINE(USE_NUM_NONE, 1, [Define this symbol to use no num implementation])
   AC_DEFINE(USE_FIELD_INV_BUILTIN, 1, [Define this symbol to use the native field inverse implementation])
   AC_DEFINE(USE_SCALAR_INV_BUILTIN, 1, [Define this symbol to use the native scalar inverse implementation])
@@ -281,9 +321,11 @@ if test x"$use_endomorphism" = x"yes"; then
   AC_DEFINE(USE_ENDOMORPHISM, 1, [Define this symbol to use endomorphism optimization])
 fi
 
+AC_MSG_NOTICE([Using assembly optimizations: $set_asm])
 AC_MSG_NOTICE([Using field implementation: $set_field])
 AC_MSG_NOTICE([Using bignum implementation: $set_bignum])
 AC_MSG_NOTICE([Using scalar implementation: $set_scalar])
+AC_MSG_NOTICE([Using endomorphism optimizations: $use_endomorphism])
 
 AC_CONFIG_HEADERS([src/libsecp256k1-config.h])
 AC_CONFIG_FILES([Makefile libsecp256k1.pc])
@@ -291,7 +333,6 @@ AC_SUBST(SECP_INCLUDES)
 AC_SUBST(SECP_LIBS)
 AC_SUBST(SECP_TEST_LIBS)
 AC_SUBST(SECP_TEST_INCLUDES)
-AM_CONDITIONAL([USE_ASM], [test x"$set_field" = x"64bit_asm"])
 AM_CONDITIONAL([USE_TESTS], [test x"$use_tests" != x"no"])
 AM_CONDITIONAL([USE_BENCHMARK], [test x"$use_benchmark" = x"yes"])
 

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -16,12 +16,10 @@
 #include "num.h"
 #include "field.h"
 
-#if defined(USE_FIELD_5X52_ASM)
+#if defined(USE_ASM_X86_64)
 #include "field_5x52_asm_impl.h"
-#elif defined(USE_FIELD_5X52_INT128)
-#include "field_5x52_int128_impl.h"
 #else
-#error "Please select field_5x52 implementation"
+#include "field_5x52_int128_impl.h"
 #endif
 
 /** Implements arithmetic modulo FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F,


### PR DESCRIPTION
- Introduce a new configuration option for assembly optimizations (which in the future will likely not just be for the field implementation), --with-asm=X, instead of it being part of --with-field=X.
- Make --without-asm and --without-bignum work.
- Move the knowledge of which options require what out of build-aux/m4/bitcoin_secp and into configure, leaving the functions there to just be checking for feature availability.
- Improve the summary printed at the end of configure a bit.
