### PR TITLE
Make git ignore bench_recover when configured with benchmark enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bench_inv
 bench_sign
 bench_verify
+bench_recover
 tests
 *.exe
 *.so


### PR DESCRIPTION
I found it in bitcoin repo, because after make check I always see bench_recover in the git status output.
