### PR TITLE
Make signing fail if a too small buffer is passed.

### DIFF
--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -88,7 +88,7 @@ int secp256k1_ecdsa_sign(const unsigned char *msg32, unsigned char *signature, i
         ret = secp256k1_ecdsa_sig_sign(&sig, &sec, &msg, &non, NULL);
     }
     if (ret) {
-        secp256k1_ecdsa_sig_serialize(signature, signaturelen, &sig);
+        ret = secp256k1_ecdsa_sig_serialize(signature, signaturelen, &sig);
     }
     secp256k1_scalar_clear(&msg);
     secp256k1_scalar_clear(&non);

--- a/src/tests.c
+++ b/src/tests.c
@@ -1298,6 +1298,8 @@ void test_ecdsa_edge_cases(void) {
         msg[31] = 0xaa;
         siglen = 72;
         CHECK(secp256k1_ecdsa_sign(msg, sig, &siglen, key, nonce) == 1);
+        siglen = 10;
+        CHECK(secp256k1_ecdsa_sign(msg, sig, &siglen, key, nonce) != 1);
     }
 
     /* Privkey export where pubkey is the point at infinity. */


### PR DESCRIPTION
Bug discovered by Sergio Demian Lerner.
