### PR TITLE
field10x26: change type of uX to uint32_t

### DIFF
--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -326,7 +326,6 @@ SECP256K1_INLINE static void secp256k1_fe_add(secp256k1_fe_t *r, const secp256k1
 #else
 #define VERIFY_BITS(x, n) do { } while(0)
 #endif
-
 SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t *a, const uint32_t * SECP256K1_RESTRICT b) {
     VERIFY_BITS(a[0], 30);
     VERIFY_BITS(a[1], 30);
@@ -388,12 +387,12 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[9] * b[1];
     VERIFY_BITS(d, 63);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
-    uint64_t u0 = d & M; d >>= 26; c += u0 * R0;
+    uint32_t u0 = d & M; d >>= 26; c += (uint64_t)u0 * R0;
     VERIFY_BITS(u0, 26);
     VERIFY_BITS(d, 37);
     VERIFY_BITS(c, 61);
     /* [d u0 t9 0 0 0 0 0 0 0 0 c-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
-    uint32_t t0 = c & M; c >>= 26; c += u0 * R1;
+    uint32_t t0 = c & M; c >>= 26; c += (uint64_t)u0 * R1;
     VERIFY_BITS(t0, 26);
     VERIFY_BITS(c, 37);
     /* [d u0 t9 0 0 0 0 0 0 0 c-u0*R1 t0-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
@@ -413,12 +412,12 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[9] * b[2];
     VERIFY_BITS(d, 63);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
-    uint64_t u1 = d & M; d >>= 26; c += u1 * R0;
+    uint32_t u1 = d & M; d >>= 26; c += (uint64_t)u1 * R0;
     VERIFY_BITS(u1, 26);
     VERIFY_BITS(d, 37);
     VERIFY_BITS(c, 63);
     /* [d u1 0 t9 0 0 0 0 0 0 0 c-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
-    uint32_t t1 = c & M; c >>= 26; c += u1 * R1;
+    uint32_t t1 = c & M; c >>= 26; c += (uint64_t)u1 * R1;
     VERIFY_BITS(t1, 26);
     VERIFY_BITS(c, 38);
     /* [d u1 0 t9 0 0 0 0 0 0 c-u1*R1 t1-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
@@ -438,12 +437,12 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[9] * b[3];
     VERIFY_BITS(d, 63);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
-    uint64_t u2 = d & M; d >>= 26; c += u2 * R0;
+    uint32_t u2 = d & M; d >>= 26; c += (uint64_t)u2 * R0;
     VERIFY_BITS(u2, 26);
     VERIFY_BITS(d, 37);
     VERIFY_BITS(c, 63);
     /* [d u2 0 0 t9 0 0 0 0 0 0 c-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
-    uint32_t t2 = c & M; c >>= 26; c += u2 * R1;
+    uint32_t t2 = c & M; c >>= 26; c += (uint64_t)u2 * R1;
     VERIFY_BITS(t2, 26);
     VERIFY_BITS(c, 38);
     /* [d u2 0 0 t9 0 0 0 0 0 c-u2*R1 t2-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
@@ -463,12 +462,12 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[9] * b[4];
     VERIFY_BITS(d, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
-    uint64_t u3 = d & M; d >>= 26; c += u3 * R0;
+    uint32_t u3 = d & M; d >>= 26; c += (uint64_t)u3 * R0;
     VERIFY_BITS(u3, 26);
     VERIFY_BITS(d, 37);
     /* VERIFY_BITS(c, 64); */
     /* [d u3 0 0 0 t9 0 0 0 0 0 c-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
-    uint32_t t3 = c & M; c >>= 26; c += u3 * R1;
+    uint32_t t3 = c & M; c >>= 26; c += (uint64_t)u3 * R1;
     VERIFY_BITS(t3, 26);
     VERIFY_BITS(c, 39);
     /* [d u3 0 0 0 t9 0 0 0 0 c-u3*R1 t3-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
@@ -488,12 +487,12 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[9] * b[5];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
-    uint64_t u4 = d & M; d >>= 26; c += u4 * R0;
+    uint32_t u4 = d & M; d >>= 26; c += (uint64_t)u4 * R0;
     VERIFY_BITS(u4, 26);
     VERIFY_BITS(d, 36);
     /* VERIFY_BITS(c, 64); */
     /* [d u4 0 0 0 0 t9 0 0 0 0 c-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
-    uint32_t t4 = c & M; c >>= 26; c += u4 * R1;
+    uint32_t t4 = c & M; c >>= 26; c += (uint64_t)u4 * R1;
     VERIFY_BITS(t4, 26);
     VERIFY_BITS(c, 39);
     /* [d u4 0 0 0 0 t9 0 0 0 c-u4*R1 t4-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
@@ -513,12 +512,12 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[9] * b[6];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
-    uint64_t u5 = d & M; d >>= 26; c += u5 * R0;
+    uint32_t u5 = d & M; d >>= 26; c += (uint64_t)u5 * R0;
     VERIFY_BITS(u5, 26);
     VERIFY_BITS(d, 36);
     /* VERIFY_BITS(c, 64); */
     /* [d u5 0 0 0 0 0 t9 0 0 0 c-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
-    uint32_t t5 = c & M; c >>= 26; c += u5 * R1;
+    uint32_t t5 = c & M; c >>= 26; c += (uint64_t)u5 * R1;
     VERIFY_BITS(t5, 26);
     VERIFY_BITS(c, 39);
     /* [d u5 0 0 0 0 0 t9 0 0 c-u5*R1 t5-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
@@ -538,12 +537,12 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[9] * b[7];
     VERIFY_BITS(d, 61);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
-    uint64_t u6 = d & M; d >>= 26; c += u6 * R0;
+    uint32_t u6 = d & M; d >>= 26; c += (uint64_t)u6 * R0;
     VERIFY_BITS(u6, 26);
     VERIFY_BITS(d, 35);
     /* VERIFY_BITS(c, 64); */
     /* [d u6 0 0 0 0 0 0 t9 0 0 c-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
-    uint32_t t6 = c & M; c >>= 26; c += u6 * R1;
+    uint32_t t6 = c & M; c >>= 26; c += (uint64_t)u6 * R1;
     VERIFY_BITS(t6, 26);
     VERIFY_BITS(c, 39);
     /* [d u6 0 0 0 0 0 0 t9 0 c-u6*R1 t6-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
@@ -564,13 +563,13 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[9] * b[8];
     VERIFY_BITS(d, 58);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
-    uint64_t u7 = d & M; d >>= 26; c += u7 * R0;
+    uint32_t u7 = d & M; d >>= 26; c += (uint64_t)u7 * R0;
     VERIFY_BITS(u7, 26);
     VERIFY_BITS(d, 32);
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x800001703FFFC2F7ULL);
     /* [d u7 0 0 0 0 0 0 0 t9 0 c-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
-    uint32_t t7 = c & M; c >>= 26; c += u7 * R1;
+    uint32_t t7 = c & M; c >>= 26; c += (uint64_t)u7 * R1;
     VERIFY_BITS(t7, 26);
     VERIFY_BITS(c, 38);
     /* [d u7 0 0 0 0 0 0 0 t9 c-u7*R1 t7-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
@@ -591,7 +590,7 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
     d += (uint64_t)a[9] * b[9];
     VERIFY_BITS(d, 57);
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p18 p17 p16 p15 p14 p13 p12 p11 p10 p9 p8 p7 p6 p5 p4 p3 p2 p1 p0] */
-    uint64_t u8 = d & M; d >>= 26; c += u8 * R0;
+    uint32_t u8 = d & M; d >>= 26; c += (uint64_t)u8 * R0;
     VERIFY_BITS(u8, 26);
     VERIFY_BITS(d, 31);
     /* VERIFY_BITS(c, 64); */
@@ -614,7 +613,7 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint32_t *r, const uint32_t 
     VERIFY_BITS(r[7], 26);
     /* [d u8 0 0 0 0 0 0 0 0 t9 c-u8*R0 r7 r6 r5 r4 r3 t2 t1 t0] = [p18 p17 p16 p15 p14 p13 p12 p11 p10 p9 p8 p7 p6 p5 p4 p3 p2 p1 p0] */
 
-    r[8] = c & M; c >>= 26; c += u8 * R1;
+    r[8] = c & M; c >>= 26; c += (uint64_t)u8 * R1;
     VERIFY_BITS(r[8], 26);
     VERIFY_BITS(c, 39);
     /* [d u8 0 0 0 0 0 0 0 0 t9+c-u8*R1 r8-u8*R0 r7 r6 r5 r4 r3 t2 t1 t0] = [p18 p17 p16 p15 p14 p13 p12 p11 p10 p9 p8 p7 p6 p5 p4 p3 p2 p1 p0] */
@@ -696,12 +695,12 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[5] * a[5];
     VERIFY_BITS(d, 63);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
-    uint64_t u0 = d & M; d >>= 26; c += u0 * R0;
+    uint32_t u0 = d & M; d >>= 26; c += (uint64_t)u0 * R0;
     VERIFY_BITS(u0, 26);
     VERIFY_BITS(d, 37);
     VERIFY_BITS(c, 61);
     /* [d u0 t9 0 0 0 0 0 0 0 0 c-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
-    uint32_t t0 = c & M; c >>= 26; c += u0 * R1;
+    uint32_t t0 = c & M; c >>= 26; c += (uint64_t)u0 * R1;
     VERIFY_BITS(t0, 26);
     VERIFY_BITS(c, 37);
     /* [d u0 t9 0 0 0 0 0 0 0 c-u0*R1 t0-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
@@ -716,12 +715,12 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
        + (uint64_t)(a[5]*2) * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
-    uint64_t u1 = d & M; d >>= 26; c += u1 * R0;
+    uint32_t u1 = d & M; d >>= 26; c += (uint64_t)u1 * R0;
     VERIFY_BITS(u1, 26);
     VERIFY_BITS(d, 37);
     VERIFY_BITS(c, 63);
     /* [d u1 0 t9 0 0 0 0 0 0 0 c-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
-    uint32_t t1 = c & M; c >>= 26; c += u1 * R1;
+    uint32_t t1 = c & M; c >>= 26; c += (uint64_t)u1 * R1;
     VERIFY_BITS(t1, 26);
     VERIFY_BITS(c, 38);
     /* [d u1 0 t9 0 0 0 0 0 0 c-u1*R1 t1-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
@@ -737,12 +736,12 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[6] * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
-    uint64_t u2 = d & M; d >>= 26; c += u2 * R0;
+    uint32_t u2 = d & M; d >>= 26; c += (uint64_t)u2 * R0;
     VERIFY_BITS(u2, 26);
     VERIFY_BITS(d, 37);
     VERIFY_BITS(c, 63);
     /* [d u2 0 0 t9 0 0 0 0 0 0 c-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
-    uint32_t t2 = c & M; c >>= 26; c += u2 * R1;
+    uint32_t t2 = c & M; c >>= 26; c += (uint64_t)u2 * R1;
     VERIFY_BITS(t2, 26);
     VERIFY_BITS(c, 38);
     /* [d u2 0 0 t9 0 0 0 0 0 c-u2*R1 t2-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
@@ -757,12 +756,12 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
        + (uint64_t)(a[6]*2) * a[7];
     VERIFY_BITS(d, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
-    uint64_t u3 = d & M; d >>= 26; c += u3 * R0;
+    uint32_t u3 = d & M; d >>= 26; c += (uint64_t)u3 * R0;
     VERIFY_BITS(u3, 26);
     VERIFY_BITS(d, 37);
     /* VERIFY_BITS(c, 64); */
     /* [d u3 0 0 0 t9 0 0 0 0 0 c-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
-    uint32_t t3 = c & M; c >>= 26; c += u3 * R1;
+    uint32_t t3 = c & M; c >>= 26; c += (uint64_t)u3 * R1;
     VERIFY_BITS(t3, 26);
     VERIFY_BITS(c, 39);
     /* [d u3 0 0 0 t9 0 0 0 0 c-u3*R1 t3-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
@@ -778,12 +777,12 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[7] * a[7];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
-    uint64_t u4 = d & M; d >>= 26; c += u4 * R0;
+    uint32_t u4 = d & M; d >>= 26; c += (uint64_t)u4 * R0;
     VERIFY_BITS(u4, 26);
     VERIFY_BITS(d, 36);
     /* VERIFY_BITS(c, 64); */
     /* [d u4 0 0 0 0 t9 0 0 0 0 c-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
-    uint32_t t4 = c & M; c >>= 26; c += u4 * R1;
+    uint32_t t4 = c & M; c >>= 26; c += (uint64_t)u4 * R1;
     VERIFY_BITS(t4, 26);
     VERIFY_BITS(c, 39);
     /* [d u4 0 0 0 0 t9 0 0 0 c-u4*R1 t4-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
@@ -798,12 +797,12 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
        + (uint64_t)(a[7]*2) * a[8];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
-    uint64_t u5 = d & M; d >>= 26; c += u5 * R0;
+    uint32_t u5 = d & M; d >>= 26; c += (uint64_t)u5 * R0;
     VERIFY_BITS(u5, 26);
     VERIFY_BITS(d, 36);
     /* VERIFY_BITS(c, 64); */
     /* [d u5 0 0 0 0 0 t9 0 0 0 c-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
-    uint32_t t5 = c & M; c >>= 26; c += u5 * R1;
+    uint32_t t5 = c & M; c >>= 26; c += (uint64_t)u5 * R1;
     VERIFY_BITS(t5, 26);
     VERIFY_BITS(c, 39);
     /* [d u5 0 0 0 0 0 t9 0 0 c-u5*R1 t5-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
@@ -819,12 +818,12 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
        + (uint64_t)a[8] * a[8];
     VERIFY_BITS(d, 61);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
-    uint64_t u6 = d & M; d >>= 26; c += u6 * R0;
+    uint32_t u6 = d & M; d >>= 26; c += (uint64_t)u6 * R0;
     VERIFY_BITS(u6, 26);
     VERIFY_BITS(d, 35);
     /* VERIFY_BITS(c, 64); */
     /* [d u6 0 0 0 0 0 0 t9 0 0 c-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
-    uint32_t t6 = c & M; c >>= 26; c += u6 * R1;
+    uint32_t t6 = c & M; c >>= 26; c += (uint64_t)u6 * R1;
     VERIFY_BITS(t6, 26);
     VERIFY_BITS(c, 39);
     /* [d u6 0 0 0 0 0 0 t9 0 c-u6*R1 t6-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
@@ -840,13 +839,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     d += (uint64_t)(a[8]*2) * a[9];
     VERIFY_BITS(d, 58);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
-    uint64_t u7 = d & M; d >>= 26; c += u7 * R0;
+    uint32_t u7 = d & M; d >>= 26; c += (uint64_t)u7 * R0;
     VERIFY_BITS(u7, 26);
     VERIFY_BITS(d, 32);
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x800001703FFFC2F7ULL);
     /* [d u7 0 0 0 0 0 0 0 t9 0 c-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
-    uint32_t t7 = c & M; c >>= 26; c += u7 * R1;
+    uint32_t t7 = c & M; c >>= 26; c += (uint64_t)u7 * R1;
     VERIFY_BITS(t7, 26);
     VERIFY_BITS(c, 38);
     /* [d u7 0 0 0 0 0 0 0 t9 c-u7*R1 t7-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
@@ -863,7 +862,7 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     d += (uint64_t)a[9] * a[9];
     VERIFY_BITS(d, 57);
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p18 p17 p16 p15 p14 p13 p12 p11 p10 p9 p8 p7 p6 p5 p4 p3 p2 p1 p0] */
-    uint64_t u8 = d & M; d >>= 26; c += u8 * R0;
+    uint32_t u8 = d & M; d >>= 26; c += (uint64_t)u8 * R0;
     VERIFY_BITS(u8, 26);
     VERIFY_BITS(d, 31);
     /* VERIFY_BITS(c, 64); */
@@ -886,7 +885,7 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     VERIFY_BITS(r[7], 26);
     /* [d u8 0 0 0 0 0 0 0 0 t9 c-u8*R0 r7 r6 r5 r4 r3 t2 t1 t0] = [p18 p17 p16 p15 p14 p13 p12 p11 p10 p9 p8 p7 p6 p5 p4 p3 p2 p1 p0] */
 
-    r[8] = c & M; c >>= 26; c += u8 * R1;
+    r[8] = c & M; c >>= 26; c += (uint64_t)u8 * R1;
     VERIFY_BITS(r[8], 26);
     VERIFY_BITS(c, 39);
     /* [d u8 0 0 0 0 0 0 0 0 t9+c-u8*R1 r8-u8*R0 r7 r6 r5 r4 r3 t2 t1 t0] = [p18 p17 p16 p15 p14 p13 p12 p11 p10 p9 p8 p7 p6 p5 p4 p3 p2 p1 p0] */


### PR DESCRIPTION
Change the type of uX in `secp256k1_fe_mul_inner` and `secp256k1_fe_sqr_inner` to `uint32_t`, and cast only to `uint64_t` when necessary. 

On X86 the difference was in the noise bound, but for ARM this reduces code and required stack size, and increases performance significantly. Apparantly, GCC is less smart there and sees this as a hint that `uint32_t`*`uint32_t`→`uint64_t` instructions can be used.

Before ([asm](http://www.hastebin.com/uhiburiron.armasm)):

| test | min | avg | max |
| --- | --- | --- | --- |
| inv | 384.321us | 384.537us | 385.125us |
| recover | 2845.161us | 2845.341us | 2845.426us |
| sign | 1324.141us | 1324.300us | 1324.453us |
| verify | 2672.787us | 2673.188us | 2673.498us |

After ([asm](http://www.hastebin.com/afekihumoz.armasm)):

| test | min | avg | max |
| --- | --- | --- | --- |
| inv | 384.400us | 384.614us | 385.357us |
| recover | 2549.572us | 2550.015us | 2552.387us |
| sign | 1223.006us | 1223.169us | 1223.313us |
| verify | 2410.431us | 2410.598us | 2410.885us |

Eg, a 10% speedup for verification.

I still intend to do a NEON implementation, but this picks a bit of low-hanging fruit that I expect to be significant on other embedded 32-bit architectures as well.
