### PR TITLE
secp256k1 benchmarking programs can now accept parameters

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -50,7 +50,8 @@ extern "C" {
  *  It cannot run in parallel with any other functions, but once
  *  secp256k1_start() returns, all other functions are thread-safe.
  */
-void secp256k1_start(unsigned int flags);
+void secp256k1_start(unsigned int flags, unsigned int tablesize);
+
 
 /** Free all memory associated with this library. After this, no
  *  functions can be called anymore, except secp256k1_start()

--- a/src/bench.h
+++ b/src/bench.h
@@ -7,6 +7,8 @@
 #ifndef _SECP256K1_BENCH_H_
 #define _SECP256K1_BENCH_H_
 
+#include <unistd.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <math.h>
 #include "sys/time.h"
@@ -17,21 +19,46 @@ static double gettimedouble(void) {
     return tv.tv_usec * 0.000001 + tv.tv_sec;
 }
 
-void run_benchmark(void (*benchmark)(void*), void (*setup)(void*), void (*teardown)(void*), void* data, int count, int iter) {
+void run_benchmark(void (*benchmark)(void*,unsigned int), void (*setup)(void*), void (*teardown)(void*), void* data, int count, int iters) {
     double min = HUGE_VAL;
     double sum = 0.0;
     double max = 0.0;
     for (int i = 0; i < count; i++) {
         if (setup) setup(data);
         double begin = gettimedouble();
-        benchmark(data);
+        benchmark(data, iters);
         double total = gettimedouble() - begin;
         if (teardown) teardown(data);
         if (total < min) min = total;
         if (total > max) max = total;
         sum += total;
     }
-    printf("min %.3fus / avg %.3fus / max %.3fus\n", min * 1000000.0 / iter, (sum / count) * 1000000.0 / iter, max * 1000000.0 / iter);
+    printf("min %.3fus / avg %.3fus / max %.3fus\n", min * 1000000.0 / iters, (sum / count) * 1000000.0 / iters, max * 1000000.0 / iters);
+}
+
+void parse_bench_args(int argc, char **argv, int *iters, int *count, int *tablesize) {
+    int oa;
+
+    while ((oa = getopt(argc, argv, "c:i:w:")) != -1) {
+        switch (oa) {
+        case 'c':
+            *count=atoi(optarg);
+            ( *count<0 || *count > 5000 ) ? (printf("Count %d out of sane bounds. Resetting to 10.\n",*count),(*count=10)):0x0;
+            break;
+        case 'i':
+            *iters=atoi(optarg);
+            ( *iters<0 || *iters > 200000 ) ? (printf("Iterations %d out of sane bounds. Resetting to 20000.\n",*iters),*iters=20000):0x0;
+            break;
+        case 'w':
+            *tablesize=atoi(optarg);
+            ( *tablesize<2 || *tablesize > 30) ? (printf("WINDOW_G cache %d out of sane bounds. Resetting to 16.\n",*tablesize),*tablesize=16):0x0;
+            break;
+        case '?':
+            printf("Missing argument to %c.", (char)optopt);
+        default:
+            return;
+        }
+    }
 }
 
 #endif

--- a/src/bench_inv.c
+++ b/src/bench_inv.c
@@ -32,20 +32,24 @@ void bench_inv_setup(void* arg) {
     secp256k1_scalar_set_b32(&data->x, init, NULL);
 }
 
-void bench_inv(void* arg) {
+void bench_inv(void* arg, unsigned int iters) {
     bench_inv_t *data = (bench_inv_t*)arg;
 
-    for (int i=0; i<20000; i++) {
+    for (unsigned int i=0; i<iters; i++) {
         secp256k1_scalar_inverse(&data->x, &data->x);
         secp256k1_scalar_add(&data->x, &data->x, &data->base);
     }
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    int iters=20000, count=10, tablesize=0;
+
+    parse_bench_args(argc, argv, &iters, &count, &tablesize);
+
     secp256k1_ge_start();
 
     bench_inv_t data;
-    run_benchmark(bench_inv, bench_inv_setup, NULL, &data, 10, 20000);
+    run_benchmark(bench_inv, bench_inv_setup, NULL, &data, count, iters);
 
     secp256k1_ge_stop();
     return 0;

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -13,11 +13,11 @@ typedef struct {
     unsigned char sig[64];
 } bench_recover_t;
 
-void bench_recover(void* arg) {
+void bench_recover(void* arg, unsigned int iters) {
     bench_recover_t *data = (bench_recover_t*)arg;
 
     unsigned char pubkey[33];
-    for (int i=0; i<20000; i++) {
+    for (unsigned int i=0; i<iters; i++) {
         int pubkeylen = 33;
         CHECK(secp256k1_ecdsa_recover_compact(data->msg, data->sig, pubkey, &pubkeylen, 1, i % 2));
         for (int j = 0; j < 32; j++) {
@@ -35,11 +35,15 @@ void bench_recover_setup(void* arg) {
     for (int i = 0; i < 64; i++) data->sig[i] = 65 + i;
 }
 
-int main(void) {
-    secp256k1_start(SECP256K1_START_VERIFY);
+int main(int argc, char **argv) {
+    int iters=20000,count=10,tablesize=0;
+
+    parse_bench_args(argc, argv, &iters, &count, &tablesize);
+
+    secp256k1_start(SECP256K1_START_VERIFY, tablesize);
 
     bench_recover_t data;
-    run_benchmark(bench_recover, bench_recover_setup, NULL, &data, 10, 20000);
+    run_benchmark(bench_recover, bench_recover_setup, NULL, &data, count, iters);
 
     secp256k1_stop();
     return 0;

--- a/src/bench_sign.c
+++ b/src/bench_sign.c
@@ -20,11 +20,11 @@ static void bench_sign_setup(void* arg) {
     for (int i = 0; i < 32; i++) data->key[i] = i + 65;
 }
 
-static void bench_sign(void* arg) {
+static void bench_sign(void* arg, unsigned int iters) {
     bench_sign_t *data = (bench_sign_t*)arg;
 
     unsigned char sig[64];
-    for (int i=0; i<20000; i++) {
+    for (unsigned int i=0; i<iters; i++) {
         int recid = 0;
         CHECK(secp256k1_ecdsa_sign_compact(data->msg, sig, data->key, NULL, NULL, &recid));
         for (int j = 0; j < 32; j++) {
@@ -34,11 +34,15 @@ static void bench_sign(void* arg) {
     }
 }
 
-int main(void) {
-    secp256k1_start(SECP256K1_START_SIGN);
+int main(int argc, char **argv) {
+    int iters=20000, count=10, tablesize=0;
+
+    parse_bench_args(argc, argv, &iters, &count, &tablesize);
+
+    secp256k1_start(SECP256K1_START_SIGN, tablesize);
 
     bench_sign_t data;
-    run_benchmark(bench_sign, bench_sign_setup, NULL, &data, 10, 20000);
+    run_benchmark(bench_sign, bench_sign_setup, NULL, &data, count, iters);
 
     secp256k1_stop();
     return 0;

--- a/src/bench_verify.c
+++ b/src/bench_verify.c
@@ -20,10 +20,10 @@ typedef struct {
     int pubkeylen;
 } benchmark_verify_t;
 
-static void benchmark_verify(void* arg) {
+static void benchmark_verify(void* arg, unsigned int iters) {
     benchmark_verify_t* data = (benchmark_verify_t*)arg;
 
-    for (int i=0; i<20000; i++) {
+    for (unsigned int i=0; i<iters; i++) {
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
@@ -34,8 +34,12 @@ static void benchmark_verify(void* arg) {
     }
 }
 
-int main(void) {
-    secp256k1_start(SECP256K1_START_VERIFY | SECP256K1_START_SIGN);
+int main(int argc, char **argv) {
+    int iters=20000, count=10, tablesize=0;
+
+    parse_bench_args(argc, argv, &iters, &count, &tablesize);
+
+    secp256k1_start(SECP256K1_START_VERIFY | SECP256K1_START_SIGN, tablesize);
 
     benchmark_verify_t data;
 
@@ -46,7 +50,7 @@ int main(void) {
     data.pubkeylen = 33;
     CHECK(secp256k1_ec_pubkey_create(data.pubkey, &data.pubkeylen, data.key, 1));
 
-    run_benchmark(benchmark_verify, NULL, NULL, &data, 10, 20000);
+    run_benchmark(benchmark_verify, NULL, NULL, &data, count, iters);
 
     secp256k1_stop();
     return 0;

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -10,7 +10,7 @@
 #include "num.h"
 #include "group.h"
 
-static void secp256k1_ecmult_start(void);
+static void secp256k1_ecmult_start(unsigned int);
 static void secp256k1_ecmult_stop(void);
 
 /** Double multiply: R = na*A + ng*G */

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -75,20 +75,28 @@ static void secp256k1_ecmult_table_precomp_ge_var(secp256k1_ge_t *pre, const sec
 
 typedef struct {
     /* For accelerating the computation of a*P + b*G: */
-    secp256k1_ge_t pre_g[ECMULT_TABLE_SIZE(WINDOW_G)];    /* odd multiples of the generator */
+    secp256k1_ge_t *pre_g;    /* odd multiples of the generator */
 #ifdef USE_ENDOMORPHISM
-    secp256k1_ge_t pre_g_128[ECMULT_TABLE_SIZE(WINDOW_G)]; /* odd multiples of 2^128*generator */
+    secp256k1_ge_t *pre_g_128; /* odd multiples of 2^128*generator */
 #endif
 } secp256k1_ecmult_consts_t;
 
 static const secp256k1_ecmult_consts_t *secp256k1_ecmult_consts = NULL;
 
-static void secp256k1_ecmult_start(void) {
+static unsigned int ecmult_impl_windowG=WINDOW_G;
+
+static void secp256k1_ecmult_start(unsigned int tablesize) {
+
     if (secp256k1_ecmult_consts != NULL)
         return;
 
+    tablesize=(tablesize == 0)?WINDOW_G:tablesize;
+    ecmult_impl_windowG=(ecmult_impl_windowG != tablesize)?tablesize:ecmult_impl_windowG;
+
     /* Allocate the precomputation table. */
     secp256k1_ecmult_consts_t *ret = (secp256k1_ecmult_consts_t*)checked_malloc(sizeof(secp256k1_ecmult_consts_t));
+    secp256k1_ge_t *getret = (secp256k1_ge_t*)checked_malloc(sizeof(secp256k1_ge_t)*ECMULT_TABLE_SIZE(ecmult_impl_windowG));
+    ret->pre_g = getret;
 
     /* get the generator */
     const secp256k1_ge_t *g = &secp256k1_ge_consts->g;
@@ -102,9 +110,9 @@ static void secp256k1_ecmult_start(void) {
 #endif
 
     /* precompute the tables with odd multiples */
-    secp256k1_ecmult_table_precomp_ge_var(ret->pre_g, &gj, WINDOW_G);
+    secp256k1_ecmult_table_precomp_ge_var(ret->pre_g, &gj, ecmult_impl_windowG);
 #ifdef USE_ENDOMORPHISM
-    secp256k1_ecmult_table_precomp_ge_var(ret->pre_g_128, &g_128j, WINDOW_G);
+    secp256k1_ecmult_table_precomp_ge_var(ret->pre_g_128, &g_128j, ecmult_impl_windowG);
 #endif
 
     /* Set the global pointer to the precomputation table. */
@@ -117,7 +125,13 @@ static void secp256k1_ecmult_stop(void) {
 
     secp256k1_ecmult_consts_t *c = (secp256k1_ecmult_consts_t*)secp256k1_ecmult_consts;
     secp256k1_ecmult_consts = NULL;
-    free(c);
+
+    secp256k1_ge_t *d = c->pre_g;
+    if (c->pre_g != NULL) {
+        c->pre_g = NULL;
+    }
+
+    free(c); free(d);
 }
 
 /** Convert a number to WNAF notation. The number becomes represented by sum(2^i * wnaf[i], i=0..bits),
@@ -199,12 +213,12 @@ static void secp256k1_ecmult(secp256k1_gej_t *r, const secp256k1_gej_t *a, const
     secp256k1_scalar_split_128(&ng_1, &ng_128, ng);
 
     /* Build wnaf representation for ng_1 and ng_128 */
-    int wnaf_ng_1[129];   int bits_ng_1   = secp256k1_ecmult_wnaf(wnaf_ng_1,   &ng_1,   WINDOW_G);
-    int wnaf_ng_128[129]; int bits_ng_128 = secp256k1_ecmult_wnaf(wnaf_ng_128, &ng_128, WINDOW_G);
+    int wnaf_ng_1[129];   int bits_ng_1   = secp256k1_ecmult_wnaf(wnaf_ng_1,   &ng_1,   ecmult_impl_windowG);
+    int wnaf_ng_128[129]; int bits_ng_128 = secp256k1_ecmult_wnaf(wnaf_ng_128, &ng_128, ecmult_impl_windowG);
     if (bits_ng_1 > bits) bits = bits_ng_1;
     if (bits_ng_128 > bits) bits = bits_ng_128;
 #else
-    int wnaf_ng[257];     int bits_ng     = secp256k1_ecmult_wnaf(wnaf_ng,     ng,      WINDOW_G);
+    int wnaf_ng[257];     int bits_ng     = secp256k1_ecmult_wnaf(wnaf_ng,     ng,      ecmult_impl_windowG);
     if (bits_ng > bits) bits = bits_ng;
 #endif
 
@@ -225,11 +239,11 @@ static void secp256k1_ecmult(secp256k1_gej_t *r, const secp256k1_gej_t *a, const
             secp256k1_gej_add_var(r, r, &tmpj);
         }
         if (i < bits_ng_1 && (n = wnaf_ng_1[i])) {
-            ECMULT_TABLE_GET_GE(&tmpa, c->pre_g, n, WINDOW_G);
+            ECMULT_TABLE_GET_GE(&tmpa, c->pre_g, n, ecmult_impl_windowG);
             secp256k1_gej_add_ge_var(r, r, &tmpa);
         }
         if (i < bits_ng_128 && (n = wnaf_ng_128[i])) {
-            ECMULT_TABLE_GET_GE(&tmpa, c->pre_g_128, n, WINDOW_G);
+            ECMULT_TABLE_GET_GE(&tmpa, c->pre_g_128, n, ecmult_impl_windowG);
             secp256k1_gej_add_ge_var(r, r, &tmpa);
         }
 #else
@@ -238,7 +252,7 @@ static void secp256k1_ecmult(secp256k1_gej_t *r, const secp256k1_gej_t *a, const
             secp256k1_gej_add_var(r, r, &tmpj);
         }
         if (i < bits_ng && (n = wnaf_ng[i])) {
-            ECMULT_TABLE_GET_GE(&tmpa, c->pre_g, n, WINDOW_G);
+            ECMULT_TABLE_GET_GE(&tmpa, c->pre_g, n, ecmult_impl_windowG);
             secp256k1_gej_add_ge_var(r, r, &tmpa);
         }
 #endif

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -19,7 +19,7 @@
 #include "eckey_impl.h"
 #include "hash_impl.h"
 
-void secp256k1_start(unsigned int flags) {
+void secp256k1_start(unsigned int flags, unsigned int tablesize) {
     secp256k1_fe_start();
     secp256k1_ge_start();
     secp256k1_scalar_start();
@@ -28,7 +28,7 @@ void secp256k1_start(unsigned int flags) {
         secp256k1_ecmult_gen_start();
     }
     if (flags & SECP256K1_START_VERIFY) {
-        secp256k1_ecmult_start();
+        secp256k1_ecmult_start(tablesize);
     }
 }
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -1652,10 +1652,10 @@ int main(int argc, char **argv) {
     printf("random seed = %llu\n", (unsigned long long)seed);
 
     /* initialize */
-    secp256k1_start(SECP256K1_START_SIGN | SECP256K1_START_VERIFY);
+    secp256k1_start(SECP256K1_START_SIGN | SECP256K1_START_VERIFY, 0);
 
     /* initializing a second time shouldn't cause any harm or memory leaks. */
-    secp256k1_start(SECP256K1_START_SIGN | SECP256K1_START_VERIFY);
+    secp256k1_start(SECP256K1_START_SIGN | SECP256K1_START_VERIFY, 0);
 
     /* Likewise, re-running the internal init functions should be harmless. */
     secp256k1_fe_start();


### PR DESCRIPTION
-c will vary the loop counter
-i will vary the iterations per-loop
-w will change the WINDOW_G table size setting at runtime (primary reason for patch)
