### PR TITLE
Disable Visual Studio 2015 zero-pad warning.

### DIFF
--- a/src/scalar_8x32_impl.h
+++ b/src/scalar_8x32_impl.h
@@ -193,6 +193,10 @@ SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar *a) 
     return (a->d[0] | a->d[1] | a->d[2] | a->d[3] | a->d[4] | a->d[5] | a->d[6] | a->d[7]) == 0;
 }
 
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#pragma warning ( push )
+#pragma warning ( disable: 4319 )
+#endif
 static void secp256k1_scalar_negate(secp256k1_scalar *r, const secp256k1_scalar *a) {
     uint32_t nonzero = 0xFFFFFFFFUL * (secp256k1_scalar_is_zero(a) == 0);
     uint64_t t = (uint64_t)(~a->d[0]) + SECP256K1_N_0 + 1;
@@ -212,6 +216,9 @@ static void secp256k1_scalar_negate(secp256k1_scalar *r, const secp256k1_scalar 
     t += (uint64_t)(~a->d[7]) + SECP256K1_N_7;
     r->d[7] = t & nonzero;
 }
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#pragma warning ( pop )
+#endif
 
 SECP256K1_INLINE static int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
     return ((a->d[0] ^ 1) | a->d[1] | a->d[2] | a->d[3] | a->d[4] | a->d[5] | a->d[6] | a->d[7]) == 0;


### PR DESCRIPTION
With the latest version, Visual Studio warns about zero-padding the upcasted values in `secp256k1_scalar_negate`. Since that behavior is (apparently) intentional, this change will silence those warnings.
