### PR TITLE
[Schnorr API BREAK] Improve Schnorr multisigning API + fix vulnerability

### DIFF
--- a/include/secp256k1_schnorr.h
+++ b/include/secp256k1_schnorr.h
@@ -9,7 +9,8 @@ extern "C" {
 
 /** This header file defines an API for a custom EC-Schnorr-SHA256 constructions.
  *  It supports non-malleable 64-byte signatures which support public key
- *  recovery, batch validation, and multiparty signing.
+ *  recovery, batch validation, and multiparty signing. See schnorr.md for more
+ *  details.
  */
 
 /** Create a single party Schnorr signature.

--- a/include/secp256k1_schnorr.h
+++ b/include/secp256k1_schnorr.h
@@ -7,9 +7,12 @@
 extern "C" {
 # endif
 
-/** Create a signature using a custom EC-Schnorr-SHA256 construction. It
- *  produces non-malleable 64-byte signatures which support public key recovery
- *  batch validation, and multiparty signing.
+/** This header file defines an API for a custom EC-Schnorr-SHA256 constructions.
+ *  It supports non-malleable 64-byte signatures which support public key
+ *  recovery, batch validation, and multiparty signing.
+ */
+
+/** Create a single party Schnorr signature.
  *  Returns: 1: signature created
  *           0: the nonce generation function failed, or the private key was
  *              invalid.
@@ -33,13 +36,16 @@ SECP256K1_API int secp256k1_schnorr_sign(
   const void *ndata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
-/** Verify a signature created by secp256k1_schnorr_sign.
+/** Verify a Schnorr signature.
  *  Returns: 1: correct signature
  *           0: incorrect signature
  *  Args:    ctx:       a secp256k1 context object, initialized for verification.
  *  In:      sig64:     the 64-byte signature being verified (cannot be NULL)
  *           msg32:     the 32-byte message hash being verified (cannot be NULL)
  *           pubkey:    the public key to verify with (cannot be NULL)
+ *
+ *  Signatures verifiable by this function can be created using
+ *  secp256k1_schnorr_sign, or secp256k1_multischnorr_combine_sigs.
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
   const secp256k1_context* ctx,
@@ -48,8 +54,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
   const secp256k1_pubkey *pubkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
-/** Recover an EC public key from a Schnorr signature created using
- *  secp256k1_schnorr_sign.
+/** Recover an EC public key from a Schnorr signature.
  *  Returns: 1: public key successfully recovered (which guarantees a correct
  *           signature).
  *           0: otherwise.
@@ -60,6 +65,9 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
  *  In:      sig64:      signature as 64 byte array (cannot be NULL)
  *           msg32:      the 32-byte message hash assumed to be signed (cannot
  *                       be NULL)
+ *
+ *  Signatures recoverable by this function can be created using
+ *  secp256k1_schnorr_sign, or secp256k1_multischnorr_combine_sigs.
  */
 SECP256K1_API int secp256k1_schnorr_recover(
   const secp256k1_context* ctx,
@@ -68,102 +76,120 @@ SECP256K1_API int secp256k1_schnorr_recover(
   const unsigned char *msg32
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
-/** Generate a nonce pair deterministically for use with
- *  secp256k1_schnorr_partial_sign.
- *  Returns: 1: valid nonce pair was generated.
- *           0: otherwise (nonce generation function failed)
- *  Args:    ctx:         pointer to a context object, initialized for signing
- *                        (cannot be NULL)
- *  Out:     pubnonce:    public side of the nonce (cannot be NULL)
- *           privnonce32: private side of the nonce (32 byte) (cannot be NULL)
- *  In:      msg32:       the 32-byte message hash assumed to be signed (cannot
- *                        be NULL)
- *           sec32:       the 32-byte private key (cannot be NULL)
- *           noncefp:     pointer to a nonce generation function. If NULL,
- *                        secp256k1_nonce_function_default is used
- *           noncedata:   pointer to arbitrary data used by the nonce generation
- *                        function (can be NULL)
+/** Produce a 32-byte first stage partial multisignature.
+ *  Returns: 1: a first stage partial signature was created
+ *           0: otherwise (nonce generation failed, invalid private key, or
+ *              a very unlikely unsignable combination)
+ *  Args:    ctx:       pointer to a context object, initialized for signing
+ *                      (cannot be NULL)
+ *  Out:     stage1sig32: pointer to a 32-byte array to store the signature
+ *  In:      msg32:  the 32-byte message hash being signed (cannot be NULL)
+ *           seckey: pointer to a 32-byte secret key (cannot be NULL)
+ *           noncefp:pointer to a nonce generation function. If NULL,
+ *                   secp256k1_nonce_function_default is used
+ *           ndata:  pointer to arbitrary data used by the nonce generation
+ *                   function (can be NULL)
  *
- *  Do not use the output as a private/public key pair for signing/validation.
+ *  All cosigners must use the same msg32, but may use different nonce
+ *  generation parameters.
+ *
+ *  The purpose of the stage 1 round is establishing a shared public nonce that
+ *  all cosigners agree on (without revealing their secret nonces).
  */
-SECP256K1_API int secp256k1_schnorr_generate_nonce_pair(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_multischnorr_stage1(
   const secp256k1_context* ctx,
-  secp256k1_pubkey *pubnonce,
-  unsigned char *privnonce32,
+  unsigned char *stage1sig32,
   const unsigned char *msg32,
   const unsigned char *sec32,
   secp256k1_nonce_function noncefp,
   const void* noncedata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
-/** Produce a partial Schnorr signature, which can be combined using
- *  secp256k1_schnorr_partial_combine, to end up with a full signature that is
- *  verifiable using secp256k1_schnorr_verify.
- *  Returns: 1: signature created successfully.
- *           0: no valid signature exists with this combination of keys, nonces
- *              and message (chance around 1 in 2^128)
- *          -1: invalid private key, nonce, or public nonces.
- *  Args: ctx:             pointer to context object, initialized for signing (cannot
- *                         be NULL)
- *  Out:  sig64:           pointer to 64-byte array to put partial signature in
- *  In:   msg32:           pointer to 32-byte message to sign
- *        sec32:           pointer to 32-byte private key
- *        pubnonce_others: pointer to pubkey containing the sum of the other's
- *                         nonces (see secp256k1_ec_pubkey_combine)
- *        secnonce32:      pointer to 32-byte array containing our nonce
+/** Produce a 64-byte second stage partial multisignature.
+ *  Returns: 1: a second stage partial signature was created.
+ *           0: otherwise (nonce generation failed, invalid private key,
+ *              invalid stage 1 signatures, or a very unlikely unsignable
+ *              combination)
+ *  Args: ctx:               pointer to a context object, initialized for
+ *                           signing and verification (cannot be NULL)
+ *  Out: stage2sig64:        pointer to a 64-byte array to store the signature
+ *  In:  other_stage1sig32s: pointer to an array of num_others pointers to
+ *                           32-byte stage 1 partial multisignatures from all
+ *                           other cosigners (can only be NULL if num_others is
+ *                           0)
+ *       num_others:         the number of cosigners (excluding yourself)
+ *       msg32:              the 32-byte message hash being signed (cannot be
+ *                           NULL)
+ *       sec32:              pointer to a 32-byte secret key (cannot be NULL)
+ *       noncefp:            pointer to a nonce generation function. If NULL,
+ *                           secp256k1_nonce_function_default is used
+ *       ndata:              pointer to arbitrary data used by the nonce
+ *                           generation function (can be NULL)
  *
- * The intended procedure for creating a multiparty signature is:
- * - Each signer S[i] with private key x[i] and public key Q[i] runs
- *   secp256k1_schnorr_generate_nonce_pair to produce a pair (k[i],R[i]) of
- *   private/public nonces.
- * - All signers communicate their public nonces to each other (revealing your
- *   private nonce can lead to discovery of your private key, so it should be
- *   considered secret).
- * - All signers combine all the public nonces they received (excluding their
- *   own) using secp256k1_ec_pubkey_combine to obtain an
- *   Rall[i] = sum(R[0..i-1,i+1..n]).
- * - All signers produce a partial signature using
- *   secp256k1_schnorr_partial_sign, passing in their own private key x[i],
- *   their own private nonce k[i], and the sum of the others' public nonces
- *   Rall[i].
- * - All signers communicate their partial signatures to each other.
- * - Someone combines all partial signatures using
- *   secp256k1_schnorr_partial_combine, to obtain a full signature.
- * - The resulting signature is validatable using secp256k1_schnorr_verify, with
- *   public key equal to the result of secp256k1_ec_pubkey_combine of the
- *   signers' public keys (sum(Q[0..n])).
+ *  The second stage uses the stage 1 partial signatures from all other
+ *  cosigners and computes a stage 2 partial signature. If num_others is 0, the
+ *  result is a full signature (though different than the one produced by
+ *  secp256k1_schnorr_sign, given the same msg32, sec32, noncefp, ndata).
  *
- *  Note that secp256k1_schnorr_partial_combine and secp256k1_ec_pubkey_combine
- *  function take their arguments in any order, and it is possible to
- *  pre-combine several inputs already with one call, and add more inputs later
- *  by calling the function again (they are commutative and associative).
+ *  All cosigners must use the same msg32, and the same as in stage1. Different
+ *  cosigners may use different nonce generating functions and data, as long as
+ *  they are each consistent between stage 1 and stage 2.
+ *
+ *  The order of stage 1 signatures in other_stage1sig32s does not matter.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_sign(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_multischnorr_stage2(
   const secp256k1_context* ctx,
-  unsigned char *sig64,
+  unsigned char *stage2sig64,
+  const unsigned char * const * other_stage1sig96s,
+  size_t num_others,
   const unsigned char *msg32,
   const unsigned char *sec32,
-  const secp256k1_pubkey *pubnonce_others,
-  const unsigned char *secnonce32
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6);
+  secp256k1_nonce_function noncefp,
+  const void* noncedata
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6);
 
-/** Combine multiple Schnorr partial signatures.
- * Returns: 1: the passed signatures were successfully combined.
- *          0: the resulting signature is not valid (chance of 1 in 2^256)
- *         -1: some inputs were invalid, or the signatures were not created
- *             using the same set of nonces
- * Args:   ctx:      pointer to a context object
- * Out:    sig64:    pointer to a 64-byte array to place the combined signature
- *                   (cannot be NULL)
- * In:     sig64sin: pointer to an array of n pointers to 64-byte input
- *                   signatures
- *         n:        the number of signatures to combine (at least 1)
+/** Combine multiple Schnorr stage 2 partial signatures into a full signature.
+ *  Returns: 1: the passed signatures were succesfully combined.
+ *           0: the resulting signature is not valid (chance of 1 in 2^256) or
+ *              the inputs were not created using the same set of keys
+ *  Args:   ctx:          pointer to a context object
+ *  Out:    sig64:        pointer to a 64-byte array to place the combined
+ *                        full signature (cannot be NULL)
+ *  In:     stage2sig64s: pointer to an array of n pointers to 64-byte stage 2
+ *                        partial signatures (cannot be NULL)
+ *          n:            the number of signatures to combine (at least 1)
+ *
+ *  The order of the stage 2 partial signatures in stage2sig64s does not matter.
+ *
+ *  If succesful, the resulting combined full signature will be verifiable with
+ *  secp256k1_schnorr_verify(ctx, sig64, msg32, pub), where:
+ *  - sig64 is the output of secp256k1_multischnorr_combine_sigs
+ *  - msg32 is the message used by all cosigners in stage 1 and stage 2
+ *  - pub is the result of secp256k1_multischnorr_combine_keys, applied to all
+ *    cosigners' public keys (including yours).
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_combine(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_multischnorr_combine_sigs(
   const secp256k1_context* ctx,
   unsigned char *sig64,
-  const unsigned char * const * sig64sin,
+  const unsigned char * const * stage2sig64s,
   size_t n
+) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+
+/** Compute the combined public key that a multisignature will be verifiable
+ *  with.
+ *  Returns: 1: the sum of the public keys is valid.
+ *           0: the sum of the public keys is not valid.
+ *  Args:   ctx:        pointer to a context object
+ *  Out:    out:        pointer to pubkey for placing the resulting public key
+ *                      (cannot be NULL)
+ *  In:     ins:        pointer to array of pointers to public keys (cannot be NULL)
+ *          n:          the number of public keys to add together (must be at least 1)
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_multischnorr_combine_keys(
+    const secp256k1_context* ctx,
+    secp256k1_pubkey *out,
+    const secp256k1_pubkey * const * ins,
+    size_t n
 ) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 # ifdef __cplusplus

--- a/src/modules/schnorr/main_impl.h
+++ b/src/modules/schnorr/main_impl.h
@@ -20,40 +20,42 @@ static void secp256k1_schnorr_msghash_sha256(unsigned char *h32, const unsigned 
 
 static const unsigned char secp256k1_schnorr_algo16[17] = "Schnorr+SHA256  ";
 
-int secp256k1_schnorr_sign(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
-    secp256k1_scalar sec, non;
+int secp256k1_schnorr_sign(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void *ndata) {
+    secp256k1_scalar sec, nonce_mine;
+    secp256k1_ge pubnonce_all;
     int ret = 0;
     int overflow = 0;
     unsigned int count = 0;
     VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(sig64 != NULL);
+    memset(sig64, 0, 64);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
     ARG_CHECK(msg32 != NULL);
-    ARG_CHECK(sig64 != NULL);
     ARG_CHECK(seckey != NULL);
     if (noncefp == NULL) {
         noncefp = secp256k1_nonce_function_default;
     }
 
-    secp256k1_scalar_set_b32(&sec, seckey, NULL);
-    while (1) {
+    secp256k1_scalar_set_b32(&sec, seckey, &overflow);
+    ret = !secp256k1_scalar_is_zero(&sec) && !overflow;
+    while (ret) {
         unsigned char nonce32[32];
-        ret = noncefp(nonce32, msg32, seckey, secp256k1_schnorr_algo16, (void*)noncedata, count);
+        ret = noncefp(nonce32, msg32, seckey, secp256k1_schnorr_algo16, (void*)ndata, count);
         if (!ret) {
             break;
         }
-        secp256k1_scalar_set_b32(&non, nonce32, &overflow);
+        ret = secp256k1_schnorr_nonces_set_b32(&ctx->ecmult_gen_ctx, &nonce_mine, &pubnonce_all, nonce32, NULL) &&
+            secp256k1_schnorr_sig_sign(sig64, &sec, &nonce_mine, &pubnonce_all, secp256k1_schnorr_msghash_sha256, msg32);
         memset(nonce32, 0, 32);
-        if (!secp256k1_scalar_is_zero(&non) && !overflow) {
-            if (secp256k1_schnorr_sig_sign(&ctx->ecmult_gen_ctx, sig64, &sec, &non, NULL, secp256k1_schnorr_msghash_sha256, msg32)) {
-                break;
-            }
+        if (ret) {
+            break;
         }
         count++;
     }
     if (!ret) {
         memset(sig64, 0, 64);
     }
-    secp256k1_scalar_clear(&non);
+    secp256k1_scalar_clear(&nonce_mine);
     secp256k1_scalar_clear(&sec);
     return ret;
 }
@@ -74,91 +76,158 @@ int secp256k1_schnorr_recover(const secp256k1_context* ctx, secp256k1_pubkey *pu
     secp256k1_ge q;
 
     VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(pubkey != NULL);
+    memset(pubkey, 0, sizeof(*pubkey));
     ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
     ARG_CHECK(msg32 != NULL);
     ARG_CHECK(sig64 != NULL);
-    ARG_CHECK(pubkey != NULL);
 
     if (secp256k1_schnorr_sig_recover(&ctx->ecmult_ctx, sig64, &q, secp256k1_schnorr_msghash_sha256, msg32)) {
         secp256k1_pubkey_save(pubkey, &q);
         return 1;
     } else {
-        memset(pubkey, 0, sizeof(*pubkey));
         return 0;
     }
 }
 
-int secp256k1_schnorr_generate_nonce_pair(const secp256k1_context* ctx, secp256k1_pubkey *pubnonce, unsigned char *privnonce32, const unsigned char *sec32, const unsigned char *msg32, secp256k1_nonce_function noncefp, const void* noncedata) {
+static int secp256k1_multischnorr_generate_key_nonces(const secp256k1_context* ctx, secp256k1_scalar* key_mine, secp256k1_scalar* nonce_mine, secp256k1_ge *pubnonce_all, const secp256k1_ge *pubnonce_others, const unsigned char *msg32, const unsigned char *sec32, secp256k1_nonce_function noncefp, const void* ndata) {
+    unsigned char sec32t[32];
+    int ret;
     int count = 0;
-    int ret = 1;
-    secp256k1_gej Qj;
-    secp256k1_ge Q;
-    secp256k1_scalar sec;
-
-    VERIFY_CHECK(ctx != NULL);
-    ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
-    ARG_CHECK(msg32 != NULL);
-    ARG_CHECK(sec32 != NULL);
-    ARG_CHECK(pubnonce != NULL);
-    ARG_CHECK(privnonce32 != NULL);
 
     if (noncefp == NULL) {
         noncefp = secp256k1_nonce_function_default;
     }
 
-    do {
-        int overflow;
-        ret = noncefp(privnonce32, sec32, msg32, secp256k1_schnorr_algo16, (void*)noncedata, count++);
+    ret = secp256k1_multischnorr_compute_tweaked_privkey(ctx, key_mine, sec32t, sec32);
+
+    while (ret) {
+        unsigned char nonce32[32];
+        ret = noncefp(nonce32, msg32, sec32t, secp256k1_schnorr_algo16, (void*)ndata, count);
         if (!ret) {
             break;
         }
-        secp256k1_scalar_set_b32(&sec, privnonce32, &overflow);
-        if (overflow || secp256k1_scalar_is_zero(&sec)) {
-            continue;
+        ret = secp256k1_schnorr_nonces_set_b32(&ctx->ecmult_gen_ctx, nonce_mine, pubnonce_all, nonce32, pubnonce_others);
+        memset(nonce32, 0, 32);
+        if (ret) {
+            break;
         }
-        secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &Qj, &sec);
-        secp256k1_ge_set_gej(&Q, &Qj);
+        count++;
+    }
 
-        secp256k1_pubkey_save(pubnonce, &Q);
-        break;
-    } while(1);
+    memset(sec32t, 0, 32);
 
-    secp256k1_scalar_clear(&sec);
     if (!ret) {
-        memset(pubnonce, 0, sizeof(*pubnonce));
+        secp256k1_scalar_clear(key_mine);
+        secp256k1_scalar_clear(nonce_mine);
     }
     return ret;
 }
 
-int secp256k1_schnorr_partial_sign(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg32, const unsigned char *sec32, const secp256k1_pubkey *pubnonce_others, const unsigned char *secnonce32) {
-    int overflow = 0;
-    secp256k1_scalar sec, non;
-    secp256k1_ge pubnon;
+int secp256k1_multischnorr_stage1(const secp256k1_context* ctx, unsigned char *stage1, const unsigned char *msg32, const unsigned char *sec32, secp256k1_nonce_function noncefp, const void* noncedata) {
+    secp256k1_scalar nonce_mine;
+    secp256k1_scalar key_mine;
+    secp256k1_ge pubnonce_mine;
+    int ret;
+
     VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(stage1 != NULL);
+    memset(stage1, 0, 32);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
     ARG_CHECK(msg32 != NULL);
-    ARG_CHECK(sig64 != NULL);
     ARG_CHECK(sec32 != NULL);
-    ARG_CHECK(secnonce32 != NULL);
-    ARG_CHECK(pubnonce_others != NULL);
 
-    secp256k1_scalar_set_b32(&sec, sec32, &overflow);
-    if (overflow || secp256k1_scalar_is_zero(&sec)) {
-        return -1;
+    ret = secp256k1_multischnorr_generate_key_nonces(ctx, &key_mine, &nonce_mine, &pubnonce_mine, NULL, msg32, sec32, noncefp, noncedata);
+    secp256k1_scalar_clear(&nonce_mine);
+    secp256k1_scalar_clear(&key_mine);
+    if (ret) {
+        secp256k1_schnorr_ge_get_b32(stage1, &pubnonce_mine);
     }
-    secp256k1_scalar_set_b32(&non, secnonce32, &overflow);
-    if (overflow || secp256k1_scalar_is_zero(&non)) {
-        return -1;
-    }
-    secp256k1_pubkey_load(ctx, &pubnon, pubnonce_others);
-    return secp256k1_schnorr_sig_sign(&ctx->ecmult_gen_ctx, sig64, &sec, &non, &pubnon, secp256k1_schnorr_msghash_sha256, msg32);
+    return ret;
 }
 
-int secp256k1_schnorr_partial_combine(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char * const *sig64sin, size_t n) {
+int secp256k1_multischnorr_stage2(const secp256k1_context* ctx, unsigned char *stage2, const unsigned char * const *other_stage1s, size_t num_others, const unsigned char *msg32, const unsigned char *sec32, secp256k1_nonce_function noncefp, const void* noncedata) {
+    int ret = 1;
+    secp256k1_scalar sec, nonce_mine;
+    secp256k1_ge pubnonce_others;
+    secp256k1_ge pubnonce_all;
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(stage2 != NULL);
+    memset(stage2, 0, 64);
+    ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
+    ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
+    if (num_others > 0) {
+        ARG_CHECK(other_stage1s != NULL);
+        ARG_CHECK(other_stage1s[num_others - 1] != NULL);
+    }
+    ARG_CHECK(msg32 != NULL);
+    ARG_CHECK(sec32 != NULL);
+
+    if (num_others > 0) {
+        secp256k1_gej pubnoncej_others;
+        size_t n = 0;
+        while (n < num_others) {
+            secp256k1_ge tmppub;
+            ret = ret & secp256k1_schnorr_ge_set_b32(&tmppub, other_stage1s[n]);
+            if (!ret) {
+                break;
+            }
+            if (n) {
+                secp256k1_gej_add_ge(&pubnoncej_others, &pubnoncej_others, &tmppub);
+            } else {
+                secp256k1_gej_set_ge(&pubnoncej_others, &tmppub);
+            }
+            n++;
+        }
+        if (ret) {
+            secp256k1_ge_set_gej(&pubnonce_others, &pubnoncej_others);
+        }
+    }
+
+    ret = ret && secp256k1_multischnorr_generate_key_nonces(ctx, &sec, &nonce_mine, &pubnonce_all, num_others > 0 ? &pubnonce_others : NULL, msg32, sec32, noncefp, noncedata);
+    ret = ret && secp256k1_schnorr_sig_sign(stage2, &sec, &nonce_mine, &pubnonce_all, secp256k1_schnorr_msghash_sha256, msg32);
+    secp256k1_scalar_clear(&sec);
+    secp256k1_scalar_clear(&nonce_mine);
+    if (!ret) {
+        memset(stage2, 0, 64);
+    }
+    return ret;
+}
+
+int secp256k1_multischnorr_combine_sigs(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char * const *stage2s, size_t n) {
     ARG_CHECK(sig64 != NULL);
+    memset(sig64, 0, 64);
     ARG_CHECK(n >= 1);
-    ARG_CHECK(sig64sin != NULL);
-    return secp256k1_schnorr_sig_combine(sig64, n, sig64sin);
+    ARG_CHECK(stage2s != NULL);
+    ARG_CHECK(stage2s[n - 1] != NULL);
+    return secp256k1_schnorr_sig_combine(sig64, n, stage2s);
+}
+
+int secp256k1_multischnorr_combine_keys(const secp256k1_context* ctx, secp256k1_pubkey *pubcomb, const secp256k1_pubkey * const *pub, size_t n) {
+    size_t i;
+    secp256k1_gej Qj, pubcombj;
+    secp256k1_ge Q;
+    int ret = 1;
+
+    ARG_CHECK(pubcomb != NULL);
+    memset(pubcomb, 0, sizeof(*pubcomb));
+    ARG_CHECK(n >= 1);
+    ARG_CHECK(pub != NULL);
+
+    secp256k1_gej_set_infinity(&pubcombj);
+
+    for (i = 0; i < n; i++) {
+        secp256k1_pubkey_load(ctx, &Q, pub[i]);
+        ret = ret && secp256k1_multischnorr_compute_tweaked_pubkey(ctx, &Qj, &Q);
+        secp256k1_gej_add_var(&pubcombj, &pubcombj, &Qj, NULL);
+        ret = ret && !secp256k1_gej_is_infinity(&pubcombj);
+    }
+    if (ret) {
+       secp256k1_ge_set_gej_var(&Q, &pubcombj);
+       secp256k1_pubkey_save(pubcomb, &Q);
+    }
+    return ret;
 }
 
 #endif

--- a/src/modules/schnorr/schnorr.h
+++ b/src/modules/schnorr/schnorr.h
@@ -12,9 +12,19 @@
 
 typedef void (*secp256k1_schnorr_msghash)(unsigned char *h32, const unsigned char *r32, const unsigned char *msg32);
 
-static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context* ctx, unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar *nonce, const secp256k1_ge *pubnonce, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+/** Compute the private and public nonce to use in signing, based on a 32-byte array and the sum of others' public nonces. */
+static int secp256k1_schnorr_nonces_set_b32(const secp256k1_ecmult_gen_context* ctx, secp256k1_scalar* nonce_mine, secp256k1_ge* pubnonce_all, const unsigned char *b32, const secp256k1_ge* pubnonce_others);
+
+/** Compute a Schnorr signature given a private key, your own private nonce, and the sum of everyone's public nonces. */
+static int secp256k1_schnorr_sig_sign(unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar* priv_mine, const secp256k1_ge* pub_all, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+
+/** Verify a Schnorr signature. */
 static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, const secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+
+/** Recover the public key of the signer of a Schnorr signature, assuming it is valid. */
 static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+
+/** Combine several partial stage 2 Schnorr signatures. */
 static int secp256k1_schnorr_sig_combine(unsigned char *sig64, size_t n, const unsigned char * const *sig64ins);
 
 #endif

--- a/src/modules/schnorr/schnorr.md
+++ b/src/modules/schnorr/schnorr.md
@@ -1,0 +1,195 @@
+Schnorr-SHA256 module
+=====================
+
+This module implements a custom Schnorr-based signature scheme.
+
+Features:
+* Fixed size 64-byte signatures
+* Public key recovery without additional information
+* Batch validation (not yet implemented)
+* Multiparty signing with 2 rounds of communication but no setup
+
+### Signature format
+
+Signatures and stage 2 partial multisignatures:
+* 32-byte big endian unsigned integer `R.x` in the range `[0..p-1]`
+* 32-byte big endian unsigned integer `s` in the range `[0..order-1]`
+
+Stage 1 partial multisignatures:
+* 32-byte big endian unsigned integer `R.x` in the range `[0..p-1]`
+
+For a valid signature for message `m` with public key `Q` the following
+It is computed as:
+
+##### Signing
+
+Inputs:
+* 32-byte message `m`
+* 32-byte scalar private key `x` (`!=0`)
+* 32-byte scalar private nonce `k` (`!=0`)
+
+Steps:
+* Compute public nonce `R = k * G`.
+* If R.y is odd, negate `k` and `R`.
+* Compute scalar `e = SHA256(R.x || m)`. If `e == 0` or `e >= order`, fail.
+* Compute scalar `s = k - e * x`.
+* The signature is `(R.x, s)`.
+
+##### Verification (method 1)
+
+Inputs:
+* 32-byte message `m`
+* public key point `Q`
+* signature pair (field element `R.x`, scalar `s`)
+
+Steps:
+* Signature is invalid if `s >= order`.
+* Signature is invalid if `R.x >= p`.
+* Compute scalar `e = SHA256(R.x || m)`. Signature is invalid if `e == 0` or
+  `e >= order`
+* Compute point `R' = e * Q + s * G`. Signature is invalid if `R'` is infinity
+  or `R'.y` is odd.
+* Signature is valid if `R'.x == R.x`.
+
+This method is faster for single signature verification.
+
+##### Verification (method 2)
+
+Inputs:
+* 32-byte message `m`
+* public key point `Q`
+* signature pair (field element `R.x`, scalar `s`)
+
+Steps:
+* Signature is invalid if `s >= order`.
+* Signature is invalid if `R.x >= p`.
+* Compute scalar `e = SHA256(R.x || m)`. Signature is invalid if `e == 0` or
+  `e >= order`.
+* Decompress `R.x` into point `R'`, with odd `y` coordinate. Fail if `R'` is
+  not on the curve.
+* Signature is valid if `R' + e * Q + s * G == 0`.
+
+As this results in a verification equation that is entirely in the point domain,
+it can be adapted easily for batch verification or public key recovery.
+
+##### Multisigning combined public key
+
+Inputs:
+* Public keys `Q(j) = x(j) * G` from all cosigners, for all `j`
+
+Steps:
+* Multiply each of the `Q(j)` values by their hash `SHA256(Q(j))`.
+* Compute the sum `Q_all` of all `Q(j)` values.
+* The full combined public key is `Q_all`.
+
+##### Multisigning stage 1
+
+Inputs:
+* 32-byte message `m`
+* 32-byte scalar private nonce `k(i)` (`!=0`)
+
+Steps:
+* Compute public nonce `R(i) = k(i) * G`.
+* The partial signature is `R(i).x`.
+
+##### Multisigning stage 2
+
+Inputs:
+* 32-byte message `m`
+* 32-byte scalar private key `x(i)` (`!=0`)
+* 32-byte scalar private nonce `k(i)` (`!=0`)
+* Partial stage 1 signatures `R(j).x` from all other cosigners, for all `j != i`
+
+Steps:
+* Tweak the private key: multiply `x(i)` by `SHA256(x(i) * G)`.
+* Compute (or reuse from stage 1) public nonce `R(i) = k(i) * G`.
+* If `R(i).y` is odd, negate `k(i)` and `R(i)`.
+* Convert each `R(j).x` coordinate into an `R(j)` point, with even `y`
+  coordinate.
+* Compute the sum `R_all(i)` of all the `R(j)` points, including your own
+  `R(i)`.
+* If `R_all.y` is odd, negate `k(i)` and `R_all(i)`.
+* Compute scalar `e = SHA256(R_all(i).x || m)`. If `e == 0` or `e >= order`,
+  fail.
+* Compute scalar `s(i) = k(i) - e * x`.
+* The partial stage 2 signature is `(R_all(i).x, s(i))`.
+
+##### Multisigning combine stage 2 signatures into a full signature
+
+Inputs:
+* Partial stage 2 signatures `(R_all(j).x, s(j))` from all cosigners, for all
+  `j`
+
+Steps:
+* Check whether all `R_all(j).x` values in each of the stage 2 signature are
+  identical. If not, fail.
+* Compute the sum `s_all` of all `s(j)` values.
+* The full combined signature is `(R_all.x, s(i))`.
+
+### Design choices
+
+##### Verifying `R`'s `y` coordinate
+
+In order to support batch verification and public key recovery, the full `R`
+point must be known to verifiers, rather than just its `x` coordinate. In order
+to not risk being more strict in batch verification than normal verification,
+verifiers must be required to reject signatures with incorrect `y` coordinate.
+
+This is only possible by:
+* Including the `y` coordinate in the signature, making it very cheap to verify,
+  but increases the signature size by 32 bytes.
+* Including enough information in the signature to recover the `y` coordinate
+  from the `x` coordinate. As every valid `x` only has two corresponding `y`
+  coordinates, only one bit is needed.
+* Outlawing one of the two possible `y` coordinates. As the signer can trivially
+  switch from one `y` to the other by negating R, this has negligable
+  performance overhead compared to the previous option, and saves one bit.
+
+The mechanism chosen here is to require that the `y` coordinate is even.
+Unfortunately, that does require either a field inverse to compute `y` in a
+normalized form that shows its oddness, or a field square root to recover `R`
+from `R.x`. The potential performance benefit from having batch validation is
+much larger though.
+
+##### Multiplying public keys by their hash in multisigning
+
+In multisignatures we don't sign with key `x`, but with `x * SHA256(x * G)`.
+This is done to prevent an attack where participants claim their public key is a
+point that has been constructed to cancel out other participants' keys.
+
+For example, if there are 3 participants `P1`, `P2` and `P3`, with private keys
+`x1`, `x2`, and `x3`. After `P1` and `P2` have revealed their public keys as
+`Q1 = x1 * G` and `Q2 = x2 * G` respectively, `P3` can claim his public key is
+`Q3 = x3 * G - Q1 - Q2`. `P3` cannot sign with this key, but the resulting
+combined public key would be `Q1 + Q2 + Q3`, which is in this case equal to
+`Q1 + Q2 + x3 * G - Q1 - Q2` or just `x3 * G`, which `P3` can sign for without
+cooperation from `P1` or `P2`.
+
+It is of course possible to demand that whenever someone computes a combined
+public key, they verify that all constituent public keys carry a valid signature
+from their own private key. But this is a non-obvious requirement, and not
+enforcable within the signature scheme itself.
+
+Instead we choose to sign with tweaked private keys, and get a signature that is
+valid for the combined public key
+`Q_all = Q1 * SHA256(Q1) + Q2 * SHA256(Q2) + Q3 * SHA256(Q3)` instead of for
+`Q_all = Q1 + Q2 + Q3`. It is impossible for any of the participants to make
+other participants' keys cancel out in this case.
+
+Proof:
+* Assume `Q = Q1 * H(Q1) + Q2 * H(Q2) + ...`.
+* Assume we have a point `R` and scalar `y` such that
+  `Q_all = Q + H(R) * R = y * G`.
+* Let `H'(x) = 1 / H(x) mod n`, so `Q + R / H'(R) = y * G`.
+* Multiply both sides by `H'(R)`, so `Q * H'(R) + R = H'(R) * y * G`
+* Move everything to the left side, so `Q * H'(R) + R - H'(R) * y * G = 0`.
+* Let scalar `s = -H'(R) * y`, so `R + Q * H'(R) + s * G = 0`.
+* Assume `H(x) = SHA256(x || m)`, for some value of `m`.
+* We now have `R + Q * (1 / SHA256(R || m)) + s * G = 0`, or `(R, s)` is a valid
+  Schnorr signature for hash function `H'(x) = 1 / SHA256(x) mod n` on message
+  `m` with public key `Q`. If `H'(x)` is a random oracle (which it is when
+  `SHA256 mod n` is), this is presumed to be only possible to someone who knows
+  `x` such that `Q = x * G`.
+* Thus, you can only pick a public key `R` that enables you to sign for the
+  combined multiparty public key `Q_all = Q + R * H(R)` if you already know the
+  private key `x` for the others' combined multiparty public key `Q`.

--- a/src/modules/schnorr/schnorr_impl.h
+++ b/src/modules/schnorr/schnorr_impl.h
@@ -59,46 +59,82 @@
  *     Signature is valid if R + h * Q + s * G == 0.
  */
 
-static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context* ctx, unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar *nonce, const secp256k1_ge *pubnonce, secp256k1_schnorr_msghash hash, const unsigned char *msg32) {
-    secp256k1_gej Rj;
-    secp256k1_ge Ra;
+static void secp256k1_schnorr_ge_get_b32(unsigned char *b32, secp256k1_ge* p) {
+    secp256k1_fe_normalize(&p->x);
+    secp256k1_fe_get_b32(b32, &p->x);
+}
+
+static int secp256k1_schnorr_ge_set_b32(secp256k1_ge* p, const unsigned char *b32) {
+    secp256k1_fe x;
+    if (!secp256k1_fe_set_b32(&x, b32)) {
+        return 0;
+    }
+    return secp256k1_ge_set_xo_var(p, &x, 0);
+}
+
+/** Computes {priv = +/- (scalar)b32; pub' = priv * G; pub = +-(pub' + pub_others} with pub'.y and pub.y even. */
+static int secp256k1_schnorr_nonces_set_b32(const secp256k1_ecmult_gen_context* ctx, secp256k1_scalar* priv, secp256k1_ge* pub, const unsigned char *b32, const secp256k1_ge* pub_others) {
+    int overflow = 0;
+    int flip = 0;
+    secp256k1_gej gej;
+
+    secp256k1_scalar_set_b32(priv, b32, &overflow);
+    if (overflow || secp256k1_scalar_is_zero(priv)) {
+        secp256k1_scalar_clear(priv);
+        return 0;
+    }
+    secp256k1_ecmult_gen(ctx, &gej, priv);
+    VERIFY_CHECK(!secp256k1_gej_is_infinity(&gej));
+    secp256k1_ge_set_gej(pub, &gej);
+    secp256k1_fe_normalize(&pub->y);
+    if (secp256k1_fe_is_odd(&pub->y)) {
+        /* our R's y coordinate is odd, which is not allowed (see rationale above).
+           Force it to be even by negating our nonce. */
+        flip++;
+        if (pub_others != NULL) {
+            secp256k1_gej_neg(&gej, &gej);
+        } else {
+            secp256k1_ge_neg(pub, pub);
+        }
+    }
+    if (pub_others != NULL) {
+        secp256k1_gej_add_ge(&gej, &gej, pub_others);
+        secp256k1_ge_set_gej(pub, &gej);
+        secp256k1_fe_normalize(&pub->y);
+        if (secp256k1_fe_is_odd(&pub->y)) {
+            /* The combined R's y coordinate odd, which is not allowed. Force it
+               to be even by by negating our nonce (and assuming everyone else
+               does the same). */
+            flip++;
+            secp256k1_ge_neg(pub, pub);
+        }
+    }
+    if (flip & 1) {
+        secp256k1_scalar_negate(priv, priv);
+    }
+    return 1;
+}
+
+/** Compute a Schnorr signature given our own nonce, and the sum of everyone's public nonces. */
+static int secp256k1_schnorr_sig_sign(unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar *nonce_mine, const secp256k1_ge *pubnonce_all, secp256k1_schnorr_msghash hash, const unsigned char *msg32) {
+    secp256k1_ge Ra = *pubnonce_all;
     unsigned char h32[32];
     secp256k1_scalar h, s;
     int overflow;
-    secp256k1_scalar n;
 
-    if (secp256k1_scalar_is_zero(key) || secp256k1_scalar_is_zero(nonce)) {
+    if (secp256k1_scalar_is_zero(key)) {
         return 0;
     }
-    n = *nonce;
-
-    secp256k1_ecmult_gen(ctx, &Rj, &n);
-    if (pubnonce != NULL) {
-        secp256k1_gej_add_ge(&Rj, &Rj, pubnonce);
-    }
-    secp256k1_ge_set_gej(&Ra, &Rj);
-    secp256k1_fe_normalize(&Ra.y);
-    if (secp256k1_fe_is_odd(&Ra.y)) {
-        /* R's y coordinate is odd, which is not allowed (see rationale above).
-           Force it to be even by negating the nonce. Note that this even works
-           for multiparty signing, as the R point is known to all participants,
-           which can all decide to flip the sign in unison, resulting in the
-           overall R point to be negated too. */
-        secp256k1_scalar_negate(&n, &n);
-    }
-    secp256k1_fe_normalize(&Ra.x);
-    secp256k1_fe_get_b32(sig64, &Ra.x);
+    secp256k1_schnorr_ge_get_b32(sig64, &Ra);
     hash(h32, sig64, msg32);
     overflow = 0;
     secp256k1_scalar_set_b32(&h, h32, &overflow);
     if (overflow || secp256k1_scalar_is_zero(&h)) {
-        secp256k1_scalar_clear(&n);
         return 0;
     }
     secp256k1_scalar_mul(&s, &h, key);
     secp256k1_scalar_negate(&s, &s);
-    secp256k1_scalar_add(&s, &s, &n);
-    secp256k1_scalar_clear(&n);
+    secp256k1_scalar_add(&s, &s, nonce_mine);
     secp256k1_scalar_get_b32(sig64 + 32, &s);
     return 1;
 }
@@ -144,7 +180,6 @@ static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context* ctx, con
 static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32) {
     secp256k1_gej Qj, Rj;
     secp256k1_ge Ra;
-    secp256k1_fe Rx;
     secp256k1_scalar h, s;
     unsigned char hh[32];
     int overflow;
@@ -160,10 +195,7 @@ static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context* ctx, co
     if (overflow) {
         return 0;
     }
-    if (!secp256k1_fe_set_b32(&Rx, sig64)) {
-        return 0;
-    }
-    if (!secp256k1_ge_set_xo_var(&Ra, &Rx, 0)) {
+    if (!secp256k1_schnorr_ge_set_b32(&Ra, sig64)) {
         return 0;
     }
     secp256k1_gej_set_ge(&Rj, &Ra);
@@ -186,11 +218,11 @@ static int secp256k1_schnorr_sig_combine(unsigned char *sig64, size_t n, const u
         int overflow;
         secp256k1_scalar_set_b32(&si, sig64ins[i] + 32, &overflow);
         if (overflow) {
-            return -1;
+            return 0;
         }
         if (i) {
             if (memcmp(sig64ins[i - 1], sig64ins[i], 32) != 0) {
-                return -1;
+                return 0;
             }
         }
         secp256k1_scalar_add(&s, &s, &si);
@@ -202,6 +234,68 @@ static int secp256k1_schnorr_sig_combine(unsigned char *sig64, size_t n, const u
     secp256k1_scalar_get_b32(sig64 + 32, &s);
     secp256k1_scalar_clear(&s);
     return 1;
+}
+
+static int secp256k1_multischnorr_compute_tweak(secp256k1_scalar* tweak, const secp256k1_ge* pubkey) {
+    secp256k1_ge ge = *pubkey;
+    unsigned char c[33];
+    unsigned char h[32];
+    size_t size = 33;
+    secp256k1_sha256_t sha;
+    int overflow = 0;
+
+    if (!secp256k1_eckey_pubkey_serialize(&ge, c, &size, SECP256K1_EC_COMPRESSED)) {
+        return 0;
+    }
+    secp256k1_sha256_initialize(&sha);
+    secp256k1_sha256_write(&sha, c, size);
+    secp256k1_sha256_finalize(&sha, h);
+    secp256k1_scalar_set_b32(tweak, h, &overflow);
+    if (overflow || secp256k1_scalar_is_zero(tweak)) {
+        secp256k1_scalar_clear(tweak);
+        return 0;
+    }
+    return 1;
+}
+
+static int secp256k1_multischnorr_compute_tweaked_privkey(const secp256k1_context* ctx, secp256k1_scalar* key, unsigned char *sec32out, const unsigned char *sec32in) {
+    secp256k1_gej pubj;
+    secp256k1_ge pub;
+    secp256k1_scalar tweak;
+    int overflow = 0;
+    int ret;
+
+    secp256k1_scalar_set_b32(key, sec32in, &overflow);
+    ret = !overflow && !secp256k1_scalar_is_zero(key);
+    if (ret) {
+        secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &pubj, key);
+        secp256k1_ge_set_gej(&pub, &pubj);
+        ret = secp256k1_multischnorr_compute_tweak(&tweak, &pub);
+    }
+    if (ret) {
+        secp256k1_scalar_mul(key, key, &tweak);
+        secp256k1_scalar_get_b32(sec32out, key);
+    } else {
+        secp256k1_scalar_clear(key);
+        memset(sec32out, 0, 32);
+    }
+    return ret;
+}
+
+static int secp256k1_multischnorr_compute_tweaked_pubkey(const secp256k1_context* ctx, secp256k1_gej* pub_tweaked, const secp256k1_ge* pub) {
+    secp256k1_scalar tweak;
+    static const secp256k1_scalar zero = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
+    int ret;
+
+    ret = secp256k1_multischnorr_compute_tweak(&tweak, pub);
+    if (ret) {
+        secp256k1_gej_set_ge(pub_tweaked, pub);
+        secp256k1_ecmult(&ctx->ecmult_ctx, pub_tweaked, pub_tweaked, &tweak, &zero);
+    }
+    if (!ret) {
+        secp256k1_gej_clear(pub_tweaked);
+    }
+    return ret;
 }
 
 #endif

--- a/src/modules/schnorr/tests_impl.h
+++ b/src/modules/schnorr/tests_impl.h
@@ -52,7 +52,7 @@ void test_schnorr_sign_verify(void) {
     unsigned char sig64[3][64];
     secp256k1_gej pubkeyj[3];
     secp256k1_ge pubkey[3];
-    secp256k1_scalar nonce[3], key[3];
+    secp256k1_scalar key[3];
     int i = 0;
     int k;
 
@@ -62,8 +62,11 @@ void test_schnorr_sign_verify(void) {
         random_scalar_order_test(&key[k]);
 
         do {
-            random_scalar_order_test(&nonce[k]);
-            if (secp256k1_schnorr_sig_sign(&ctx->ecmult_gen_ctx, sig64[k], &key[k], &nonce[k], NULL, &test_schnorr_hash, msg32)) {
+            unsigned char nonce32[32];
+            secp256k1_ge pubnonce;
+            secp256k1_scalar privnonce;
+            secp256k1_rand256_test(nonce32);
+            if (secp256k1_schnorr_nonces_set_b32(&ctx->ecmult_gen_ctx, &privnonce, &pubnonce, nonce32, NULL) && secp256k1_schnorr_sig_sign(sig64[k], &key[k], &privnonce, &pubnonce, &test_schnorr_hash, msg32)) {
                 break;
             }
         } while(1);
@@ -82,60 +85,61 @@ void test_schnorr_sign_verify(void) {
     }
 }
 
-void test_schnorr_threshold(void) {
+void test_multischnorr(void) {
     unsigned char msg[32];
     unsigned char sec[5][32];
     secp256k1_pubkey pub[5];
-    unsigned char nonce[5][32];
-    secp256k1_pubkey pubnonce[5];
-    unsigned char sig[5][64];
-    const unsigned char* sigs[5];
+    unsigned char stage1[5][32];
+    unsigned char stage2[5][64];
     unsigned char allsig[64];
-    const secp256k1_pubkey* pubs[5];
+    const secp256k1_pubkey *allpubs[5];
+    const unsigned char *allstage2s[5];
     secp256k1_pubkey allpub;
     int n, i;
     int damage;
     int ret = 0;
 
-    damage = secp256k1_rand_bits(1) ? (1 + secp256k1_rand_int(4)) : 0;
+    n = 1 + secp256k1_rand_int(5);
+    if (n == 1) {
+        damage = secp256k1_rand_bits(1) ? 2 + secp256k1_rand_int(3) : 0;
+    } else {
+        damage = secp256k1_rand_bits(1) ? 1 + secp256k1_rand_int(4) : 0;
+    }
     secp256k1_rand256_test(msg);
-    n = 2 + secp256k1_rand_int(4);
     for (i = 0; i < n; i++) {
         do {
             secp256k1_rand256_test(sec[i]);
         } while (!secp256k1_ec_seckey_verify(ctx, sec[i]));
         CHECK(secp256k1_ec_pubkey_create(ctx, &pub[i], sec[i]));
-        CHECK(secp256k1_schnorr_generate_nonce_pair(ctx, &pubnonce[i], nonce[i], msg, sec[i], NULL, NULL));
-        pubs[i] = &pub[i];
+        CHECK(secp256k1_multischnorr_stage1(ctx, stage1[i], msg, sec[i], NULL, NULL));
+        allpubs[i] = &pub[i];
     }
     if (damage == 1) {
-        nonce[secp256k1_rand_int(n)][secp256k1_rand_int(32)] ^= 1 + secp256k1_rand_int(255);
+        stage1[secp256k1_rand_int(n - 1)][secp256k1_rand_bits(5)] ^= 1 + secp256k1_rand_int(255);
     } else if (damage == 2) {
         sec[secp256k1_rand_int(n)][secp256k1_rand_int(32)] ^= 1 + secp256k1_rand_int(255);
     }
     for (i = 0; i < n; i++) {
-        secp256k1_pubkey allpubnonce;
-        const secp256k1_pubkey *pubnonces[4];
+        const unsigned char *stage1s[4];
         int j;
         for (j = 0; j < i; j++) {
-            pubnonces[j] = &pubnonce[j];
+            stage1s[j] = stage1[j];
         }
         for (j = i + 1; j < n; j++) {
-            pubnonces[j - 1] = &pubnonce[j];
+            stage1s[j - 1] = stage1[j];
         }
-        CHECK(secp256k1_ec_pubkey_combine(ctx, &allpubnonce, pubnonces, n - 1));
-        ret |= (secp256k1_schnorr_partial_sign(ctx, sig[i], msg, sec[i], &allpubnonce, nonce[i]) != 1) * 1;
-        sigs[i] = sig[i];
+        ret |= (secp256k1_multischnorr_stage2(ctx, stage2[i], stage1s, n - 1, msg, sec[i], NULL, NULL) != 1) * 1;
+        allstage2s[i] = stage2[i];
     }
     if (damage == 3) {
-        sig[secp256k1_rand_int(n)][secp256k1_rand_bits(6)] ^= 1 + secp256k1_rand_int(255);
+        stage2[secp256k1_rand_int(n)][secp256k1_rand_bits(6)] ^= 1 + secp256k1_rand_int(5);
     }
-    ret |= (secp256k1_ec_pubkey_combine(ctx, &allpub, pubs, n) != 1) * 2;
+    ret |= (secp256k1_multischnorr_combine_keys(ctx, &allpub, allpubs, n) != 1) * 2;
     if ((ret & 1) == 0) {
-        ret |= (secp256k1_schnorr_partial_combine(ctx, allsig, sigs, n) != 1) * 4;
+        ret |= (secp256k1_multischnorr_combine_sigs(ctx, allsig, allstage2s, n) != 1) * 4;
     }
     if (damage == 4) {
-        allsig[secp256k1_rand_int(32)] ^= 1 + secp256k1_rand_int(255);
+        allsig[secp256k1_rand_bits(6)] ^= 1 + secp256k1_rand_int(255);
     }
     if ((ret & 7) == 0) {
         ret |= (secp256k1_schnorr_verify(ctx, allsig, msg, &allpub) != 1) * 8;
@@ -168,7 +172,7 @@ void run_schnorr_tests(void) {
          test_schnorr_recovery();
     }
     for (i = 0; i < 10 * count; i++) {
-         test_schnorr_threshold();
+         test_multischnorr();
     }
 }
 


### PR DESCRIPTION
This reworks the Schnorr multisigning API to 4 self-contained functions:
* secp256k1_multischnorr_stage1 computes public nonces
* secp256k1_multischnorr_stage2 computes partial signatures using those public nonces
* secp256k1_multischnorr_combine_sigs combines stage2 sigs into a full signature
* secp256k1_multischnorr_combine_keys combines signers' public keys into a combined public key.

This changes the combined public key to be `A*H(A) + B*H(B) + C*H(C) + ...`, in an attempt to prevent a pubkey cancellation vulnerability.

The documentation is also moved out to a separate schnorr.md document.

