### PR TITLE
Add string.h include to ecmult_impl

### DIFF
--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -11,6 +11,8 @@
 #include "scalar.h"
 #include "ecmult.h"
 
+#include <string.h>
+
 /* optimal for 128-bit and 256-bit exponents. */
 #define WINDOW_A 5
 


### PR DESCRIPTION
`memcpy` and `memset` are used, so include the appropriate header for the declaration.

Fixes #409
Ref: https://github.com/bitcoin/bitcoin/pull/8453
