### PR TITLE
Remove guarantees about memcmp-ability

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -47,11 +47,8 @@ typedef struct secp256k1_context_struct secp256k1_context;
  *  The exact representation of data inside is implementation defined and not
  *  guaranteed to be portable between different platforms or versions. It is
  *  however guaranteed to be 64 bytes in size, and can be safely copied/moved.
- *  If you need to convert to a format suitable for storage or transmission, use
- *  secp256k1_ec_pubkey_serialize and secp256k1_ec_pubkey_parse.
- *
- *  Furthermore, it is guaranteed that identical public keys (ignoring
- *  compression) will have identical representation, so they can be memcmp'ed.
+ *  If you need to convert to a format suitable for storage, transmission, or
+ *  comparison, use secp256k1_ec_pubkey_serialize and secp256k1_ec_pubkey_parse.
  */
 typedef struct {
     unsigned char data[64];
@@ -62,12 +59,9 @@ typedef struct {
  *  The exact representation of data inside is implementation defined and not
  *  guaranteed to be portable between different platforms or versions. It is
  *  however guaranteed to be 64 bytes in size, and can be safely copied/moved.
- *  If you need to convert to a format suitable for storage or transmission, use
- *  the secp256k1_ecdsa_signature_serialize_* and
+ *  If you need to convert to a format suitable for storage, transmission, or
+ *  comparison, use the secp256k1_ecdsa_signature_serialize_* and
  *  secp256k1_ecdsa_signature_serialize_* functions.
- *
- *  Furthermore, it is guaranteed to identical signatures will have identical
- *  representation, so they can be memcmp'ed.
  */
 typedef struct {
     unsigned char data[64];


### PR DESCRIPTION
We had a discussion in person some months ago about the guarantees on the representation of the publicly exposed types, and I think guaranteeing memcmp is too strong. There are lots of internal things that can't be memcmp'd and it stands to reason that we might want the freedom to use similar representations for public types in future.

Note that removing this guarantee makes comparison of points that might be infinity quite annoying.