### PR TITLE
Make the libcrypto detection fail the newer API.

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -46,6 +46,10 @@ if test x"$has_libcrypto" = x"yes" && test x"$has_openssl_ec" = x; then
     ECDSA_sign(0, NULL, 0, NULL, NULL, eckey);
     ECDSA_verify(0, NULL, 0, NULL, 0, eckey);
     EC_KEY_free(eckey);
+    ECDSA_SIG *sig_openssl;
+    sig_openssl = ECDSA_SIG_new();
+    (void)sig_openssl->r;
+    ECDSA_SIG_free(sig_openssl);
   ]])],[has_openssl_ec=yes],[has_openssl_ec=no])
   AC_MSG_RESULT([$has_openssl_ec])
 fi


### PR DESCRIPTION
OpenSSL 1.1 makes ECDSA_SIG opaque and our tests need access
inside this object.

The comparison tests against OpenSSL aren't important for most
users, but the build failing is...