### PR TITLE
[trivial] clear stack variable by function

### DIFF
--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -150,7 +150,7 @@ static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context *ctx, secp25
         secp256k1_ge_from_storage(&add, &adds);
         secp256k1_gej_add_ge(r, r, &add);
     }
-    bits = 0;
+    secp256k1_int_clear(&bits);
     secp256k1_ge_clear(&add);
     secp256k1_scalar_clear(&gnb);
 }

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -214,8 +214,13 @@ static void secp256k1_ge_clear(secp256k1_ge *r) {
     secp256k1_fe_clear(&r->y);
 }
 
-static void __attribute__((optimize("O0"))) secp256k1_secure_clear(void *s, size_t n) {
-    (void) memset(s, 0, n);
+typedef void *(*memset_t)(void *, int, size_t);
+
+static volatile memset_t secure_memset = memset;
+
+static void secp256k1_secure_clear(void *s, size_t n) {
+    (void) secure_memset(s, 0, n);
+
 }
 
 static void secp256k1_int_clear(int *r) {

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -7,6 +7,7 @@
 #ifndef _SECP256K1_GROUP_IMPL_H_
 #define _SECP256K1_GROUP_IMPL_H_
 
+#include <string.h>
 #include "num.h"
 #include "field.h"
 #include "group.h"
@@ -211,6 +212,14 @@ static void secp256k1_ge_clear(secp256k1_ge *r) {
     r->infinity = 0;
     secp256k1_fe_clear(&r->x);
     secp256k1_fe_clear(&r->y);
+}
+
+static void __attribute__((optimize("O0"))) secp256k1_secure_clear(void *s, size_t n) {
+    (void) memset(s, 0, n);
+}
+
+static void secp256k1_int_clear(int *r) {
+    secp256k1_secure_clear(r, sizeof(*r));
 }
 
 static int secp256k1_ge_set_xquad(secp256k1_ge *r, const secp256k1_fe *x) {


### PR DESCRIPTION
The bare `bits = 0;` raises a clang static analysis issue.

```
--------------------------------------------------------------------------------
An issue has been found in ./src/ecmult_gen_impl.h:153:5
Type:         Dead assignment
Description:  Value stored to 'bits' is never read

0: ./src/ecmult_gen_impl.h:153:5 - Value stored to 'bits' is never read
--------------------------------------------------------------------------------
```

The line was introduced in 2f6c8019114743e46a741fc6a01f9c6600ccdb5d (when `secp256k1_ecmult_gen()` lived in `src/ecmult_impl.h`) with the purpose of clearing stack variables that might have secret info.

However, without that context, the purpose for clearing isn't obvious from reading the code. Aside from making clang happy, the function name should help it be understood.