### PR TITLE
Fixes typos

### DIFF
--- a/sage/group_prover.sage
+++ b/sage/group_prover.sage
@@ -3,7 +3,7 @@
 # to independently set assumptions on input or intermediary variables.
 #
 # The general approach is:
-# * A constraint is a tuple of two sets of of symbolic expressions:
+# * A constraint is a tuple of two sets of symbolic expressions:
 #   the first of which are required to evaluate to zero, the second of which
 #   are required to evaluate to nonzero.
 #   - A constraint is said to be conflicting if any of its nonzero expressions

--- a/src/asm/field_10x26_arm.s
+++ b/src/asm/field_10x26_arm.s
@@ -11,7 +11,7 @@ Note:
 
 - To avoid unnecessary loads and make use of available registers, two
   'passes' have every time been interleaved, with the odd passes accumulating c' and d' 
-  which will be added to c and d respectively in the the even passes
+  which will be added to c and d respectively in the even passes
 
 */
 


### PR DESCRIPTION
“of of” -> “of” and “the the” -> “the”

Mirroring downstream changes committed in
https://github.com/bitcoin/bitcoin/commit/0a5a6b90bc75a8d75fdff71c9b08abe9b0b96b0a