### PR TITLE
Don't fail JNI dependency checks if we can build a JNI program

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -401,6 +401,9 @@ if test x"$use_jni" != x"no"; then
     have_jni_dependencies=no
   fi
   if test "x$have_jni_dependencies" = "xno"; then
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <jni.h>]])], [have_jni_dependencies=yes])
+  fi
+  if test "x$have_jni_dependencies" = "xno"; then
     if test x"$use_jni" = x"yes"; then
       AC_MSG_ERROR([jni support explicitly requested but headers/dependencies were not found. Enable ECDH and try again.])
     fi


### PR DESCRIPTION
Not all setups will result in JNI_INCLUDE_DIRS having a value, in
particular Android builds from standalone toolchain directories have
the JNI headers installed in the standard include directories.

Instead of failing if the configure macro didn't find a directory
based on the installed Java runtime, only fail if we cannot build a
JNI-including program.