### PR TITLE
add secp256k1_recovery.h to include_HEADERS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,9 @@ noinst_LTLIBRARIES = $(JNI_LIB)
 else
 JNI_LIB =
 endif
-include_HEADERS = include/secp256k1.h
+include_HEADERS =
+include_HEADERS += include/secp256k1.h
+include_HEADERS += include/secp256k1_recovery.h
 noinst_HEADERS =
 noinst_HEADERS += src/scalar.h
 noinst_HEADERS += src/scalar_4x64.h


### PR DESCRIPTION
If you intend to use this as a library in order to do public key recovery, it's necessary to have access to secp256k1_recovery.h, but make install wasn't installing it. This commit modifies Makefile.am in order to add this file to the list of headers installed by make install.