### PR TITLE
README: Require uint128_t support, not just uint64_t

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Implementation details
   * No runtime heap allocation.
   * Extensive testing infrastructure.
   * Structured to facilitate review and analysis.
-  * Intended to be portable to any system with a C89 compiler and uint64_t support.
+  * Intended to be portable to any system with a C89 compiler and uint128_t support.
   * Expose only higher level interfaces to minimize the API surface and improve application security. ("Be difficult to use insecurely.")
 * Field operations
   * Optimized implementation of arithmetic modulo the curve's field size (2^256 - 0x1000003D1).


### PR DESCRIPTION
On trying to run the test suite in the TIS Interpreter, I realized that I can't, because of the uint128_t requirement.