### PR TITLE
Fixing a build failure (see below)

### DIFF
--- a/src/bench_ecdh.c
+++ b/src/bench_ecdh.c
@@ -36,7 +36,7 @@ static void bench_ecdh_setup(void* arg) {
     CHECK(secp256k1_ec_pubkey_parse(data->ctx, &data->point, point, sizeof(point)) == 1);
 }
 
-static void bench_ecdh(void* arg) {
+static void bench_ecdh_run(void* arg) {
     int i;
     unsigned char res[32];
     bench_ecdh *data = (bench_ecdh*)arg;
@@ -49,6 +49,6 @@ static void bench_ecdh(void* arg) {
 int main(void) {
     bench_ecdh data;
 
-    run_benchmark("ecdh", bench_ecdh, bench_ecdh_setup, NULL, &data, 10, 20000);
+    run_benchmark("ecdh", bench_ecdh_run, bench_ecdh_setup, NULL, &data, 10, 20000);
     return 0;
 }

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -15,7 +15,7 @@ typedef struct {
     unsigned char sig[64];
 } bench_recover;
 
-void bench_recover(void* arg) {
+void bench_recover_run(void* arg) {
     int i;
     bench_recover *data = (bench_recover*)arg;
     secp256k1_pubkey pubkey;
@@ -53,7 +53,7 @@ int main(void) {
 
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
 
-    run_benchmark("ecdsa_recover", bench_recover, bench_recover_setup, NULL, &data, 10, 20000);
+    run_benchmark("ecdsa_recover", bench_recover_run, bench_recover_setup, NULL, &data, 10, 20000);
 
     secp256k1_context_destroy(data.ctx);
     return 0;


### PR DESCRIPTION
With gcc (Ubuntu 7.2.0-8ubuntu3) 7.2.0:
```
src/bench_recover.c:18:6: error: ‘bench_recover’ redeclared as different kind of symbol
 void bench_recover(void* arg) {
      ^~~~~~~~~~~~~
src/bench_recover.c:16:3: note: previous declaration of ‘bench_recover’ was here
 } bench_recover;
   ^~~~~~~~~~~~~
```