### PR TITLE
Support OpenSSL versions >= 1.1 for ENABLE_OPENSSL_TESTS

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -48,7 +48,6 @@ if test x"$has_libcrypto" = x"yes" && test x"$has_openssl_ec" = x; then
     EC_KEY_free(eckey);
     ECDSA_SIG *sig_openssl;
     sig_openssl = ECDSA_SIG_new();
-    (void)sig_openssl->r;
     ECDSA_SIG_free(sig_openssl);
   ]])],[has_openssl_ec=yes],[has_openssl_ec=no])
   AC_MSG_RESULT([$has_openssl_ec])


### PR DESCRIPTION
The only reason OpenSSL 1.1 was not supported was the removal of direct
access to r and s in ECDSA_SIG. This commit adds a simplified version of
ECDSA_SIG_get0 for < 1.1 that can be used like ECDSA_SIG_get0 in >= 1.1