### PR TITLE
tests: Avoid calling fclose(...) with an invalid argument

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -4924,7 +4924,9 @@ int main(int argc, char **argv) {
             seed16[6] ^= t >> 48;
             seed16[7] ^= t >> 56;
         }
-        fclose(frand);
+        if (frand) {
+            fclose(frand);
+        }
     }
     secp256k1_rand_seed(seed16);
 


### PR DESCRIPTION
Avoid calling `fclose(...)` with an invalid argument.