### PR TITLE
Update URLs to MIT license.

### DIFF
--- a/contrib/lax_der_parsing.c
+++ b/contrib/lax_der_parsing.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #include <string.h>

--- a/contrib/lax_der_parsing.h
+++ b/contrib/lax_der_parsing.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 /****

--- a/contrib/lax_der_privatekey_parsing.c
+++ b/contrib/lax_der_privatekey_parsing.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014, 2015 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #include <string.h>

--- a/contrib/lax_der_privatekey_parsing.h
+++ b/contrib/lax_der_privatekey_parsing.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014, 2015 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 /****

--- a/src/asm/field_10x26_arm.s
+++ b/src/asm/field_10x26_arm.s
@@ -2,7 +2,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Wladimir J. van der Laan                        *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 /*
 ARM implementation of field_10x26 inner loops.

--- a/src/basic-config.h
+++ b/src/basic-config.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_BASIC_CONFIG_H

--- a/src/bench.h
+++ b/src/bench.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_BENCH_H

--- a/src/bench_ecdh.c
+++ b/src/bench_ecdh.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Pieter Wuille, Andrew Poelstra                  *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #include <string.h>

--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2017 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 #include <stdio.h>
 

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 #include <stdio.h>
 

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #include "include/secp256k1.h"

--- a/src/bench_sign.c
+++ b/src/bench_sign.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #include "include/secp256k1.h"

--- a/src/bench_verify.c
+++ b/src/bench_verify.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #include <stdio.h>

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_ECDSA_H

--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 

--- a/src/eckey.h
+++ b/src/eckey.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_ECKEY_H

--- a/src/eckey_impl.h
+++ b/src/eckey_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_ECKEY_IMPL_H

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014, 2017 Pieter Wuille, Andrew Poelstra      *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_ECMULT_H

--- a/src/ecmult_const.h
+++ b/src/ecmult_const.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_ECMULT_CONST_H

--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Pieter Wuille, Andrew Poelstra                  *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_ECMULT_CONST_IMPL_H

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_ECMULT_GEN_H

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014, 2015 Pieter Wuille, Gregory Maxwell      *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_ECMULT_GEN_IMPL_H

--- a/src/field.h
+++ b/src/field.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_FIELD_H

--- a/src/field_10x26.h
+++ b/src/field_10x26.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_FIELD_REPR_H

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_FIELD_REPR_IMPL_H

--- a/src/field_5x52.h
+++ b/src/field_5x52.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_FIELD_REPR_H

--- a/src/field_5x52_asm_impl.h
+++ b/src/field_5x52_asm_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2014 Diederik Huys, Pieter Wuille               *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 /**

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_FIELD_REPR_IMPL_H

--- a/src/field_5x52_int128_impl.h
+++ b/src/field_5x52_int128_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_FIELD_INNER5X52_IMPL_H

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_FIELD_IMPL_H

--- a/src/gen_context.c
+++ b/src/gen_context.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014, 2015 Thomas Daede, Cory Fields           *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #define USE_BASIC_CONFIG 1

--- a/src/group.h
+++ b/src/group.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_GROUP_H

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_GROUP_IMPL_H

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_HASH_H

--- a/src/hash_impl.h
+++ b/src/hash_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_HASH_IMPL_H

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_MODULE_ECDH_MAIN_H

--- a/src/modules/ecdh/tests_impl.h
+++ b/src/modules/ecdh/tests_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_MODULE_ECDH_TESTS_H

--- a/src/modules/recovery/main_impl.h
+++ b/src/modules/recovery/main_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_MODULE_RECOVERY_MAIN_H

--- a/src/modules/recovery/tests_impl.h
+++ b/src/modules/recovery/tests_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_MODULE_RECOVERY_TESTS_H

--- a/src/num.h
+++ b/src/num.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_NUM_H

--- a/src/num_gmp.h
+++ b/src/num_gmp.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_NUM_REPR_H

--- a/src/num_gmp_impl.h
+++ b/src/num_gmp_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_NUM_REPR_IMPL_H

--- a/src/num_impl.h
+++ b/src/num_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_NUM_IMPL_H

--- a/src/scalar.h
+++ b/src/scalar.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_SCALAR_H

--- a/src/scalar_4x64.h
+++ b/src/scalar_4x64.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_SCALAR_REPR_H

--- a/src/scalar_4x64_impl.h
+++ b/src/scalar_4x64_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_SCALAR_REPR_IMPL_H

--- a/src/scalar_8x32.h
+++ b/src/scalar_8x32.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_SCALAR_REPR_H

--- a/src/scalar_8x32_impl.h
+++ b/src/scalar_8x32_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_SCALAR_REPR_IMPL_H

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_SCALAR_IMPL_H

--- a/src/scalar_low.h
+++ b/src/scalar_low.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_SCALAR_REPR_H

--- a/src/scalar_low_impl.h
+++ b/src/scalar_low_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_SCALAR_REPR_IMPL_H

--- a/src/scratch.h
+++ b/src/scratch.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2017 Andrew Poelstra	                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef _SECP256K1_SCRATCH_

--- a/src/scratch_impl.h
+++ b/src/scratch_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2017 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef _SECP256K1_SCRATCH_IMPL_H_

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #include "include/secp256k1.h"

--- a/src/testrand.h
+++ b/src/testrand.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_TESTRAND_H

--- a/src/testrand_impl.h
+++ b/src/testrand_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_TESTRAND_IMPL_H

--- a/src/tests.c
+++ b/src/tests.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014, 2015 Pieter Wuille, Gregory Maxwell      *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #if defined HAVE_CONFIG_H

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -1,7 +1,7 @@
 /***********************************************************************
  * Copyright (c) 2016 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #if defined HAVE_CONFIG_H

--- a/src/util.h
+++ b/src/util.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef SECP256K1_UTIL_H


### PR DESCRIPTION
This closes #503 (where further discussion is linked).
Command(s) used to create this changeset was/were:

'''
find . -type f -print0 | xargs -0 sed -i -e
's,http://www.opensource.org/licenses/mit-license.php\.\*,https://opensource.org/licenses/mit-license.php\.
\*,g'
'''