### PR TITLE
Implement `decompress` function in JNI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,9 @@ addons:
 compiler:
   - clang
   - gcc
-cache:
-  directories:
-  - src/java/guava/
 env:
   global:
     - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  STATICPRECOMPUTATION=yes  ASM=no  BUILD=check  EXTRAFLAGS=  HOST=  ECDH=no  RECOVERY=no  EXPERIMENTAL=no  JNI=no
-    - GUAVA_URL=https://search.maven.org/remotecontent?filepath=com/google/guava/guava/18.0/guava-18.0.jar GUAVA_JAR=src/java/guava/guava-18.0.jar
   matrix:
     - SCALAR=32bit    RECOVERY=yes
     - SCALAR=32bit    FIELD=32bit       ECDH=yes  EXPERIMENTAL=yes
@@ -59,8 +55,6 @@ matrix:
           packages:
             - gcc-multilib
             - libgmp-dev:i386
-before_install: mkdir -p `dirname $GUAVA_JAR`
-install: if [ ! -f $GUAVA_JAR ]; then wget $GUAVA_URL -O $GUAVA_JAR; fi
 before_script: ./autogen.sh
 script:
  - if [ -n "$HOST" ]; then export USE_HOST="--host=$HOST"; fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -121,8 +121,6 @@ endif
 
 JAVAROOT=src/java
 JAVAORG=org/bitcoin
-JAVA_GUAVA=$(srcdir)/$(JAVAROOT)/guava/guava-18.0.jar
-CLASSPATH_ENV=CLASSPATH=$(JAVA_GUAVA)
 JAVA_FILES= \
   $(JAVAROOT)/$(JAVAORG)/NativeSecp256k1.java \
   $(JAVAROOT)/$(JAVAORG)/NativeSecp256k1Test.java \
@@ -131,20 +129,15 @@ JAVA_FILES= \
 
 if USE_JNI
 
-$(JAVA_GUAVA):
-	@echo Guava is missing. Fetch it via: \
-	wget https://search.maven.org/remotecontent?filepath=com/google/guava/guava/18.0/guava-18.0.jar -O $(@)
-	@false
-
 .stamp-java: $(JAVA_FILES)
 	@echo   Compiling $^
-	$(AM_V_at)$(CLASSPATH_ENV) javac $^
+	$(AM_V_at) javac $^
 	@touch $@
 
 if USE_TESTS
 
-check-java: libsecp256k1.la $(JAVA_GUAVA) .stamp-java
-	$(AM_V_at)java -Djava.library.path="./:./src:./src/.libs:.libs/" -cp "$(JAVA_GUAVA):$(JAVAROOT)" $(JAVAORG)/NativeSecp256k1Test
+check-java: libsecp256k1.la .stamp-java
+	$(AM_V_at)java -Djava.library.path="./:./src:./src/.libs:.libs/" -cp "$(JAVAROOT)" $(JAVAORG)/NativeSecp256k1Test
 
 endif
 endif

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -141,10 +141,10 @@ public class NativeSecp256k1 {
      * libsecp256k1 Compute Pubkey - computes public key from secret key
      *
      * @param seckey ECDSA Secret key, 32 bytes
+     * @param compressed Should the generated public key be compressed
      * @return pubkey ECDSA Public key, 33 or 65 bytes
      */
-    //TODO add a 'compressed' arg
-    public static byte[] computePubkey(byte[] seckey) throws AssertFailException{
+    public static byte[] computePubkey(byte[] seckey, boolean compressed) throws AssertFailException{
         checkArgument(seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
@@ -160,7 +160,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-          retByteArray = secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext());
+          retByteArray = secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext(), compressed);
         } finally {
           r.unlock();
         }
@@ -277,8 +277,9 @@ public class NativeSecp256k1 {
      *
      * @param pubkey ECDSA Public key, 33 or 65 bytes
      * @param tweak some bytes to tweak with
+     * @param compressed should the output public key be compressed
      */
-    public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak) throws AssertFailException{
+    public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak, boolean compressed) throws AssertFailException{
         checkArgument(pubkey.length == 33 || pubkey.length == 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
@@ -294,7 +295,7 @@ public class NativeSecp256k1 {
         byte[][] retByteArray;
         r.lock();
         try {
-          retByteArray = secp256k1_pubkey_tweak_add(byteBuff,Secp256k1Context.getContext(), pubkey.length);
+          retByteArray = secp256k1_pubkey_tweak_add(byteBuff, Secp256k1Context.getContext(), pubkey.length, compressed);
         } finally {
           r.unlock();
         }
@@ -316,8 +317,9 @@ public class NativeSecp256k1 {
      *
      * @param pubkey ECDSA Public key, 33 or 65 bytes
      * @param tweak some bytes to tweak with
+     * @param compressed should the output public key be compressed
      */
-    public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak) throws AssertFailException{
+    public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak, boolean compressed) throws AssertFailException{
         checkArgument(pubkey.length == 33 || pubkey.length == 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
@@ -333,7 +335,7 @@ public class NativeSecp256k1 {
         byte[][] retByteArray;
         r.lock();
         try {
-          retByteArray = secp256k1_pubkey_tweak_mul(byteBuff,Secp256k1Context.getContext(), pubkey.length);
+          retByteArray = secp256k1_pubkey_tweak_mul(byteBuff,Secp256k1Context.getContext(), pubkey.length, compressed);
         } finally {
           r.unlock();
         }
@@ -370,7 +372,7 @@ public class NativeSecp256k1 {
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_ec_pubkey_parse(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+            retByteArray = secp256k1_ec_pubkey_decompress(byteBuff, Secp256k1Context.getContext(), pubkey.length);
         } finally {
             r.unlock();
         }
@@ -409,7 +411,7 @@ public class NativeSecp256k1 {
         byte[][] retByteArray;
         r.lock();
         try {
-            retByteArray = secp256k1_ec_pubkey_parse(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+            retByteArray = secp256k1_ec_pubkey_decompress(byteBuff, Secp256k1Context.getContext(), pubkey.length);
         } finally {
             r.unlock();
         }
@@ -488,9 +490,9 @@ public class NativeSecp256k1 {
 
     private static native byte[][] secp256k1_privkey_tweak_mul(ByteBuffer byteBuff, long context);
 
-    private static native byte[][] secp256k1_pubkey_tweak_add(ByteBuffer byteBuff, long context, int pubLen);
+    private static native byte[][] secp256k1_pubkey_tweak_add(ByteBuffer byteBuff, long context, int pubLen, boolean compressed);
 
-    private static native byte[][] secp256k1_pubkey_tweak_mul(ByteBuffer byteBuff, long context, int pubLen);
+    private static native byte[][] secp256k1_pubkey_tweak_mul(ByteBuffer byteBuff, long context, int pubLen, boolean compressed);
 
     private static native void secp256k1_destroy_context(long context);
 
@@ -500,9 +502,9 @@ public class NativeSecp256k1 {
 
     private static native int secp256k1_ec_seckey_verify(ByteBuffer byteBuff, long context);
 
-    private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context);
+    private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context, boolean compressed);
 
-    private static native byte[][] secp256k1_ec_pubkey_parse(ByteBuffer byteBuff, long context, int inputLen);
+    private static native byte[][] secp256k1_ec_pubkey_decompress(ByteBuffer byteBuff, long context, int inputLen);
 
     private static native byte[][] secp256k1_ecdh(ByteBuffer byteBuff, long context, int inputLen);
 

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -64,8 +64,6 @@ public class NativeSecp256k1 {
         byteBuff.put(signature);
         byteBuff.put(pub);
 
-        byte[][] retByteArray;
-
         r.lock();
         try {
           return secp256k1_ecdsa_verify(byteBuff, Secp256k1Context.getContext(), signature.length, pub.length) == 1;

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import java.math.BigInteger;
-import com.google.common.base.Preconditions;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import static org.bitcoin.NativeSecp256k1Util.*;
@@ -52,7 +51,7 @@ public class NativeSecp256k1 {
      * @param pub The public key which did the signing
      */
     public static boolean verify(byte[] data, byte[] signature, byte[] pub) throws AssertFailException{
-        Preconditions.checkArgument(data.length == 32 && signature.length <= 520 && pub.length <= 520);
+        checkArgument(data.length == 32 && signature.length <= 520 && pub.length <= 520);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 520) {
@@ -83,7 +82,7 @@ public class NativeSecp256k1 {
      * @return sig byte array of signature
      */
     public static byte[] sign(byte[] data, byte[] seckey) throws AssertFailException{
-        Preconditions.checkArgument(data.length == 32 && seckey.length <= 32);
+        checkArgument(data.length == 32 && seckey.length <= 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 32 + 32) {
@@ -120,7 +119,7 @@ public class NativeSecp256k1 {
      * @return true if valid, false if invalid
      */
     public static boolean secKeyVerify(byte[] seckey) {
-        Preconditions.checkArgument(seckey.length == 32);
+        checkArgument(seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seckey.length) {
@@ -148,7 +147,7 @@ public class NativeSecp256k1 {
      */
     //TODO add a 'compressed' arg
     public static byte[] computePubkey(byte[] seckey) throws AssertFailException{
-        Preconditions.checkArgument(seckey.length == 32);
+        checkArgument(seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seckey.length) {
@@ -204,7 +203,7 @@ public class NativeSecp256k1 {
      * @param tweak some bytes to tweak with
      */
     public static byte[] privKeyTweakMul(byte[] seckey, byte[] tweak) throws AssertFailException{
-        Preconditions.checkArgument(seckey.length == 32);
+        checkArgument(seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seckey.length + tweak.length) {
@@ -243,7 +242,7 @@ public class NativeSecp256k1 {
      * @param tweak some bytes to tweak with
      */
     public static byte[] privKeyTweakAdd(byte[] seckey, byte[] tweak) throws AssertFailException{
-        Preconditions.checkArgument(seckey.length == 32);
+        checkArgument(seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seckey.length + tweak.length) {
@@ -282,7 +281,7 @@ public class NativeSecp256k1 {
      * @param tweak some bytes to tweak with
      */
     public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak) throws AssertFailException{
-        Preconditions.checkArgument(pubkey.length == 33 || pubkey.length == 65);
+        checkArgument(pubkey.length == 33 || pubkey.length == 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < pubkey.length + tweak.length) {
@@ -321,7 +320,7 @@ public class NativeSecp256k1 {
      * @param tweak some bytes to tweak with
      */
     public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak) throws AssertFailException{
-        Preconditions.checkArgument(pubkey.length == 33 || pubkey.length == 65);
+        checkArgument(pubkey.length == 33 || pubkey.length == 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < pubkey.length + tweak.length) {
@@ -359,7 +358,7 @@ public class NativeSecp256k1 {
      * @param pubkey ECDSA Public key, 33 or 65 bytes
      */
     public static byte[] decompress(byte[] pubkey) throws AssertFailException{
-        Preconditions.checkArgument(pubkey.length == 33 || pubkey.length == 65);
+        checkArgument(pubkey.length == 33 || pubkey.length == 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < pubkey.length) {
@@ -397,7 +396,7 @@ public class NativeSecp256k1 {
      * @param pubkey byte array of public key used in exponentiaion
      */
     public static byte[] createECDHSecret(byte[] seckey, byte[] pubkey) throws AssertFailException{
-        Preconditions.checkArgument(seckey.length <= 32 && pubkey.length <= 65);
+        checkArgument(seckey.length <= 32 && pubkey.length <= 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 32 + pubkey.length) {
@@ -432,7 +431,7 @@ public class NativeSecp256k1 {
      * @param seed 32-byte random seed
      */
     public static synchronized boolean randomize(byte[] seed) throws AssertFailException{
-        Preconditions.checkArgument(seed.length == 32 || seed == null);
+        checkArgument(seed.length == 32 || seed == null);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seed.length) {

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -357,11 +357,11 @@ public class NativeSecp256k1 {
     }
 
     /**
-     * libsecp256k1 Parse - Parse a variable-length pub key and serialize it in an uncompressed form
+     * libsecp256k1 Decompress - Parse and decompress a variable-length pub key
      *
      * @param pubkey ECDSA Public key, 33 or 65 bytes
      */
-    public static byte[] parse(byte[] pubkey) throws AssertFailException{
+    public static byte[] decompress(byte[] pubkey) throws AssertFailException{
         Preconditions.checkArgument(pubkey.length == 33 || pubkey.length == 65);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -79,13 +79,11 @@ public class NativeSecp256k1 {
      * libsecp256k1 Create an ECDSA signature.
      *
      * @param data Message hash, 32 bytes
-     * @param key Secret key, 32 bytes
-     *
-     * Return values
-     * @param sig byte array of signature
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @return sig byte array of signature
      */
-    public static byte[] sign(byte[] data, byte[] sec) throws AssertFailException{
-        Preconditions.checkArgument(data.length == 32 && sec.length <= 32);
+    public static byte[] sign(byte[] data, byte[] seckey) throws AssertFailException{
+        Preconditions.checkArgument(data.length == 32 && seckey.length <= 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 32 + 32) {
@@ -95,7 +93,7 @@ public class NativeSecp256k1 {
         }
         byteBuff.rewind();
         byteBuff.put(data);
-        byteBuff.put(sec);
+        byteBuff.put(seckey);
 
         byte[][] retByteArray;
 
@@ -116,9 +114,10 @@ public class NativeSecp256k1 {
     }
 
     /**
-     * libsecp256k1 Seckey Verify - returns 1 if valid, 0 if invalid
+     * libsecp256k1 Seckey Verify - Verifies an ECDSA secret key
      *
      * @param seckey ECDSA Secret key, 32 bytes
+     * @return true if valid, false if invalid
      */
     public static boolean secKeyVerify(byte[] seckey) {
         Preconditions.checkArgument(seckey.length == 32);
@@ -145,9 +144,7 @@ public class NativeSecp256k1 {
      * libsecp256k1 Compute Pubkey - computes public key from secret key
      *
      * @param seckey ECDSA Secret key, 32 bytes
-     *
-     * Return values
-     * @param pubkey ECDSA Public key, 33 or 65 bytes
+     * @return pubkey ECDSA Public key, 33 or 65 bytes
      */
     //TODO add a 'compressed' arg
     public static byte[] computePubkey(byte[] seckey) throws AssertFailException{
@@ -201,22 +198,22 @@ public class NativeSecp256k1 {
     }
 
     /**
-     * libsecp256k1 PrivKey Tweak-Mul - Tweak privkey by multiplying to it
+     * libsecp256k1 PrivKey Tweak-Mul - Tweak seckey by multiplying to it
      *
+     * @param seckey ECDSA Secret key, 32 bytes
      * @param tweak some bytes to tweak with
-     * @param seckey 32-byte seckey
      */
-    public static byte[] privKeyTweakMul(byte[] privkey, byte[] tweak) throws AssertFailException{
-        Preconditions.checkArgument(privkey.length == 32);
+    public static byte[] privKeyTweakMul(byte[] seckey, byte[] tweak) throws AssertFailException{
+        Preconditions.checkArgument(seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
-        if (byteBuff == null || byteBuff.capacity() < privkey.length + tweak.length) {
-            byteBuff = ByteBuffer.allocateDirect(privkey.length + tweak.length);
+        if (byteBuff == null || byteBuff.capacity() < seckey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(seckey.length + tweak.length);
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
         byteBuff.rewind();
-        byteBuff.put(privkey);
+        byteBuff.put(seckey);
         byteBuff.put(tweak);
 
         byte[][] retByteArray;
@@ -240,22 +237,22 @@ public class NativeSecp256k1 {
     }
 
     /**
-     * libsecp256k1 PrivKey Tweak-Add - Tweak privkey by adding to it
+     * libsecp256k1 PrivKey Tweak-Add - Tweak seckey by adding to it
      *
+     * @param seckey ECDSA Secret key, 32 bytes
      * @param tweak some bytes to tweak with
-     * @param seckey 32-byte seckey
      */
-    public static byte[] privKeyTweakAdd(byte[] privkey, byte[] tweak) throws AssertFailException{
-        Preconditions.checkArgument(privkey.length == 32);
+    public static byte[] privKeyTweakAdd(byte[] seckey, byte[] tweak) throws AssertFailException{
+        Preconditions.checkArgument(seckey.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
-        if (byteBuff == null || byteBuff.capacity() < privkey.length + tweak.length) {
-            byteBuff = ByteBuffer.allocateDirect(privkey.length + tweak.length);
+        if (byteBuff == null || byteBuff.capacity() < seckey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(seckey.length + tweak.length);
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
         byteBuff.rewind();
-        byteBuff.put(privkey);
+        byteBuff.put(seckey);
         byteBuff.put(tweak);
 
         byte[][] retByteArray;
@@ -281,8 +278,8 @@ public class NativeSecp256k1 {
     /**
      * libsecp256k1 PubKey Tweak-Add - Tweak pubkey by adding to it
      *
+     * @param pubkey ECDSA Public key, 33 or 65 bytes
      * @param tweak some bytes to tweak with
-     * @param pubkey 32-byte seckey
      */
     public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak) throws AssertFailException{
         Preconditions.checkArgument(pubkey.length == 33 || pubkey.length == 65);
@@ -320,8 +317,8 @@ public class NativeSecp256k1 {
     /**
      * libsecp256k1 PubKey Tweak-Mul - Tweak pubkey by multiplying to it
      *
+     * @param pubkey ECDSA Public key, 33 or 65 bytes
      * @param tweak some bytes to tweak with
-     * @param pubkey 32-byte seckey
      */
     public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak) throws AssertFailException{
         Preconditions.checkArgument(pubkey.length == 33 || pubkey.length == 65);

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -50,7 +50,7 @@ public class NativeSecp256k1 {
      * @param signature The signature
      * @param pub The public key which did the signing
      */
-    public static boolean verify(byte[] data, byte[] signature, byte[] pub) throws AssertFailException{
+    public static boolean verify(byte[] data, byte[] signature, byte[] pub) {
         checkArgument(data.length == 32 && signature.length <= 520 && pub.length <= 520);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
@@ -463,7 +463,7 @@ public class NativeSecp256k1 {
      * @param seed 32-byte random seed
      */
     public static synchronized boolean randomize(byte[] seed) throws AssertFailException{
-        checkArgument(seed.length == 32 || seed == null);
+        checkArgument(seed.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < seed.length) {

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -28,7 +28,7 @@ import static org.bitcoin.NativeSecp256k1Util.*;
 /**
  * <p>This class holds native methods to handle ECDSA verification.</p>
  *
- * <p>You can find an example library that can be used for this at https://github.com/bitcoin/secp256k1</p>
+ * <p>You can find an example library that can be used for this at https://github.com/bitcoin-core/secp256k1</p>
  *
  * <p>To build secp256k1 for use with bitcoinj, run
  * `./configure --enable-jni --enable-experimental --enable-module-ecdh`

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -395,30 +395,12 @@ public class NativeSecp256k1 {
      * @param pubkey ECDSA Public key, 33 or 65 bytes
      */
     public static boolean isValidPubKey(byte[] pubkey) {
-        if (!(pubkey.length == 33 || pubkey.length == 65)) {
+        try {
+            decompress(pubkey);
+            return true;
+        } catch (Throwable e) {
             return false;
         }
-
-        ByteBuffer byteBuff = nativeECDSABuffer.get();
-        if (byteBuff == null || byteBuff.capacity() < pubkey.length) {
-            byteBuff = ByteBuffer.allocateDirect(pubkey.length);
-            byteBuff.order(ByteOrder.nativeOrder());
-            nativeECDSABuffer.set(byteBuff);
-        }
-        byteBuff.rewind();
-        byteBuff.put(pubkey);
-
-        byte[][] retByteArray;
-        r.lock();
-        try {
-            retByteArray = secp256k1_ec_pubkey_decompress(byteBuff, Secp256k1Context.getContext(), pubkey.length);
-        } finally {
-            r.unlock();
-        }
-
-        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
-
-        return retVal == 1;
     }
 
     /**

--- a/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/src/java/org/bitcoin/NativeSecp256k1.java
@@ -462,7 +462,7 @@ public class NativeSecp256k1 {
      *
      * @param seed 32-byte random seed
      */
-    public static synchronized boolean randomize(byte[] seed) throws AssertFailException{
+    public static synchronized boolean randomize(byte[] seed) {
         checkArgument(seed.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();

--- a/src/java/org/bitcoin/NativeSecp256k1Test.java
+++ b/src/java/org/bitcoin/NativeSecp256k1Test.java
@@ -238,10 +238,10 @@ public class NativeSecp256k1Test {
         //Test privKeyTweakMul()
         testPrivKeyTweakMul();
 
-        //Test privKeyTweakAdd()
+        //Test testPubKeyTweakAdd()
         testPubKeyTweakAdd();
 
-        //Test privKeyTweakMul()
+        //Test testPubKeyTweakMul()
         testPubKeyTweakMul();
 
         // Test parsing public keys

--- a/src/java/org/bitcoin/NativeSecp256k1Test.java
+++ b/src/java/org/bitcoin/NativeSecp256k1Test.java
@@ -1,8 +1,5 @@
 package org.bitcoin;
 
-import com.google.common.io.BaseEncoding;
-import java.util.Arrays;
-import java.math.BigInteger;
 import javax.xml.bind.DatatypeConverter;
 import static org.bitcoin.NativeSecp256k1Util.*;
 
@@ -17,9 +14,9 @@ public class NativeSecp256k1Test {
       */
     public static void testVerifyPos() throws AssertFailException{
         boolean result = false;
-        byte[] data = BaseEncoding.base16().lowerCase().decode("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90".toLowerCase()); //sha256hash of "testing"
-        byte[] sig = BaseEncoding.base16().lowerCase().decode("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589".toLowerCase());
-        byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
+        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sig = DatatypeConverter.parseHexBinary("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
+        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
 
         result = NativeSecp256k1.verify( data, sig, pub);
         assertEquals( result, true , "testVerifyPos");
@@ -30,12 +27,11 @@ public class NativeSecp256k1Test {
       */
     public static void testVerifyNeg() throws AssertFailException{
         boolean result = false;
-        byte[] data = BaseEncoding.base16().lowerCase().decode("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A91".toLowerCase()); //sha256hash of "testing"
-        byte[] sig = BaseEncoding.base16().lowerCase().decode("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589".toLowerCase());
-        byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
+        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A91"); //sha256hash of "testing"
+        byte[] sig = DatatypeConverter.parseHexBinary("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
+        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
 
         result = NativeSecp256k1.verify( data, sig, pub);
-        //System.out.println(" TEST " + new BigInteger(1, resultbytes).toString(16));
         assertEquals( result, false , "testVerifyNeg");
     }
 
@@ -44,10 +40,9 @@ public class NativeSecp256k1Test {
       */
     public static void testSecKeyVerifyPos() throws AssertFailException{
         boolean result = false;
-        byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
+        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
         result = NativeSecp256k1.secKeyVerify( sec );
-        //System.out.println(" TEST " + new BigInteger(1, resultbytes).toString(16));
         assertEquals( result, true , "testSecKeyVerifyPos");
     }
 
@@ -56,10 +51,9 @@ public class NativeSecp256k1Test {
       */
     public static void testSecKeyVerifyNeg() throws AssertFailException{
         boolean result = false;
-        byte[] sec = BaseEncoding.base16().lowerCase().decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".toLowerCase());
+        byte[] sec = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
         result = NativeSecp256k1.secKeyVerify( sec );
-        //System.out.println(" TEST " + new BigInteger(1, resultbytes).toString(16));
         assertEquals( result, false , "testSecKeyVerifyNeg");
     }
 
@@ -67,10 +61,10 @@ public class NativeSecp256k1Test {
       * This tests public key create() for a valid secretkey
       */
     public static void testPubKeyCreatePos() throws AssertFailException{
-        byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
+        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
         byte[] resultArr = NativeSecp256k1.computePubkey( sec);
-        String pubkeyString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+        String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( pubkeyString , "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6" , "testPubKeyCreatePos");
     }
 
@@ -78,10 +72,10 @@ public class NativeSecp256k1Test {
       * This tests public key create() for a invalid secretkey
       */
     public static void testPubKeyCreateNeg() throws AssertFailException{
-       byte[] sec = BaseEncoding.base16().lowerCase().decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".toLowerCase());
+       byte[] sec = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
        byte[] resultArr = NativeSecp256k1.computePubkey( sec);
-       String pubkeyString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+       String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
        assertEquals( pubkeyString, "" , "testPubKeyCreateNeg");
     }
 
@@ -90,11 +84,11 @@ public class NativeSecp256k1Test {
       */
     public static void testSignPos() throws AssertFailException{
 
-        byte[] data = BaseEncoding.base16().lowerCase().decode("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90".toLowerCase()); //sha256hash of "testing"
-        byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
+        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
         byte[] resultArr = NativeSecp256k1.sign(data, sec);
-        String sigString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+        String sigString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( sigString, "30440220182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A202201C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9" , "testSignPos");
     }
 
@@ -102,11 +96,11 @@ public class NativeSecp256k1Test {
       * This tests sign() for a invalid secretkey
       */
     public static void testSignNeg() throws AssertFailException{
-        byte[] data = BaseEncoding.base16().lowerCase().decode("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90".toLowerCase()); //sha256hash of "testing"
-        byte[] sec = BaseEncoding.base16().lowerCase().decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".toLowerCase());
+        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sec = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
         byte[] resultArr = NativeSecp256k1.sign(data, sec);
-        String sigString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+        String sigString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( sigString, "" , "testSignNeg");
     }
 
@@ -114,11 +108,11 @@ public class NativeSecp256k1Test {
       * This tests private key tweak-add
       */
     public static void testPrivKeyTweakAdd_1() throws AssertFailException {
-        byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
-        byte[] data = BaseEncoding.base16().lowerCase().decode("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3".toLowerCase()); //sha256hash of "tweak"
+        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.privKeyTweakAdd( sec , data );
-        String sigString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+        String sigString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( sigString , "A168571E189E6F9A7E2D657A4B53AE99B909F7E712D1C23CED28093CD57C88F3" , "testPrivKeyAdd_1");
     }
 
@@ -126,11 +120,11 @@ public class NativeSecp256k1Test {
       * This tests private key tweak-mul
       */
     public static void testPrivKeyTweakMul_1() throws AssertFailException {
-        byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
-        byte[] data = BaseEncoding.base16().lowerCase().decode("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3".toLowerCase()); //sha256hash of "tweak"
+        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.privKeyTweakMul( sec , data );
-        String sigString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+        String sigString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( sigString , "97F8184235F101550F3C71C927507651BD3F1CDB4A5A33B8986ACF0DEE20FFFC" , "testPrivKeyMul_1");
     }
 
@@ -138,11 +132,11 @@ public class NativeSecp256k1Test {
       * This tests private key tweak-add uncompressed
       */
     public static void testPrivKeyTweakAdd_2() throws AssertFailException {
-        byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
-        byte[] data = BaseEncoding.base16().lowerCase().decode("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3".toLowerCase()); //sha256hash of "tweak"
+        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+        byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.pubKeyTweakAdd( pub , data );
-        String sigString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+        String sigString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( sigString , "0411C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF525A268E2A863C148555C48FB5FBA368E88718A46E205FABC3DBA2CCFFAB0796EF" , "testPrivKeyAdd_2");
     }
 
@@ -150,11 +144,11 @@ public class NativeSecp256k1Test {
       * This tests private key tweak-mul uncompressed
       */
     public static void testPrivKeyTweakMul_2() throws AssertFailException {
-        byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
-        byte[] data = BaseEncoding.base16().lowerCase().decode("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3".toLowerCase()); //sha256hash of "tweak"
+        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+        byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.pubKeyTweakMul( pub , data );
-        String sigString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+        String sigString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( sigString , "04E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791EC060D4F412A794D5370F672BC94B722640B5F76914151CFCA6E712CA48CC589" , "testPrivKeyMul_2");
     }
 
@@ -162,24 +156,23 @@ public class NativeSecp256k1Test {
       * This tests seed randomization
       */
     public static void testRandomize() throws AssertFailException {
-        byte[] seed = BaseEncoding.base16().lowerCase().decode("A441B15FE9A3CF56661190A0B93B9DEC7D04127288CC87250967CF3B52894D11".toLowerCase()); //sha256hash of "random"
+        byte[] seed = DatatypeConverter.parseHexBinary("A441B15FE9A3CF56661190A0B93B9DEC7D04127288CC87250967CF3B52894D11"); //sha256hash of "random"
         boolean result = NativeSecp256k1.randomize(seed);
         assertEquals( result, true, "testRandomize");
     }
 
     public static void testCreateECDHSecret() throws AssertFailException{
 
-        byte[] sec = BaseEncoding.base16().lowerCase().decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530".toLowerCase());
-        byte[] pub = BaseEncoding.base16().lowerCase().decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40".toLowerCase());
+        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
 
         byte[] resultArr = NativeSecp256k1.createECDHSecret(sec, pub);
-        String ecdhString = javax.xml.bind.DatatypeConverter.printHexBinary(resultArr);
+        String ecdhString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( ecdhString, "2A2A67007A926E6594AF3EB564FC74005B37A9C8AEF2033C4552051B5C87F043" , "testCreateECDHSecret");
     }
 
     public static void main(String[] args) throws AssertFailException{
-
-
+        
         System.out.println("\n libsecp256k1 enabled: " + Secp256k1Context.isEnabled() + "\n");
 
         assertEquals( Secp256k1Context.isEnabled(), true, "isEnabled" );

--- a/src/java/org/bitcoin/NativeSecp256k1Test.java
+++ b/src/java/org/bitcoin/NativeSecp256k1Test.java
@@ -60,7 +60,7 @@ public class NativeSecp256k1Test {
     public static void testPubKeyCreatePos() throws AssertFailException{
         byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
-        byte[] resultArr = NativeSecp256k1.computePubkey( sec);
+        byte[] resultArr = NativeSecp256k1.computePubkey(sec, false);
         String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
         assertEquals( pubkeyString , "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6" , "testPubKeyCreatePos");
     }
@@ -71,7 +71,7 @@ public class NativeSecp256k1Test {
     public static void testPubKeyCreateNeg() throws AssertFailException{
        byte[] sec = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
-       byte[] resultArr = NativeSecp256k1.computePubkey( sec);
+       byte[] resultArr = NativeSecp256k1.computePubkey(sec, false);
        String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
        assertEquals( pubkeyString, "" , "testPubKeyCreateNeg");
     }
@@ -104,49 +104,55 @@ public class NativeSecp256k1Test {
     /**
       * This tests private key tweak-add
       */
-    public static void testPrivKeyTweakAdd_1() throws AssertFailException {
+    public static void testPrivKeyTweakAdd() throws AssertFailException {
         byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
         byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.privKeyTweakAdd( sec , data );
-        String sigString = DatatypeConverter.printHexBinary(resultArr);
-        assertEquals( sigString , "A168571E189E6F9A7E2D657A4B53AE99B909F7E712D1C23CED28093CD57C88F3" , "testPrivKeyAdd_1");
+        String seckeyString = DatatypeConverter.printHexBinary(resultArr);
+        assertEquals( seckeyString , "A168571E189E6F9A7E2D657A4B53AE99B909F7E712D1C23CED28093CD57C88F3" , "testPrivKeyTweakAdd");
     }
 
     /**
       * This tests private key tweak-mul
       */
-    public static void testPrivKeyTweakMul_1() throws AssertFailException {
+    public static void testPrivKeyTweakMul() throws AssertFailException {
         byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
         byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.privKeyTweakMul( sec , data );
-        String sigString = DatatypeConverter.printHexBinary(resultArr);
-        assertEquals( sigString , "97F8184235F101550F3C71C927507651BD3F1CDB4A5A33B8986ACF0DEE20FFFC" , "testPrivKeyMul_1");
+        String seckeyString = DatatypeConverter.printHexBinary(resultArr);
+        assertEquals( seckeyString , "97F8184235F101550F3C71C927507651BD3F1CDB4A5A33B8986ACF0DEE20FFFC" , "testPrivKeyTweakMul");
     }
 
     /**
-      * This tests private key tweak-add uncompressed
+      * This tests public key tweak-add
       */
-    public static void testPrivKeyTweakAdd_2() throws AssertFailException {
+    public static void testPubKeyTweakAdd() throws AssertFailException {
         byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
         byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
-        byte[] resultArr = NativeSecp256k1.pubKeyTweakAdd( pub , data );
-        String sigString = DatatypeConverter.printHexBinary(resultArr);
-        assertEquals( sigString , "0411C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF525A268E2A863C148555C48FB5FBA368E88718A46E205FABC3DBA2CCFFAB0796EF" , "testPrivKeyAdd_2");
+        byte[] resultArr = NativeSecp256k1.pubKeyTweakAdd( pub , data, false);
+        String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
+        byte[] resultArrCompressed = NativeSecp256k1.pubKeyTweakAdd( pub , data, true);
+        String pubkeyStringCompressed = DatatypeConverter.printHexBinary(resultArrCompressed);
+        assertEquals(pubkeyString , "0411C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF525A268E2A863C148555C48FB5FBA368E88718A46E205FABC3DBA2CCFFAB0796EF" , "testPubKeyTweakAdd");
+        assertEquals(pubkeyStringCompressed , "0311C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF52" , "testPubKeyTweakAdd (compressed)");
     }
 
     /**
-      * This tests private key tweak-mul uncompressed
+      * This tests public key tweak-mul
       */
-    public static void testPrivKeyTweakMul_2() throws AssertFailException {
+    public static void testPubKeyTweakMul() throws AssertFailException {
         byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
         byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
-        byte[] resultArr = NativeSecp256k1.pubKeyTweakMul( pub , data );
-        String sigString = DatatypeConverter.printHexBinary(resultArr);
-        assertEquals( sigString , "04E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791EC060D4F412A794D5370F672BC94B722640B5F76914151CFCA6E712CA48CC589" , "testPrivKeyMul_2");
+        byte[] resultArr = NativeSecp256k1.pubKeyTweakMul( pub , data, false);
+        String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
+        byte[] resultArrCompressed = NativeSecp256k1.pubKeyTweakMul( pub , data, true);
+        String pubkeyStringCompressed = DatatypeConverter.printHexBinary(resultArrCompressed);
+        assertEquals(pubkeyString , "04E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791EC060D4F412A794D5370F672BC94B722640B5F76914151CFCA6E712CA48CC589" , "testPubKeyTweakMul");
+        assertEquals(pubkeyStringCompressed , "03E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791" , "testPubKeyTweakMul (compressed)");
     }
 
     /**
@@ -170,7 +176,7 @@ public class NativeSecp256k1Test {
         String resultString1 = DatatypeConverter.printHexBinary(result1);
         String resultString2 = DatatypeConverter.printHexBinary(result2);
         assertEquals(resultString1, "0415EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD9817551BE3DF159C83045D9DFAC030A1A31DC9104082DB7719C098E87C1C4A36C19", "testDecompressPubKey (compressed)");
-        assertEquals(resultString2, "0415EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD9817551BE3DF159C83045D9DFAC030A1A31DC9104082DB7719C098E87C1C4A36C19", "testDecompressPubKey (uncompressed)");
+        assertEquals(resultString2, "0415EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD9817551BE3DF159C83045D9DFAC030A1A31DC9104082DB7719C098E87C1C4A36C19", "testDecompressPubKey (no-op)");
     }
 
     /**
@@ -183,7 +189,7 @@ public class NativeSecp256k1Test {
 
         boolean result1 = NativeSecp256k1.isValidPubKey(pubkey);
         boolean result2 = NativeSecp256k1.isValidPubKey(compressedPubKey);
-        assertEquals(result1, true, "testIsValidPubKeyPos (uncompressed)");
+        assertEquals(result1, true, "testIsValidPubKeyPos");
         assertEquals(result2, true, "testIsValidPubKeyPos (compressed)");
     }
 
@@ -226,17 +232,17 @@ public class NativeSecp256k1Test {
         testSignPos();
         testSignNeg();
 
-        //Test privKeyTweakAdd() 1
-        testPrivKeyTweakAdd_1();
+        //Test privKeyTweakAdd()
+        testPrivKeyTweakAdd();
 
-        //Test privKeyTweakMul() 2
-        testPrivKeyTweakMul_1();
+        //Test privKeyTweakMul()
+        testPrivKeyTweakMul();
 
-        //Test privKeyTweakAdd() 3
-        testPrivKeyTweakAdd_2();
+        //Test privKeyTweakAdd()
+        testPubKeyTweakAdd();
 
-        //Test privKeyTweakMul() 4
-        testPrivKeyTweakMul_2();
+        //Test privKeyTweakMul()
+        testPubKeyTweakMul();
 
         // Test parsing public keys
         testDecompressPubKey();

--- a/src/java/org/bitcoin/NativeSecp256k1Util.java
+++ b/src/java/org/bitcoin/NativeSecp256k1Util.java
@@ -42,4 +42,10 @@ public class NativeSecp256k1Util{
         super( message );
       }
     }
+
+    public static void checkArgument(boolean expression) {
+        if (!expression) {
+            throw new IllegalArgumentException();
+        }
+    }
 }

--- a/src/java/org/bitcoin/Secp256k1Context.java
+++ b/src/java/org/bitcoin/Secp256k1Context.java
@@ -31,7 +31,6 @@ public class Secp256k1Context {
           System.loadLibrary("secp256k1");
           contextRef = secp256k1_init_context();
       } catch (UnsatisfiedLinkError e) {
-          System.out.println("UnsatisfiedLinkError: " + e.toString());
           isEnabled = false;
       }
       enabled = isEnabled;

--- a/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/src/java/org_bitcoin_NativeSecp256k1.c
@@ -124,7 +124,7 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1secke
 }
 
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1create
-  (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l)
+  (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l, jboolean compressed)
 {
   secp256k1_context *ctx = (secp256k1_context*)(uintptr_t)ctx_l;
   const unsigned char* secKey = (unsigned char*) (*env)->GetDirectBufferAddress(env, byteBufferObject);
@@ -141,7 +141,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
   size_t outputLen = 65;
 
   if( ret ) {
-    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
+    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey, compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);(void)ret2;
   }
 
   intsarray[0] = outputLen;
@@ -236,10 +236,9 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
 }
 
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1pubkey_1tweak_1add
-  (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l, jint publen)
+  (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l, jint publen, jboolean compressed)
 {
   secp256k1_context *ctx = (secp256k1_context*)(uintptr_t)ctx_l;
-/*  secp256k1_pubkey* pubkey = (secp256k1_pubkey*) (*env)->GetDirectBufferAddress(env, byteBufferObject);*/
   unsigned char* pkey = (*env)->GetDirectBufferAddress(env, byteBufferObject);
   const unsigned char* tweak = (unsigned char*) (pkey + publen);
 
@@ -257,7 +256,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
   }
 
   if( ret ) {
-    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
+    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey, compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);(void)ret2;
   }
 
   intsarray[0] = outputLen;
@@ -281,7 +280,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
 }
 
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1pubkey_1tweak_1mul
-  (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l, jint publen)
+  (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l, jint publen, jboolean compressed)
 {
   secp256k1_context *ctx = (secp256k1_context*)(uintptr_t)ctx_l;
   unsigned char* pkey = (*env)->GetDirectBufferAddress(env, byteBufferObject);
@@ -301,7 +300,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
   }
 
   if( ret ) {
-    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
+    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey, compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);(void)ret2;
   }
 
   intsarray[0] = outputLen;
@@ -332,7 +331,7 @@ SECP256K1_API jlong JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdsa_1p
   return 0;
 }
 
-SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1parse
+SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1decompress
   (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l, jint publen)
 {
   secp256k1_context *ctx = (secp256k1_context*)(uintptr_t)ctx_l;
@@ -350,7 +349,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
   size_t outputLen = 65;
 
   if( ret ) {
-    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
+    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey, SECP256K1_EC_UNCOMPRESSED);(void)ret2;
   }
 
   intsarray[0] = outputLen;

--- a/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/src/java/org_bitcoin_NativeSecp256k1.c
@@ -332,6 +332,47 @@ SECP256K1_API jlong JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdsa_1p
   return 0;
 }
 
+SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1parse
+  (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l, jint publen)
+{
+  secp256k1_context *ctx = (secp256k1_context*)(uintptr_t)ctx_l;
+  const unsigned char* pubdata = (*env)->GetDirectBufferAddress(env, byteBufferObject);
+
+  secp256k1_pubkey pubkey;
+
+  jobjectArray retArray;
+  jbyteArray pubkeyArray, intsByteArray;
+  unsigned char intsarray[2];
+
+  int ret = secp256k1_ec_pubkey_parse(ctx, &pubkey, pubdata, publen);
+
+  unsigned char outputSer[65];
+  size_t outputLen = 65;
+
+  if( ret ) {
+    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
+  }
+
+  intsarray[0] = outputLen;
+  intsarray[1] = ret;
+
+  retArray = (*env)->NewObjectArray(env, 2,
+    (*env)->FindClass(env, "[B"),
+    (*env)->NewByteArray(env, 1));
+
+  pubkeyArray = (*env)->NewByteArray(env, outputLen);
+  (*env)->SetByteArrayRegion(env, pubkeyArray, 0, outputLen, (jbyte*)outputSer);
+  (*env)->SetObjectArrayElement(env, retArray, 0, pubkeyArray);
+
+  intsByteArray = (*env)->NewByteArray(env, 2);
+  (*env)->SetByteArrayRegion(env, intsByteArray, 0, 2, (jbyte*)intsarray);
+  (*env)->SetObjectArrayElement(env, retArray, 1, intsByteArray);
+
+  (void)classObject;
+
+  return retArray;
+}
+
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdh
   (JNIEnv* env, jclass classObject, jobject byteBufferObject, jlong ctx_l, jint publen)
 {

--- a/src/java/org_bitcoin_NativeSecp256k1.h
+++ b/src/java/org_bitcoin_NativeSecp256k1.h
@@ -46,7 +46,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
  * Signature: (Ljava/nio/ByteBuffer;JI)[[B
  */
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1pubkey_1tweak_1add
-  (JNIEnv *, jclass, jobject, jlong, jint);
+  (JNIEnv *, jclass, jobject, jlong, jint, jboolean);
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
@@ -54,7 +54,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
  * Signature: (Ljava/nio/ByteBuffer;JI)[[B
  */
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1pubkey_1tweak_1mul
-  (JNIEnv *, jclass, jobject, jlong, jint);
+  (JNIEnv *, jclass, jobject, jlong, jint, jboolean);
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
@@ -94,14 +94,14 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1secke
  * Signature: (Ljava/nio/ByteBuffer;J)[[B
  */
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1create
-  (JNIEnv *, jclass, jobject, jlong);
+  (JNIEnv *, jclass, jobject, jlong, jboolean);
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
  * Method:    secp256k1_ec_pubkey_parse
  * Signature: (Ljava/nio/ByteBuffer;JI)[[B
  */
-SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1parse
+SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1decompress
   (JNIEnv *, jclass, jobject, jlong, jint);
 
 /*


### PR DESCRIPTION
This function was already exported but not implemented.

Being able to efficiently decompress a public key is useful for implementing LN on JVM-based languages, mainly because [network announcements](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md) use the 33-bytes representation.