### PR TITLE
improvements to random seed in src/tests.c

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -4919,8 +4919,8 @@ int main(int argc, char **argv) {
     } else {
         FILE *frand = fopen("/dev/urandom", "r");
         if ((frand == NULL) || fread(&seed16, 1, sizeof(seed16), frand) != sizeof(seed16)) {
-            fprintf(stderr, "WARNING: could not read 16 bytes from /dev/urandom; falling back to insecure PRNG\n");
             uint64_t t = time(NULL) * (uint64_t)1337;
+            fprintf(stderr, "WARNING: could not read 16 bytes from /dev/urandom; falling back to insecure PRNG\n");
             seed16[0] ^= t;
             seed16[1] ^= t >> 8;
             seed16[2] ^= t >> 16;

--- a/src/tests.c
+++ b/src/tests.c
@@ -4919,6 +4919,7 @@ int main(int argc, char **argv) {
     } else {
         FILE *frand = fopen("/dev/urandom", "r");
         if ((frand == NULL) || fread(&seed16, sizeof(seed16), 1, frand) != sizeof(seed16)) {
+            fprintf(stderr, "WARNING: could not read 16 bytes from /dev/urandom; falling back to insecure PRNG\n");
             uint64_t t = time(NULL) * (uint64_t)1337;
             seed16[0] ^= t;
             seed16[1] ^= t >> 8;

--- a/src/tests.c
+++ b/src/tests.c
@@ -4918,7 +4918,7 @@ int main(int argc, char **argv) {
         }
     } else {
         FILE *frand = fopen("/dev/urandom", "r");
-        if ((frand == NULL) || fread(&seed16, sizeof(seed16), 1, frand) != sizeof(seed16)) {
+        if ((frand == NULL) || fread(&seed16, 1, sizeof(seed16), frand) != sizeof(seed16)) {
             fprintf(stderr, "WARNING: could not read 16 bytes from /dev/urandom; falling back to insecure PRNG\n");
             uint64_t t = time(NULL) * (uint64_t)1337;
             seed16[0] ^= t;


### PR DESCRIPTION
I've made two small changes to `src/tests.c` circa random seed generation.

Added a warning when `/dev/urandom` fails, mostly to defend against the case that someone should use the code verbatim, but also to enhance its illustrative power.

Also I fixed a bug with how the return value of `fread()` was being evaluated. In fact, `/dev/urandom` was never being applied before as the check on the return value of `fread()` always failed!