### PR TITLE
Correct order of libs returned on pkg-config --libs --static libsecp2…

### DIFF
--- a/libsecp256k1.pc.in
+++ b/libsecp256k1.pc.in
@@ -8,6 +8,6 @@ Description: Optimized C library for EC operations on curve secp256k1
 URL: https://github.com/bitcoin-core/secp256k1
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}
-Libs.private: @SECP_LIBS@
 Libs: -L${libdir} -lsecp256k1
+Libs.private: @SECP_LIBS@
 


### PR DESCRIPTION
…56k1 call.