### PR TITLE
Random isomorphism blinding for ecmult_gen

### DIFF
--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -26,6 +26,9 @@ typedef struct {
     secp256k1_ge_storage (*prec)[64][16]; /* prec[j][i] = 16^j * i * G + U_i */
     secp256k1_scalar blind;
     secp256k1_gej initial;
+#ifndef USE_ECMULT_STATIC_PRECOMPUTATION
+    secp256k1_fe iso;
+#endif
 } secp256k1_ecmult_gen_context;
 
 static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context* ctx);

--- a/src/group.h
+++ b/src/group.h
@@ -144,4 +144,10 @@ static void secp256k1_ge_storage_cmov(secp256k1_ge_storage *r, const secp256k1_g
 /** Rescale a jacobian point by b which must be non-zero. Constant-time. */
 static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *b);
 
+/** Map an affine point to an isomorphism. iso2, iso3 must be non-zero. Constant-time. */
+static void secp256k1_ge_to_iso(secp256k1_ge *r, const secp256k1_fe *iso2, const secp256k1_fe *iso3);
+
+/** Map a jacobian point to an isomorphism. iso2, iso3 must be non-zero. Constant-time. */
+static void secp256k1_gej_to_iso(secp256k1_gej *r, const secp256k1_fe *iso2, const secp256k1_fe *iso3);
+
 #endif /* SECP256K1_GROUP_H */

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -703,4 +703,14 @@ static int secp256k1_gej_has_quad_y_var(const secp256k1_gej *a) {
     return secp256k1_fe_is_quad_var(&yz);
 }
 
+static void secp256k1_ge_to_iso(secp256k1_ge *r, const secp256k1_fe *iso2, const secp256k1_fe *iso3) {
+    secp256k1_fe_mul(&r->x, &r->x, iso2);
+    secp256k1_fe_mul(&r->y, &r->y, iso3);
+}
+
+static void secp256k1_gej_to_iso(secp256k1_gej *r, const secp256k1_fe *iso2, const secp256k1_fe *iso3) {
+    secp256k1_fe_mul(&r->x, &r->x, iso2);
+    secp256k1_fe_mul(&r->y, &r->y, iso3);
+}
+
 #endif /* SECP256K1_GROUP_IMPL_H */

--- a/src/tests.c
+++ b/src/tests.c
@@ -3204,6 +3204,10 @@ void test_ecmult_gen_blind(void) {
 }
 
 void test_ecmult_gen_blind_reset(void) {
+    /* Calling ecmult_gen_blind without a seed value no longer resets the blinding */
+#if 1
+    secp256k1_ecmult_gen_blind(&ctx->ecmult_gen_ctx, 0);
+#else
     /* Test ecmult_gen() blinding reset and confirm that the blinding is consistent. */
     secp256k1_scalar b;
     secp256k1_gej initial;
@@ -3213,6 +3217,7 @@ void test_ecmult_gen_blind_reset(void) {
     secp256k1_ecmult_gen_blind(&ctx->ecmult_gen_ctx, 0);
     CHECK(secp256k1_scalar_eq(&b, &ctx->ecmult_gen_ctx.blind));
     CHECK(gej_xyz_equals_gej(&initial, &ctx->ecmult_gen_ctx.initial));
+#endif
 }
 
 void run_ecmult_gen_blind(void) {


### PR DESCRIPTION
- Precomputed basepoint multiples are mapped to random iso
- Per-scalar-mult extra cost of 1 field mult.
- Per-blinding extra cost of 2000 field mults.

The idea is to choose a random non-zero field element 'iso' (u) and scale all the precomputed points so that (x, y) => (x.u^2, y.u^3). The (Jacobian) result point of each scalar multiplication is then mapped back via (x, y, z) => (x, y, z^u). Correctness depends on the group operations not involving the curve's 'B' parameter, which would have to be B.u^6 if it was being used.

Currently the static precomp. gets a randomised table but not the iso, so doesn't work.

Note that this PR modifies _ecmult_gen_blind so that (repeated) calls with a NULL seed no longer reset the blinding each time. There was a test that exercised that reset, which I disabled, but it makes me wonder if there was some purpose to this.