### PR TITLE
Fix autoconf check for __builtin_expect

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,7 @@ AC_ARG_WITH([asm], [AS_HELP_STRING([--with-asm=x86_64|arm|no|auto]
 AC_CHECK_TYPES([__int128])
 
 AC_MSG_CHECKING([for __builtin_expect])
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([[void myfunc() {__builtin_expect(0,0);}]])],
+AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void) {__builtin_expect(0,0); return 0;}]])],
     [ AC_MSG_RESULT([yes]);AC_DEFINE(HAVE_BUILTIN_EXPECT,1,[Define this symbol if __builtin_expect is available]) ],
     [ AC_MSG_RESULT([no])
     ])


### PR DESCRIPTION
Calling the compiler is not enough to check whether a function exists
because the compiler will assume an implicit declaration if the
function does not exist. We need the linker to check if the function
really exists.