### PR TITLE
Add trivial ecmult_multi algorithm which does not require a scratch space

### DIFF
--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -139,7 +139,11 @@ int main(int argc, char **argv) {
     secp256k1_gej* pubkeys_gej;
     size_t scratch_size;
 
+    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    scratch_size = secp256k1_strauss_scratch_size(POINTS) + STRAUSS_SCRATCH_OBJECTS*16;
+    data.scratch = secp256k1_scratch_space_create(data.ctx, scratch_size);
     data.ecmult_multi = secp256k1_ecmult_multi_var;
+
     if (argc > 1) {
         if(have_flag(argc, argv, "pippenger_wnaf")) {
             printf("Using pippenger_wnaf:\n");
@@ -147,17 +151,19 @@ int main(int argc, char **argv) {
         } else if(have_flag(argc, argv, "strauss_wnaf")) {
             printf("Using strauss_wnaf:\n");
             data.ecmult_multi = secp256k1_ecmult_strauss_batch_single;
+        } else if(have_flag(argc, argv, "simple")) {
+            printf("Using simple algorithm:\n");
+            data.ecmult_multi = secp256k1_ecmult_multi_var;
+            secp256k1_scratch_space_destroy(data.scratch);
+            data.scratch = NULL;
         } else {
             fprintf(stderr, "%s: unrecognized argument '%s'.\n", argv[0], argv[1]);
-            fprintf(stderr, "Use 'pippenger_wnaf', 'strauss_wnaf' or no argument to benchmark a combined algorithm.\n");
+            fprintf(stderr, "Use 'pippenger_wnaf', 'strauss_wnaf', 'simple' or no argument to benchmark a combined algorithm.\n");
             return 1;
         }
     }
 
     /* Allocate stuff */
-    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
-    scratch_size = secp256k1_strauss_scratch_size(POINTS) + STRAUSS_SCRATCH_OBJECTS*16;
-    data.scratch = secp256k1_scratch_space_create(data.ctx, scratch_size);
     data.scalars = malloc(sizeof(secp256k1_scalar) * POINTS);
     data.seckeys = malloc(sizeof(secp256k1_scalar) * POINTS);
     data.pubkeys = malloc(sizeof(secp256k1_ge) * POINTS);
@@ -188,7 +194,9 @@ int main(int argc, char **argv) {
         }
     }
     secp256k1_context_destroy(data.ctx);
-    secp256k1_scratch_space_destroy(data.scratch);
+    if (data.scratch != NULL) {
+        secp256k1_scratch_space_destroy(data.scratch);
+    }
     free(data.scalars);
     free(data.pubkeys);
     free(data.seckeys);

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -37,7 +37,8 @@ typedef int (secp256k1_ecmult_multi_callback)(secp256k1_scalar *sc, secp256k1_ge
  * Chooses the right algorithm for a given number of points and scratch space
  * size. Resets and overwrites the given scratch space. If the points do not
  * fit in the scratch space the algorithm is repeatedly run with batches of
- * points.
+ * points. If no scratch space is given then a simple algorithm is used that
+ * simply multiplies the points with the corresponding scalars and adds them up.
  * Returns: 1 on success (including when inp_g_sc is NULL and n is 0)
  *          0 if there is not enough scratch space for a single point or
  *          callback returns 0

--- a/src/tests.c
+++ b/src/tests.c
@@ -2926,6 +2926,7 @@ void run_ecmult_multi_tests(void) {
     test_ecmult_multi_pippenger_max_points();
     scratch = secp256k1_scratch_create(&ctx->error_callback, 819200);
     test_ecmult_multi(scratch, secp256k1_ecmult_multi_var);
+    test_ecmult_multi(NULL, secp256k1_ecmult_multi_var);
     test_ecmult_multi(scratch, secp256k1_ecmult_pippenger_batch_single);
     test_ecmult_multi(scratch, secp256k1_ecmult_strauss_batch_single);
     secp256k1_scratch_destroy(scratch);


### PR DESCRIPTION
This commit adds a new ecmult_multi algorithm that is automatically selected when `ecmult_multi_var` is called with scratch space set to `NULL`. This is a trivial algorithm that simply multiplies the points with the corresponding scalars and adds them up.

The use case is to allow creating exposed function that uses `ecmult_multi` but without requiring a scratch space argument. For example, in MuSig when computing the combined public key we need to compute a weighted sum of points but we most likely don't care about the performance. And if we do we can still provide a scratch space. Having the option of not providing a scratch space is useful because creating a scratch space is not entirely trivial. One needs to decide on a size and it needs to be destroyed.