### PR TITLE
Make bench_internal obey secp256k1_fe_sqrt's contract wrt aliasing.

### DIFF
--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -184,9 +184,11 @@ void bench_field_inverse_var(void* arg) {
 void bench_field_sqrt(void* arg) {
     int i;
     bench_inv *data = (bench_inv*)arg;
+    secp256k1_fe t;
 
     for (i = 0; i < 20000; i++) {
-        secp256k1_fe_sqrt(&data->fe_x, &data->fe_x);
+        t = data->fe_x;
+        secp256k1_fe_sqrt(&data->fe_x, &t);
         secp256k1_fe_add(&data->fe_x, &data->fe_y);
     }
 }


### PR DESCRIPTION
Bench_internal was previously incorrect but wasn't detected by -DVERIFY until PR #551.