### PR TITLE
Remove all Clang Static Analyzer warnings (except one)

### DIFF
--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -475,6 +475,7 @@ static void secp256k1_fe_to_storage(secp256k1_fe_storage *r, const secp256k1_fe 
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
 #endif
+    VERIFY_CHECK(r->n);
     r->n[0] = a->n[0] | a->n[1] << 52;
     r->n[1] = a->n[1] >> 12 | a->n[2] << 40;
     r->n[2] = a->n[2] >> 24 | a->n[3] << 28;

--- a/src/util.h
+++ b/src/util.h
@@ -38,8 +38,10 @@ static SECP256K1_INLINE void secp256k1_callback_call(const secp256k1_callback * 
 
 #if SECP256K1_GNUC_PREREQ(3, 0)
 #define EXPECT(x,c) __builtin_expect((x),(c))
+#define ASSUME(x) do { if (!(x)) __builtin_unreachable(); } while(0)
 #else
 #define EXPECT(x,c) (x)
+#define ASSUME(x) (void)(x)
 #endif
 
 #ifdef DETERMINISTIC
@@ -63,6 +65,9 @@ static SECP256K1_INLINE void secp256k1_callback_call(const secp256k1_callback * 
 #elif defined(VERIFY)
 #define VERIFY_CHECK CHECK
 #define VERIFY_SETUP(stmt) do { stmt; } while(0)
+#elif defined(ASSUME) || defined(__clang_analyzer__)
+#define VERIFY_CHECK(cond) do { ASSUME(cond); } while(0)
+#define VERIFY_SETUP(stmt)
 #else
 #define VERIFY_CHECK(cond) do { (void)(cond); } while(0)
 #define VERIFY_SETUP(stmt)


### PR DESCRIPTION
Clang Static Analyzer shows 15 warnings. To see only the relevant ones, I've configured it with

```
./configure --disable-tests  --disable-benchmark --disable-exhaustive-tests --with-asm=no
```

which removed the warnings related to inline assembly. Here are the 10 warnings (Some of them are duplicates):

<table class="sortable" style="table-layout:automatic">
<thead><tr>
  <td>Bug Group</td>
  <td class="sorttable_sorted">Bug Type<span id="sorttable_sortfwdind">&nbsp;▾</span></td>
  <td>File</td>
  <td>Function/Method</td>
  <td class="Q">Line</td>
  <td class="Q">Path Length</td>
  <td class="sorttable_nosort"></td>
  <!-- REPORTBUGCOL -->
</tr></thead>
<tbody>
<tr class="bt_dead_store_dead_assignment"><td class="DESC">Dead store</td><td class="DESC">Dead assignment</td><td>ecmult_gen_impl.h</td><td class="DESC">secp256k1_ecmult_gen</td><td class="Q">153</td><td class="Q">1</td><td><a href="report-8697bd.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-8697bd.html" -->
</tr>
<tr class="bt_dead_store_dead_assignment"><td class="DESC">Dead store</td><td class="DESC">Dead assignment</td><td>ecmult_gen_impl.h</td><td class="DESC">secp256k1_ecmult_gen</td><td class="Q">153</td><td class="Q">1</td><td><a href="report-c12838.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-c12838.html" -->
</tr>
<tr class="bt_logic_error_dereference_of_null_pointer"><td class="DESC">Logic error</td><td class="DESC">Dereference of null pointer</td><td>field_5x52_impl.h</td><td class="DESC">secp256k1_fe_to_storage</td><td class="Q">478</td><td class="Q">15</td><td><a href="report-861420.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-861420.html" -->
</tr>
<tr class="bt_logic_error_dereference_of_null_pointer"><td class="DESC">Logic error</td><td class="DESC">Dereference of null pointer</td><td>ecmult_gen_impl.h</td><td class="DESC">secp256k1_ecmult_gen_context_is_built</td><td class="Q">95</td><td class="Q">5</td><td><a href="report-48a40b.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-48a40b.html" -->
</tr>
<tr class="bt_logic_error_dereference_of_null_pointer"><td class="DESC">Logic error</td><td class="DESC">Dereference of null pointer</td><td>ecmult_impl.h</td><td class="DESC">secp256k1_ecmult_context_is_built</td><td class="Q">357</td><td class="Q">5</td><td><a href="report-5b0264.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-5b0264.html" -->
</tr>
<tr class="bt_logic_error_dereference_of_null_pointer"><td class="DESC">Logic error</td><td class="DESC">Dereference of null pointer</td><td>ecmult_gen_impl.h</td><td class="DESC">secp256k1_ecmult_gen_context_is_built</td><td class="Q">95</td><td class="Q">5</td><td><a href="report-a8c644.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-a8c644.html" -->
</tr>
<tr class="bt_logic_error_dereference_of_null_pointer"><td class="DESC">Logic error</td><td class="DESC">Dereference of null pointer</td><td>util.h</td><td class="DESC">secp256k1_callback_call</td><td class="Q">24</td><td class="Q">7</td><td><a href="report-1779f3.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-1779f3.html" -->
</tr>
<tr class="bt_logic_error_dereference_of_null_pointer"><td class="DESC">Logic error</td><td class="DESC">Dereference of null pointer</td><td>field_5x52_impl.h</td><td class="DESC">secp256k1_fe_to_storage</td><td class="Q">478</td><td class="Q">15</td><td><a href="report-bef9e7.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-bef9e7.html" -->
</tr>
<tr class="bt_logic_error_dereference_of_null_pointer"><td class="DESC">Logic error</td><td class="DESC">Dereference of null pointer</td><td>util.h</td><td class="DESC">secp256k1_callback_call</td><td class="Q">24</td><td class="Q">7</td><td><a href="report-f5f3af.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-f5f3af.html" -->
</tr>
<tr class="bt_logic_error_dereference_of_null_pointer"><td class="DESC">Logic error</td><td class="DESC">Dereference of null pointer</td><td>ecmult_impl.h</td><td class="DESC">secp256k1_ecmult_context_is_built</td><td class="Q">357</td><td class="Q">5</td><td><a href="report-a60846.html#EndPath">View Report</a></td>
<!-- REPORTBUG id="report-a60846.html" -->
</tr>
</tbody>
<tfoot></tfoot></table>

This pull request silences all of those warnings (except the first two duplicate `dead-store` warnings, which are solved by #485) by sharing our assumptions with the compiler.

Comments welcome. Would you prefer to remove the `do{...}while` block?