### PR TITLE
Install headers automatically

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,8 @@ else
 JNI_LIB =
 endif
 include_HEADERS = include/secp256k1.h
+include_HEADERS += include/secp256k1_ecdh.h
+include_HEADERS += include/secp256k1_recovery.h
 noinst_HEADERS =
 noinst_HEADERS += src/scalar.h
 noinst_HEADERS += src/scalar_4x64.h


### PR DESCRIPTION
This fix install all the headers under include/ into
/usr/local/include. The fix solves problems that arise
when building libraries that depend on secp256k1 such
as libbitcoin-system which require all the headers