### PR TITLE
Avoid generate duplicated files for install command.

### DIFF
--- a/src/modules/ecdh/Makefile.am.include
+++ b/src/modules/ecdh/Makefile.am.include
@@ -1,4 +1,3 @@
-include_HEADERS += include/secp256k1_ecdh.h
 noinst_HEADERS += src/modules/ecdh/main_impl.h
 noinst_HEADERS += src/modules/ecdh/tests_impl.h
 if USE_BENCHMARK

--- a/src/modules/recovery/Makefile.am.include
+++ b/src/modules/recovery/Makefile.am.include
@@ -1,4 +1,3 @@
-include_HEADERS += include/secp256k1_recovery.h
 noinst_HEADERS += src/modules/recovery/main_impl.h
 noinst_HEADERS += src/modules/recovery/tests_impl.h
 if USE_BENCHMARK


### PR DESCRIPTION
The module headers are already added in the top `Makefile.am`, which is
introduced in 91fae3ace0291b144b27fd8bbda509042f5400f1, but the module
`Makefile.am.include` will add the headers again.

Steps to reproduce the issue:

    ./autogen.sh
    ./configure --enable-module-recovery --prefix /tmp/secp256k1
    make
    make install

Failure message:

    /usr/bin/install -c -m 644 include/secp256k1.h include/secp256k1_ecdh.h include/secp256k1_recovery.h include/secp256k1_recovery.h '/usr/local/include'
    /usr/bin/install: will not overwrite just-created '/usr/local/include/secp256k1_recovery.h' with 'include/secp256k1_recovery.h'
    Makefile:1151: recipe for target 'install-includeHEADERS' failed
    make[1]: *** [install-includeHEADERS] Error 1
    make[1]: Leaving directory '/home/travis/secp256k1'
    Makefile:1578: recipe for target 'install-am' failed
    make: *** [install-am] Error 2

Closes https://github.com/bitcoin-core/secp256k1/issues/624