### PR TITLE
Revert "Merge #620: Install headers automatically"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,8 +8,6 @@ else
 JNI_LIB =
 endif
 include_HEADERS = include/secp256k1.h
-include_HEADERS += include/secp256k1_ecdh.h
-include_HEADERS += include/secp256k1_recovery.h
 noinst_HEADERS =
 noinst_HEADERS += src/scalar.h
 noinst_HEADERS += src/scalar_4x64.h


### PR DESCRIPTION
This reverts commit 91fae3ace0291b144b27fd8bbda509042f5400f1, reversing
changes made to 5df77a0eda6e902a1aa9c6249cdeaec197b1e0cd.

See discussion in https://github.com/bitcoin-core/secp256k1/pull/625

After the change, if we enable any module, `make install` fails because of the
duplicated files in the command line arguments.

Closes https://github.com/bitcoin-core/secp256k1/issues/624