### PR TITLE
Remove OpenSSL tests

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -15,46 +15,6 @@ AC_MSG_RESULT([$has_64bit_asm])
 ])
 
 dnl
-AC_DEFUN([SECP_OPENSSL_CHECK],[
-  has_libcrypto=no
-  m4_ifdef([PKG_CHECK_MODULES],[
-    PKG_CHECK_MODULES([CRYPTO], [libcrypto], [has_libcrypto=yes],[has_libcrypto=no])
-    if test x"$has_libcrypto" = x"yes"; then
-      TEMP_LIBS="$LIBS"
-      LIBS="$LIBS $CRYPTO_LIBS"
-      AC_CHECK_LIB(crypto, main,[AC_DEFINE(HAVE_LIBCRYPTO,1,[Define this symbol if libcrypto is installed])],[has_libcrypto=no])
-      LIBS="$TEMP_LIBS"
-    fi
-  ])
-  if test x$has_libcrypto = xno; then
-    AC_CHECK_HEADER(openssl/crypto.h,[
-      AC_CHECK_LIB(crypto, main,[
-        has_libcrypto=yes
-        CRYPTO_LIBS=-lcrypto
-        AC_DEFINE(HAVE_LIBCRYPTO,1,[Define this symbol if libcrypto is installed])
-      ])
-    ])
-    LIBS=
-  fi
-if test x"$has_libcrypto" = x"yes" && test x"$has_openssl_ec" = x; then
-  AC_MSG_CHECKING(for EC functions in libcrypto)
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    #include <openssl/ec.h>
-    #include <openssl/ecdsa.h>
-    #include <openssl/obj_mac.h>]],[[
-    EC_KEY *eckey = EC_KEY_new_by_curve_name(NID_secp256k1);
-    ECDSA_sign(0, NULL, 0, NULL, NULL, eckey);
-    ECDSA_verify(0, NULL, 0, NULL, 0, eckey);
-    EC_KEY_free(eckey);
-    ECDSA_SIG *sig_openssl;
-    sig_openssl = ECDSA_SIG_new();
-    ECDSA_SIG_free(sig_openssl);
-  ]])],[has_openssl_ec=yes],[has_openssl_ec=no])
-  AC_MSG_RESULT([$has_openssl_ec])
-fi
-])
-
-dnl
 AC_DEFUN([SECP_GMP_CHECK],[
 if test x"$has_gmp" != x"yes"; then
   CPPFLAGS_TEMP="$CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -40,12 +40,7 @@ case $host_os in
          dnl in expected paths because they may conflict with system files. Ask
          dnl Homebrew where each one is located, then adjust paths accordingly.
 
-         openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
          gmp_prefix=`$BREW --prefix gmp 2>/dev/null`
-         if test x$openssl_prefix != x; then
-           PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
-           export PKG_CONFIG_PATH
-         fi
          if test x$gmp_prefix != x; then
            GMP_CPPFLAGS="-I$gmp_prefix/include"
            GMP_LIBS="-L$gmp_prefix/lib"
@@ -98,11 +93,6 @@ AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--enable-tests],[compile tests [default=yes]]),
     [use_tests=$enableval],
     [use_tests=yes])
-
-AC_ARG_ENABLE(openssl_tests,
-    AS_HELP_STRING([--enable-openssl-tests],[enable OpenSSL tests [default=auto]]),
-    [enable_openssl_tests=$enableval],
-    [enable_openssl_tests=auto])
 
 AC_ARG_ENABLE(experimental,
     AS_HELP_STRING([--enable-experimental],[allow experimental configure options [default=no]]),
@@ -422,31 +412,6 @@ case $set_ecmult_window in
   AC_DEFINE_UNQUOTED(ECMULT_WINDOW_SIZE, $set_ecmult_window, [Set window size for ecmult precomputation])
   ;;
 esac
-
-if test x"$use_tests" = x"yes"; then
-  SECP_OPENSSL_CHECK
-  if test x"$has_openssl_ec" = x"yes"; then
-    if test x"$enable_openssl_tests" != x"no"; then
-      AC_DEFINE(ENABLE_OPENSSL_TESTS, 1, [Define this symbol if OpenSSL EC functions are available])
-      SECP_TEST_INCLUDES="$SSL_CFLAGS $CRYPTO_CFLAGS"
-      SECP_TEST_LIBS="$CRYPTO_LIBS"
-
-      case $host in
-      *mingw*)
-        SECP_TEST_LIBS="$SECP_TEST_LIBS -lgdi32"
-        ;;
-      esac
-    fi
-  else
-    if test x"$enable_openssl_tests" = x"yes"; then
-      AC_MSG_ERROR([OpenSSL tests requested but OpenSSL with EC support is not available])
-    fi
-  fi
-else
-  if test x"$enable_openssl_tests" = x"yes"; then
-    AC_MSG_ERROR([OpenSSL tests requested but tests are not enabled])
-  fi
-fi
 
 if test x"$use_jni" != x"no"; then
   AX_JNI_INCLUDE_DIR

--- a/src/bench_verify.c
+++ b/src/bench_verify.c
@@ -11,12 +11,6 @@
 #include "util.h"
 #include "bench.h"
 
-#ifdef ENABLE_OPENSSL_TESTS
-#include <openssl/bn.h>
-#include <openssl/ecdsa.h>
-#include <openssl/obj_mac.h>
-#endif
-
 typedef struct {
     secp256k1_context *ctx;
     unsigned char msg[32];
@@ -25,9 +19,6 @@ typedef struct {
     size_t siglen;
     unsigned char pubkey[33];
     size_t pubkeylen;
-#ifdef ENABLE_OPENSSL_TESTS
-    EC_GROUP* ec_group;
-#endif
 } benchmark_verify_t;
 
 static void benchmark_verify(void* arg) {
@@ -48,36 +39,6 @@ static void benchmark_verify(void* arg) {
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
     }
 }
-
-#ifdef ENABLE_OPENSSL_TESTS
-static void benchmark_verify_openssl(void* arg) {
-    int i;
-    benchmark_verify_t* data = (benchmark_verify_t*)arg;
-
-    for (i = 0; i < 20000; i++) {
-        data->sig[data->siglen - 1] ^= (i & 0xFF);
-        data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
-        data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
-        {
-            EC_KEY *pkey = EC_KEY_new();
-            const unsigned char *pubkey = &data->pubkey[0];
-            int result;
-
-            CHECK(pkey != NULL);
-            result = EC_KEY_set_group(pkey, data->ec_group);
-            CHECK(result);
-            result = (o2i_ECPublicKey(&pkey, &pubkey, data->pubkeylen)) != NULL;
-            CHECK(result);
-            result = ECDSA_verify(0, &data->msg[0], sizeof(data->msg), &data->sig[0], data->siglen, pkey) == (i == 0);
-            CHECK(result);
-            EC_KEY_free(pkey);
-        }
-        data->sig[data->siglen - 1] ^= (i & 0xFF);
-        data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
-        data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
-    }
-}
-#endif
 
 int main(void) {
     int i;
@@ -101,11 +62,6 @@ int main(void) {
     CHECK(secp256k1_ec_pubkey_serialize(data.ctx, data.pubkey, &data.pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
 
     run_benchmark("ecdsa_verify", benchmark_verify, NULL, NULL, &data, 10, 20000);
-#ifdef ENABLE_OPENSSL_TESTS
-    data.ec_group = EC_GROUP_new_by_curve_name(NID_secp256k1);
-    run_benchmark("ecdsa_verify_openssl", benchmark_verify_openssl, NULL, NULL, &data, 10, 20000);
-    EC_GROUP_free(data.ec_group);
-#endif
 
     secp256k1_context_destroy(data.ctx);
     return 0;


### PR DESCRIPTION
This is for discussion obviously. 

 think we don't need the tests anymore, and they do somehwat more harm than good, e.g., they make our tests more complex, and valgrind will complain about the use of uninitialized memory in the tests (which is done on purpose in OpenSSL).