### PR TITLE
Clear sensitive memory without getting optimized out

### DIFF
--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -23,8 +23,8 @@
     VERIFY_CHECK(((n) & 1) == 1); \
     VERIFY_CHECK((n) >= -((1 << ((w)-1)) - 1)); \
     VERIFY_CHECK((n) <=  ((1 << ((w)-1)) - 1)); \
-    VERIFY_SETUP(secp256k1_fe_clear(&(r)->x)); \
-    VERIFY_SETUP(secp256k1_fe_clear(&(r)->y)); \
+    VERIFY_SETUP(secp256k1_fe_set_int(&(r)->x, 0)); \
+    VERIFY_SETUP(secp256k1_fe_set_int(&(r)->y, 0)); \
     for (m = 0; m < ECMULT_TABLE_SIZE(w); m++) { \
         /* This loop is used to avoid secret data in array indices. See
          * the comment in ecmult_gen_impl.h for rationale. */ \

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -204,6 +204,7 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
     memclear(nonce32, sizeof(nonce32));
     secp256k1_scalar_clear(&b);
     secp256k1_gej_clear(&gb);
+    secp256k1_rfc6979_hmac_sha256_clear(&rng);
 }
 
 #endif /* SECP256K1_ECMULT_GEN_IMPL_H */

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -151,7 +151,7 @@ static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context *ctx, secp25
         secp256k1_ge_from_storage(&add, &adds);
         secp256k1_gej_add_ge(r, r, &add);
     }
-    bits = 0;
+    memclear(&bits, sizeof(bits));
     secp256k1_ge_clear(&add);
     secp256k1_scalar_clear(&gnb);
 }
@@ -182,7 +182,7 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
         memcpy(keydata + 32, seed32, 32);
     }
     secp256k1_rfc6979_hmac_sha256_initialize(&rng, keydata, seed32 ? 64 : 32);
-    memset(keydata, 0, sizeof(keydata));
+    memclear(keydata, sizeof(keydata));
     /* Accept unobservably small non-uniformity. */
     secp256k1_rfc6979_hmac_sha256_generate(&rng, nonce32, 32);
     overflow = !secp256k1_fe_set_b32(&s, nonce32);
@@ -196,11 +196,12 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
     /* A blinding value of 0 works, but would undermine the projection hardening. */
     secp256k1_scalar_cmov(&b, &secp256k1_scalar_one, secp256k1_scalar_is_zero(&b));
     secp256k1_rfc6979_hmac_sha256_finalize(&rng);
-    memset(nonce32, 0, 32);
     secp256k1_ecmult_gen(ctx, &gb, &b);
     secp256k1_scalar_negate(&b, &b);
     ctx->blind = b;
     ctx->initial = gb;
+
+    memclear(nonce32, sizeof(nonce32));
     secp256k1_scalar_clear(&b);
     secp256k1_gej_clear(&gb);
 }

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -406,7 +406,9 @@ static int secp256k1_ecmult_wnaf(int *wnaf, int len, const secp256k1_scalar *a, 
     VERIFY_CHECK(a != NULL);
     VERIFY_CHECK(2 <= w && w <= 31);
 
-    memset(wnaf, 0, len * sizeof(wnaf[0]));
+    for (bit = 0; bit < len; bit++) {
+        wnaf[bit] = 0;
+    }
 
     s = *a;
     if (secp256k1_scalar_get_bits(&s, 255, 1)) {
@@ -414,6 +416,7 @@ static int secp256k1_ecmult_wnaf(int *wnaf, int len, const secp256k1_scalar *a, 
         sign = -1;
     }
 
+    bit = 0;
     while (bit < len) {
         int now;
         int word;

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -1005,7 +1005,6 @@ static int secp256k1_ecmult_pippenger_batch(const secp256k1_callback* error_call
     struct secp256k1_pippenger_state *state_space;
     size_t idx = 0;
     size_t point_idx = 0;
-    int i, j;
     int bucket_window;
 
     (void)ctx;
@@ -1055,18 +1054,6 @@ static int secp256k1_ecmult_pippenger_batch(const secp256k1_callback* error_call
     }
 
     secp256k1_ecmult_pippenger_wnaf(buckets, bucket_window, state_space, r, scalars, points, idx);
-
-    /* Clear data */
-    for(i = 0; (size_t)i < idx; i++) {
-        secp256k1_scalar_clear(&scalars[i]);
-        state_space->ps[i].skew_na = 0;
-        for(j = 0; j < WNAF_SIZE(bucket_window+1); j++) {
-            state_space->wnaf_na[i * WNAF_SIZE(bucket_window+1) + j] = 0;
-        }
-    }
-    for(i = 0; i < 1<<bucket_window; i++) {
-        secp256k1_gej_clear(&buckets[i]);
-    }
     secp256k1_scratch_apply_checkpoint(error_callback, scratch, scratch_checkpoint);
     return 1;
 }

--- a/src/field.h
+++ b/src/field.h
@@ -14,8 +14,8 @@
  *  - Each field element can be normalized or not.
  *  - Each field element has a magnitude, which represents how far away
  *    its representation is away from normalization. Normalized elements
- *    always have a magnitude of 1, but a magnitude of 1 doesn't imply
- *    normality.
+ *    always have a magnitude of 0 or 1, but a magnitude of 1 doesn't
+ *    imply normality.
  */
 
 #if defined HAVE_CONFIG_H
@@ -51,7 +51,8 @@ static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r);
  *  implementation may optionally normalize the input, but this should not be relied upon. */
 static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe *r);
 
-/** Set a field element equal to a small integer. Resulting field element is normalized. */
+/** Set a field element equal to a small integer. Resulting field element is normalized; it has
+ *  magnitude 0 if a == 0, and magnitude 1 otherwise. */
 static void secp256k1_fe_set_int(secp256k1_fe *r, int a);
 
 /** Sets a field element equal to zero, initializing all fields. */

--- a/src/field.h
+++ b/src/field.h
@@ -55,7 +55,7 @@ static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe *r);
  *  magnitude 0 if a == 0, and magnitude 1 otherwise. */
 static void secp256k1_fe_set_int(secp256k1_fe *r, int a);
 
-/** Sets a field element equal to zero, initializing all fields. */
+/** Clear a field element to prevent leaking sensitive information. */
 static void secp256k1_fe_clear(secp256k1_fe *a);
 
 /** Verify whether a field element is zero. Requires the input to be normalized. */

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -289,17 +289,6 @@ SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe *a) {
     return a->n[0] & 1;
 }
 
-SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe *a) {
-    int i;
-#ifdef VERIFY
-    a->magnitude = 0;
-    a->normalized = 0;
-#endif
-    for (i=0; i<10; i++) {
-        a->n[i] = 0;
-    }
-}
-
 static int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
     int i;
 #ifdef VERIFY

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -293,7 +293,7 @@ SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe *a) {
     int i;
 #ifdef VERIFY
     a->magnitude = 0;
-    a->normalized = 1;
+    a->normalized = 0;
 #endif
     for (i=0; i<10; i++) {
         a->n[i] = 0;

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -266,7 +266,7 @@ SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe *r, int a) {
     r->n[0] = a;
     r->n[1] = r->n[2] = r->n[3] = r->n[4] = r->n[5] = r->n[6] = r->n[7] = r->n[8] = r->n[9] = 0;
 #ifdef VERIFY
-    r->magnitude = 1;
+    r->magnitude = (a != 0);
     r->normalized = 1;
     secp256k1_fe_verify(r);
 #endif

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -256,7 +256,7 @@ SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe *a) {
     int i;
 #ifdef VERIFY
     a->magnitude = 0;
-    a->normalized = 1;
+    a->normalized = 0;
 #endif
     for (i=0; i<5; i++) {
         a->n[i] = 0;

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -252,17 +252,6 @@ SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe *a) {
     return a->n[0] & 1;
 }
 
-SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe *a) {
-    int i;
-#ifdef VERIFY
-    a->magnitude = 0;
-    a->normalized = 0;
-#endif
-    for (i=0; i<5; i++) {
-        a->n[i] = 0;
-    }
-}
-
 static int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
     int i;
 #ifdef VERIFY

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -229,7 +229,7 @@ SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe *r, int a) {
     r->n[0] = a;
     r->n[1] = r->n[2] = r->n[3] = r->n[4] = 0;
 #ifdef VERIFY
-    r->magnitude = 1;
+    r->magnitude = (a != 0);
     r->normalized = 1;
     secp256k1_fe_verify(r);
 #endif

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -36,6 +36,10 @@ SECP256K1_INLINE static int secp256k1_fe_equal_var(const secp256k1_fe *a, const 
     return secp256k1_fe_normalizes_to_zero_var(&na);
 }
 
+SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe *a) {
+    memclear(a, sizeof(secp256k1_fe));
+}
+
 static int secp256k1_fe_sqrt(secp256k1_fe *r, const secp256k1_fe *a) {
     /** Given that p is congruent to 3 mod 4, we can compute the square root of
      *  a mod p as the (p+1)/4'th power of a.

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -206,16 +206,11 @@ static void secp256k1_ge_set_infinity(secp256k1_ge *r) {
 }
 
 static void secp256k1_gej_clear(secp256k1_gej *r) {
-    r->infinity = 0;
-    secp256k1_fe_clear(&r->x);
-    secp256k1_fe_clear(&r->y);
-    secp256k1_fe_clear(&r->z);
+    memclear(r, sizeof(secp256k1_gej));
 }
 
 static void secp256k1_ge_clear(secp256k1_ge *r) {
-    r->infinity = 0;
-    secp256k1_fe_clear(&r->x);
-    secp256k1_fe_clear(&r->y);
+    memclear(r, sizeof(secp256k1_ge));
 }
 
 static int secp256k1_ge_set_xquad(secp256k1_ge *r, const secp256k1_fe *x) {

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -194,15 +194,15 @@ static void secp256k1_ge_globalz_set_table_gej(size_t len, secp256k1_ge *r, secp
 
 static void secp256k1_gej_set_infinity(secp256k1_gej *r) {
     r->infinity = 1;
-    secp256k1_fe_clear(&r->x);
-    secp256k1_fe_clear(&r->y);
-    secp256k1_fe_clear(&r->z);
+    secp256k1_fe_set_int(&r->x, 0);
+    secp256k1_fe_set_int(&r->y, 0);
+    secp256k1_fe_set_int(&r->z, 0);
 }
 
 static void secp256k1_ge_set_infinity(secp256k1_ge *r) {
     r->infinity = 1;
-    secp256k1_fe_clear(&r->x);
-    secp256k1_fe_clear(&r->y);
+    secp256k1_fe_set_int(&r->x, 0);
+    secp256k1_fe_set_int(&r->y, 0);
 }
 
 static void secp256k1_gej_clear(secp256k1_gej *r) {

--- a/src/hash.h
+++ b/src/hash.h
@@ -19,6 +19,7 @@ typedef struct {
 static void secp256k1_sha256_initialize(secp256k1_sha256 *hash);
 static void secp256k1_sha256_write(secp256k1_sha256 *hash, const unsigned char *data, size_t size);
 static void secp256k1_sha256_finalize(secp256k1_sha256 *hash, unsigned char *out32);
+static void secp256k1_sha256_clear(secp256k1_sha256 *hash);
 
 typedef struct {
     secp256k1_sha256 inner, outer;
@@ -27,6 +28,7 @@ typedef struct {
 static void secp256k1_hmac_sha256_initialize(secp256k1_hmac_sha256 *hash, const unsigned char *key, size_t size);
 static void secp256k1_hmac_sha256_write(secp256k1_hmac_sha256 *hash, const unsigned char *data, size_t size);
 static void secp256k1_hmac_sha256_finalize(secp256k1_hmac_sha256 *hash, unsigned char *out32);
+static void secp256k1_hmac_sha256_clear(secp256k1_hmac_sha256 *hash);
 
 typedef struct {
     unsigned char v[32];
@@ -37,5 +39,6 @@ typedef struct {
 static void secp256k1_rfc6979_hmac_sha256_initialize(secp256k1_rfc6979_hmac_sha256 *rng, const unsigned char *key, size_t keylen);
 static void secp256k1_rfc6979_hmac_sha256_generate(secp256k1_rfc6979_hmac_sha256 *rng, unsigned char *out, size_t outlen);
 static void secp256k1_rfc6979_hmac_sha256_finalize(secp256k1_rfc6979_hmac_sha256 *rng);
+static void secp256k1_rfc6979_hmac_sha256_clear(secp256k1_rfc6979_hmac_sha256 *rng);
 
 #endif /* SECP256K1_HASH_H */

--- a/src/hash_impl.h
+++ b/src/hash_impl.h
@@ -161,6 +161,10 @@ static void secp256k1_sha256_finalize(secp256k1_sha256 *hash, unsigned char *out
         hash->s[i] = 0;
     }
     memcpy(out32, (const unsigned char*)out, 32);
+
+    memclear(sizedesc, sizeof(sizedesc));
+    memclear(out, sizeof(out));
+    memclear(hash, sizeof(secp256k1_sha256));
 }
 
 static void secp256k1_hmac_sha256_initialize(secp256k1_hmac_sha256 *hash, const unsigned char *key, size_t keylen) {
@@ -188,7 +192,7 @@ static void secp256k1_hmac_sha256_initialize(secp256k1_hmac_sha256 *hash, const 
         rkey[n] ^= 0x5c ^ 0x36;
     }
     secp256k1_sha256_write(&hash->inner, rkey, sizeof(rkey));
-    memset(rkey, 0, sizeof(rkey));
+    memclear(rkey, sizeof(rkey));
 }
 
 static void secp256k1_hmac_sha256_write(secp256k1_hmac_sha256 *hash, const unsigned char *data, size_t size) {
@@ -199,7 +203,7 @@ static void secp256k1_hmac_sha256_finalize(secp256k1_hmac_sha256 *hash, unsigned
     unsigned char temp[32];
     secp256k1_sha256_finalize(&hash->inner, temp);
     secp256k1_sha256_write(&hash->outer, temp, 32);
-    memset(temp, 0, 32);
+    memclear(temp, sizeof(temp));
     secp256k1_sha256_finalize(&hash->outer, out32);
 }
 
@@ -266,9 +270,7 @@ static void secp256k1_rfc6979_hmac_sha256_generate(secp256k1_rfc6979_hmac_sha256
 }
 
 static void secp256k1_rfc6979_hmac_sha256_finalize(secp256k1_rfc6979_hmac_sha256 *rng) {
-    memset(rng->k, 0, 32);
-    memset(rng->v, 0, 32);
-    rng->retry = 0;
+    memclear(rng, sizeof(secp256k1_rfc6979_hmac_sha256));
 }
 
 #undef BE32

--- a/src/hash_impl.h
+++ b/src/hash_impl.h
@@ -164,7 +164,10 @@ static void secp256k1_sha256_finalize(secp256k1_sha256 *hash, unsigned char *out
 
     memclear(sizedesc, sizeof(sizedesc));
     memclear(out, sizeof(out));
-    memclear(hash, sizeof(secp256k1_sha256));
+}
+
+static void secp256k1_sha256_clear(secp256k1_sha256 *hash) {
+    memclear(hash, sizeof(*hash));
 }
 
 static void secp256k1_hmac_sha256_initialize(secp256k1_hmac_sha256 *hash, const unsigned char *key, size_t keylen) {
@@ -207,6 +210,9 @@ static void secp256k1_hmac_sha256_finalize(secp256k1_hmac_sha256 *hash, unsigned
     secp256k1_sha256_finalize(&hash->outer, out32);
 }
 
+static void secp256k1_hmac_sha256_clear(secp256k1_hmac_sha256 *hash) {
+    memclear(hash, sizeof(*hash));
+}
 
 static void secp256k1_rfc6979_hmac_sha256_initialize(secp256k1_rfc6979_hmac_sha256 *rng, const unsigned char *key, size_t keylen) {
     secp256k1_hmac_sha256 hmac;
@@ -270,7 +276,11 @@ static void secp256k1_rfc6979_hmac_sha256_generate(secp256k1_rfc6979_hmac_sha256
 }
 
 static void secp256k1_rfc6979_hmac_sha256_finalize(secp256k1_rfc6979_hmac_sha256 *rng) {
-    memclear(rng, sizeof(secp256k1_rfc6979_hmac_sha256));
+    (void) rng;
+}
+
+static void secp256k1_rfc6979_hmac_sha256_clear(secp256k1_rfc6979_hmac_sha256 *rng) {
+    memclear(rng, sizeof(*rng));
 }
 
 #undef BE32

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -19,6 +19,7 @@ static int ecdh_hash_function_sha256(unsigned char *output, const unsigned char 
     secp256k1_sha256_write(&sha, &version, 1);
     secp256k1_sha256_write(&sha, x32, 32);
     secp256k1_sha256_finalize(&sha, output);
+    secp256k1_sha256_clear(&sha);
 
     return 1;
 }

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -61,9 +61,10 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const se
 
     ret = hashfp(output, x, y, data);
 
-    memset(x, 0, 32);
-    memset(y, 0, 32);
+    memclear(x, sizeof(x));
+    memclear(y, sizeof(y));
     secp256k1_scalar_clear(&s);
+    secp256k1_ge_clear(&pt);
 
     return !!ret & !overflow;
 }

--- a/src/modules/recovery/main_impl.h
+++ b/src/modules/recovery/main_impl.h
@@ -121,8 +121,7 @@ static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context *ctx, cons
 }
 
 int secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp256k1_ecdsa_recoverable_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
-    secp256k1_scalar r, s;
-    secp256k1_scalar sec, non, msg;
+    secp256k1_scalar r, s, sec;
     int recid;
     int ret = 0;
     int overflow = 0;
@@ -138,6 +137,7 @@ int secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp256k1_ecd
     secp256k1_scalar_set_b32(&sec, seckey, &overflow);
     /* Fail if the secret key is invalid. */
     if (!overflow && !secp256k1_scalar_is_zero(&sec)) {
+        secp256k1_scalar non, msg;
         unsigned char nonce32[32];
         unsigned int count = 0;
         secp256k1_scalar_set_b32(&msg, msg32, NULL);
@@ -154,11 +154,11 @@ int secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp256k1_ecd
             }
             count++;
         }
-        memset(nonce32, 0, 32);
+        memclear(nonce32, sizeof(nonce32));
         secp256k1_scalar_clear(&msg);
         secp256k1_scalar_clear(&non);
-        secp256k1_scalar_clear(&sec);
     }
+    secp256k1_scalar_clear(&sec);
     if (ret) {
         secp256k1_ecdsa_recoverable_signature_save(signature, &r, &s, recid);
     } else {

--- a/src/num_gmp_impl.h
+++ b/src/num_gmp_impl.h
@@ -39,7 +39,7 @@ static void secp256k1_num_get_bin(unsigned char *r, unsigned int rlen, const sec
     if (len > shift) {
         memcpy(r + rlen - len + shift, tmp + shift, len - shift);
     }
-    memset(tmp, 0, sizeof(tmp));
+    memclear(tmp, sizeof(tmp));
 }
 
 static void secp256k1_num_set_bin(secp256k1_num *r, const unsigned char *a, unsigned int alen) {
@@ -85,7 +85,7 @@ static void secp256k1_num_mod(secp256k1_num *r, const secp256k1_num *m) {
     if (r->limbs >= m->limbs) {
         mp_limb_t t[2*NUM_LIMBS];
         mpn_tdiv_qr(t, r->data, 0, r->data, r->limbs, m->data, m->limbs);
-        memset(t, 0, sizeof(t));
+        memclear(t, sizeof(t));
         r->limbs = m->limbs;
         while (r->limbs > 1 && r->data[r->limbs-1]==0) {
             r->limbs--;
@@ -139,9 +139,9 @@ static void secp256k1_num_mod_inverse(secp256k1_num *r, const secp256k1_num *a, 
     } else {
         r->limbs = sn;
     }
-    memset(g, 0, sizeof(g));
-    memset(u, 0, sizeof(u));
-    memset(v, 0, sizeof(v));
+    memclear(g, sizeof(g));
+    memclear(u, sizeof(u));
+    memclear(v, sizeof(v));
 }
 
 static int secp256k1_num_jacobi(const secp256k1_num *a, const secp256k1_num *b) {
@@ -256,7 +256,7 @@ static void secp256k1_num_mul(secp256k1_num *r, const secp256k1_num *a, const se
     VERIFY_CHECK(r->limbs <= 2*NUM_LIMBS);
     mpn_copyi(r->data, tmp, r->limbs);
     r->neg = a->neg ^ b->neg;
-    memset(tmp, 0, sizeof(tmp));
+    memclear(tmp, sizeof(tmp));
 }
 
 static void secp256k1_num_shift(secp256k1_num *r, int bits) {

--- a/src/scalar_4x64_impl.h
+++ b/src/scalar_4x64_impl.h
@@ -24,13 +24,6 @@
 #define SECP256K1_N_H_2 ((uint64_t)0xFFFFFFFFFFFFFFFFULL)
 #define SECP256K1_N_H_3 ((uint64_t)0x7FFFFFFFFFFFFFFFULL)
 
-SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar *r) {
-    r->d[0] = 0;
-    r->d[1] = 0;
-    r->d[2] = 0;
-    r->d[3] = 0;
-}
-
 SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar *r, unsigned int v) {
     r->d[0] = v;
     r->d[1] = 0;

--- a/src/scalar_8x32_impl.h
+++ b/src/scalar_8x32_impl.h
@@ -34,17 +34,6 @@
 #define SECP256K1_N_H_6 ((uint32_t)0xFFFFFFFFUL)
 #define SECP256K1_N_H_7 ((uint32_t)0x7FFFFFFFUL)
 
-SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar *r) {
-    r->d[0] = 0;
-    r->d[1] = 0;
-    r->d[2] = 0;
-    r->d[3] = 0;
-    r->d[4] = 0;
-    r->d[5] = 0;
-    r->d[6] = 0;
-    r->d[7] = 0;
-}
-
 SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar *r, unsigned int v) {
     r->d[0] = v;
     r->d[1] = 0;

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -27,6 +27,10 @@
 static const secp256k1_scalar secp256k1_scalar_one = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 1);
 static const secp256k1_scalar secp256k1_scalar_zero = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
 
+SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar *r) {
+    memclear(r, sizeof(secp256k1_scalar));
+}
+
 #ifndef USE_NUM_NONE
 static void secp256k1_scalar_get_num(secp256k1_num *r, const secp256k1_scalar *a) {
     unsigned char c[32];

--- a/src/scalar_low_impl.h
+++ b/src/scalar_low_impl.h
@@ -15,7 +15,6 @@ SECP256K1_INLINE static int secp256k1_scalar_is_even(const secp256k1_scalar *a) 
     return !(*a & 1);
 }
 
-SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar *r) { *r = 0; }
 SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar *r, unsigned int v) { *r = v; }
 
 SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits(const secp256k1_scalar *a, unsigned int offset, unsigned int count) {

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -456,11 +456,13 @@ static int nonce_function_rfc6979(unsigned char *nonce32, const unsigned char *m
        buffer_append(keydata, &offset, algo16, 16);
    }
    secp256k1_rfc6979_hmac_sha256_initialize(&rng, keydata, offset);
-   memclear(keydata, sizeof(keydata));
    for (i = 0; i <= counter; i++) {
        secp256k1_rfc6979_hmac_sha256_generate(&rng, nonce32, 32);
    }
    secp256k1_rfc6979_hmac_sha256_finalize(&rng);
+
+   memclear(keydata, sizeof(keydata));
+   secp256k1_rfc6979_hmac_sha256_clear(&rng);
    return 1;
 }
 

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -456,7 +456,7 @@ static int nonce_function_rfc6979(unsigned char *nonce32, const unsigned char *m
        buffer_append(keydata, &offset, algo16, 16);
    }
    secp256k1_rfc6979_hmac_sha256_initialize(&rng, keydata, offset);
-   memset(keydata, 0, sizeof(keydata));
+   memclear(keydata, sizeof(keydata));
    for (i = 0; i <= counter; i++) {
        secp256k1_rfc6979_hmac_sha256_generate(&rng, nonce32, 32);
    }
@@ -508,7 +508,7 @@ int secp256k1_ecdsa_sign(const secp256k1_context* ctx, secp256k1_ecdsa_signature
         }
         count++;
     }
-    memset(nonce32, 0, 32);
+    memclear(nonce32, sizeof(nonce32));
     secp256k1_scalar_clear(&msg);
     secp256k1_scalar_clear(&non);
     secp256k1_scalar_clear(&sec);

--- a/src/tests.c
+++ b/src/tests.c
@@ -79,7 +79,7 @@ void random_field_element_magnitude(secp256k1_fe *fe) {
     if (n == 0) {
         return;
     }
-    secp256k1_fe_clear(&zero);
+    secp256k1_fe_set_int(&zero, 0);
     secp256k1_fe_negate(&zero, &zero, 0);
     secp256k1_fe_mul_int(&zero, n - 1);
     secp256k1_fe_add(fe, &zero);

--- a/src/tests.c
+++ b/src/tests.c
@@ -2063,7 +2063,7 @@ void test_ge(void) {
     secp256k1_fe zfi2, zfi3;
 
     secp256k1_gej_set_infinity(&gej[0]);
-    secp256k1_ge_clear(&ge[0]);
+    secp256k1_ge_set_gej(&ge[0], &gej[0]);
     secp256k1_ge_set_gej_var(&ge[0], &gej[0]);
     for (i = 0; i < runs; i++) {
         int j;
@@ -2860,12 +2860,12 @@ void test_ecmult_multi(secp256k1_scratch *scratch, secp256k1_ecmult_multi_func e
         random_group_element_test(&pt[ncount]);
     }
 
-    secp256k1_scalar_clear(&sc[0]);
+    secp256k1_scalar_set_int(&sc[0], 0);
     CHECK(ecmult_multi(&ctx->error_callback, &ctx->ecmult_ctx, scratch, &r, &szero, ecmult_multi_callback, &data, 20));
-    secp256k1_scalar_clear(&sc[1]);
-    secp256k1_scalar_clear(&sc[2]);
-    secp256k1_scalar_clear(&sc[3]);
-    secp256k1_scalar_clear(&sc[4]);
+    secp256k1_scalar_set_int(&sc[1], 0);
+    secp256k1_scalar_set_int(&sc[2], 0);
+    secp256k1_scalar_set_int(&sc[3], 0);
+    secp256k1_scalar_set_int(&sc[4], 0);
     CHECK(ecmult_multi(&ctx->error_callback, &ctx->ecmult_ctx, scratch, &r, &szero, ecmult_multi_callback, &data, 6));
     CHECK(ecmult_multi(&ctx->error_callback, &ctx->ecmult_ctx, scratch, &r, &szero, ecmult_multi_callback, &data, 5));
     CHECK(secp256k1_gej_is_infinity(&r));

--- a/src/util.h
+++ b/src/util.h
@@ -11,10 +11,16 @@
 #include "libsecp256k1-config.h"
 #endif
 
+#include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <limits.h>
+
+#if defined(_MSC_VER)
+// For SecureZeroMemory
+#include <Windows.h>
+#endif
 
 typedef struct {
     void (*fn)(const char *text, void* data);
@@ -173,6 +179,31 @@ static SECP256K1_INLINE void memczero(void *s, size_t len, int flag) {
         p++;
         len--;
     }
+}
+
+/* Cleanses memory to prevent leaking sensitive info. Won't be optimized out. */
+static SECP256K1_INLINE void memclear(void *ptr, size_t len) {
+#if defined(_MSC_VER)
+    /* SecureZeroMemory is guaranteed not to be optimized out by MSVC. */
+    SecureZeroMemory(ptr, n);
+#elif defined(__GNUC__)
+    /* We use a memory barrier that scares the compiler away from optimizing out the memset.
+     *
+     * Quoting Adam Langley <agl@google.com> in commit ad1907fe73334d6c696c8539646c21b11178f20f
+     * in BoringSSL (ISC License):
+     *    As best as we can tell, this is sufficient to break any optimisations that
+     *    might try to eliminate "superfluous" memsets.
+     * This method used in memzero_explicit() the Linux kernel, too. Its advantage is that it is
+     * pretty efficient, because the compiler can still implement the memset() efficently,
+     * just not remove it entirely. See "Dead Store Elimination (Still) Considered Harmful" by
+     * Yang et al. (USENIX Security 2017) for more background.
+     */
+    memset(ptr, 0, len);
+    __asm__ __volatile__("" : : "r"(ptr) : "memory");
+#else
+    void *(*volatile const volatile_memset)(void *, int, size_t) = memset;
+    volatile_memset(ptr, 0, len);
+#endif
 }
 
 #endif /* SECP256K1_UTIL_H */


### PR DESCRIPTION
This is a rebase of #448, including a few changes (mostly implementing what I described in #185). I haven't tested this on Windows and I actually haven't reviewed this in detail so far, but people can start to have a look.

Fixes #185 and closes #448.