### PR TITLE
Adding message length to the callbacks

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -272,7 +272,7 @@ SECP256K1_API void secp256k1_context_destroy(
  */
 SECP256K1_API void secp256k1_context_set_illegal_callback(
     secp256k1_context* ctx,
-    void (*fun)(const char* message, void* data),
+    void (*fun)(const char* message, size_t message_len, void* data),
     const void* data
 ) SECP256K1_ARG_NONNULL(1);
 
@@ -297,7 +297,7 @@ SECP256K1_API void secp256k1_context_set_illegal_callback(
  */
 SECP256K1_API void secp256k1_context_set_error_callback(
     secp256k1_context* ctx,
-    void (*fun)(const char* message, void* data),
+    void (*fun)(const char* message, size_t message_len, void* data),
     const void* data
 ) SECP256K1_ARG_NONNULL(1);
 

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -36,19 +36,21 @@
 #ifndef USE_EXTERNAL_DEFAULT_CALLBACKS
 #include <stdlib.h>
 #include <stdio.h>
-static void secp256k1_default_illegal_callback_fn(const char* str, void* data) {
+static void secp256k1_default_illegal_callback_fn(const char* str, size_t str_len, void* data) {
+    VERIFY_CHECK(strlen(str) == str_len);
     (void)data;
     fprintf(stderr, "[libsecp256k1] illegal argument: %s\n", str);
     abort();
 }
-static void secp256k1_default_error_callback_fn(const char* str, void* data) {
+static void secp256k1_default_error_callback_fn(const char* str, size_t str_len, void* data) {
+    VERIFY_CHECK(strlen(str) == str_len);
     (void)data;
     fprintf(stderr, "[libsecp256k1] internal consistency check failed: %s\n", str);
     abort();
 }
 #else
-void secp256k1_default_illegal_callback_fn(const char* str, void* data);
-void secp256k1_default_error_callback_fn(const char* str, void* data);
+void secp256k1_default_illegal_callback_fn(const char* str, size_t str_len, void* data);
+void secp256k1_default_error_callback_fn(const char* str, size_t str_len, void* data);
 #endif
 
 static const secp256k1_callback default_illegal_callback = {
@@ -187,7 +189,7 @@ void secp256k1_context_destroy(secp256k1_context* ctx) {
     }
 }
 
-void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
+void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(const char* message, size_t message_len, void* data), const void* data) {
     ARG_CHECK_NO_RETURN(ctx != secp256k1_context_no_precomp);
     if (fun == NULL) {
         fun = secp256k1_default_illegal_callback_fn;
@@ -196,7 +198,7 @@ void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(
     ctx->illegal_callback.data = data;
 }
 
-void secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
+void secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(const char* message, size_t message_len, void* data), const void* data) {
     ARG_CHECK_NO_RETURN(ctx != secp256k1_context_no_precomp);
     if (fun == NULL) {
         fun = secp256k1_default_error_callback_fn;

--- a/src/tests.c
+++ b/src/tests.c
@@ -46,18 +46,20 @@ void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps) 
 static int count = 64;
 static secp256k1_context *ctx = NULL;
 
-static void counting_illegal_callback_fn(const char* str, void* data) {
+static void counting_illegal_callback_fn(const char* str, size_t str_len, void* data) {
     /* Dummy callback function that just counts. */
     int32_t *p;
     (void)str;
+    (void)str_len;
     p = data;
     (*p)++;
 }
 
-static void uncounting_illegal_callback_fn(const char* str, void* data) {
+static void uncounting_illegal_callback_fn(const char* str, size_t str_len, void* data) {
     /* Dummy callback function that just counts (backwards). */
     int32_t *p;
     (void)str;
+    (void)str_len;
     p = data;
     (*p)--;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -14,14 +14,15 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 typedef struct {
-    void (*fn)(const char *text, void* data);
+    void (*fn)(const char *text, size_t text_len, void* data);
     const void* data;
 } secp256k1_callback;
 
 static SECP256K1_INLINE void secp256k1_callback_call(const secp256k1_callback * const cb, const char * const text) {
-    cb->fn(text, (void*)cb->data);
+    cb->fn(text, strlen(text), (void*)cb->data);
 }
 
 #ifdef DETERMINISTIC


### PR DESCRIPTION
This will help a lot for downstream code that doesn't have easy access to libc(`strlen` etc.)

Any thoughts about this?

cc downstream https://github.com/rust-bitcoin/rust-secp256k1/pull/115

(I wasn't sure when is `CHECK` vs `VERIFY_CHECK` is used so would appreciate a feedback if I used it right)