### PR TITLE
secp256k1/src/tests.c:  Properly handle sscanf return value

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -5180,7 +5180,7 @@ int main(int argc, char **argv) {
         const char* ch = argv[2];
         while (pos < 16 && ch[0] != 0 && ch[1] != 0) {
             unsigned short sh;
-            if (sscanf(ch, "%2hx", &sh)) {
+            if ((sscanf(ch, "%2hx", &sh)) == 1) {
                 seed16[pos] = sh;
             } else {
                 break;


### PR DESCRIPTION
This pull request fixes a bug which allows the `sh` variable to be used uninitialised
when sscanf(3) returns EOF.

Signed-off-by: Mustapha Abiola <mustapha@trilemma.net>