### PR TITLE
WIP batching ecdsa verification using recovery with no recid

### DIFF
--- a/include/secp256k1_recovery.h
+++ b/include/secp256k1_recovery.h
@@ -106,27 +106,29 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover(
 /** Recover a set of ECDSA public keys from a set of regular signatures and messages.
  * Producing 0-4 public keys per signature.
  *
- *  Returns: 1: Nothing memory-wise failed.
+ *  Returns: 1: Was able to recover something, and no signature or public key were invalid.
  *           0: otherwise.
  *           In particular, returns 1 if n is 0.
- *  Args:    ctx:        pointer to a context object, initialized for verification (cannot be NULL)
- *           scratch:    scratch space used for point conversions.
- *  Out:     pubkeys:    Array size n*4, the pubkeys will be written by signature to this. (4 keys assigned for each signature)
- *  Out:     pubkeys_n:  Array size n, the amount of recovered pubkeys per signature will be written to this.
- *                       i.e. if pubkeys_n[i]=x then from pubkeys[i*4] to pubkeys[i*4+x] are the valid public keys for signature i
- *  In:      sigs:       Array size n, of pointers to the signatures being recovered.
- *           msgs32:     Array size n, of pointers to the 32-byte message hashs assumed to be signed
- *           n:          The amount of public keys to recover.
- *                       All arrays *must* be at the documented size, unless n is zero then they can be NULL.
+ *  Args:    ctx:          Pointer to a context object, initialized for verification (cannot be NULL)
+ *           scratch:      Scratch space used for point conversions.
+ *  Out:     pubkeys_out:  Array of pubkeys pointers of size n*4, for each signature a corresponding 0-4 pubkey pointers will be written for it, the rest NULL. (4 keys assigned for each signature)
+ *                         i.e. if pubkeys_n[i]=x then from pubkeys[i*4] to pubkeys[i*4+x] any pointer that isn't NULL is a valid public key for signature i.
+ *  In:      sigs:         Array size n, of pointers to the signatures being recovered.
+ *           msgs32:       Array size n, of pointers to the 32-byte message hashs assumed to be signed
+ *           n:            The amount of public keys to recover.
+ *           pubkeys_in:   Array of size pubkeys_n, with a list of potential public keys to check against.
+ *           pubkeys_n:    The amount of public keys being passed to convert against.
+ *                         All arrays *must* be at the documented size, unless n is zero then they can be NULL.
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover_batch(
     const secp256k1_context* ctx,
     secp256k1_scratch_space *scratch,
-    secp256k1_pubkey pubkeys[],
-    size_t pubkeys_n[],
+    const secp256k1_pubkey *pubkeys_out[],
     const secp256k1_ecdsa_signature *const sigs[],
     const unsigned char *const msgs32[],
-    size_t n
+    size_t n,
+    const secp256k1_pubkey *const pubkeys[],
+    size_t pubkeys_n
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
 
 #ifdef __cplusplus

--- a/include/secp256k1_recovery.h
+++ b/include/secp256k1_recovery.h
@@ -103,6 +103,32 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover(
     const unsigned char *msg32
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
+/** Recover a set of ECDSA public keys from a set of regular signatures and messages.
+ * Producing 0-4 public keys per signature.
+ *
+ *  Returns: 1: Nothing memory-wise failed.
+ *           0: otherwise.
+ *           In particular, returns 1 if n is 0.
+ *  Args:    ctx:        pointer to a context object, initialized for verification (cannot be NULL)
+ *           scratch:    scratch space used for point conversions.
+ *  Out:     pubkeys:    Array size n*4, the pubkeys will be written by signature to this. (4 keys assigned for each signature)
+ *  Out:     pubkeys_n:  Array size n, the amount of recovered pubkeys per signature will be written to this.
+ *                       i.e. if pubkeys_n[i]=x then from pubkeys[i*4] to pubkeys[i*4+x] are the valid public keys for signature i
+ *  In:      sigs:       Array size n, of pointers to the signatures being recovered.
+ *           msgs32:     Array size n, of pointers to the 32-byte message hashs assumed to be signed
+ *           n:          The amount of public keys to recover.
+ *                       All arrays *must* be at the documented size, unless n is zero then they can be NULL.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover_batch(
+    const secp256k1_context* ctx,
+    secp256k1_scratch_space *scratch,
+    secp256k1_pubkey pubkeys[],
+    size_t pubkeys_n[],
+    const secp256k1_ecdsa_signature *const sigs[],
+    const unsigned char *const msgs32[],
+    size_t n
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -211,6 +211,15 @@ void bench_group_add_var(void* arg) {
     }
 }
 
+void bench_group_add_neg_var(void* arg) {
+    int i;
+    bench_inv *data = (bench_inv*)arg;
+
+    for (i = 0; i < 200000; i++) {
+        secp256k1_gej_add_neg_var(&data->gej_x, &data->gej_y, &data->gej_x, &data->gej_y, NULL);
+    }
+}
+
 void bench_group_add_affine(void* arg) {
     int i;
     bench_inv *data = (bench_inv*)arg;
@@ -348,6 +357,7 @@ int main(int argc, char **argv) {
 
     if (have_flag(argc, argv, "group") || have_flag(argc, argv, "double")) run_benchmark("group_double_var", bench_group_double_var, bench_setup, NULL, &data, 10, 200000);
     if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_var", bench_group_add_var, bench_setup, NULL, &data, 10, 200000);
+    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_neg_var", bench_group_add_neg_var, bench_setup, NULL, &data, 10, 200000);
     if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_affine", bench_group_add_affine, bench_setup, NULL, &data, 10, 200000);
     if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_affine_var", bench_group_add_affine_var, bench_setup, NULL, &data, 10, 200000);
     if (have_flag(argc, argv, "group") || have_flag(argc, argv, "jacobi")) run_benchmark("group_jacobi_var", bench_group_jacobi_var, bench_setup, NULL, &data, 10, 20000);

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -9,10 +9,19 @@
 #include "util.h"
 #include "bench.h"
 
+#define RECOVER_AMOUNT 10
+#define BREATHING_OFFSET 16
+
 typedef struct {
     secp256k1_context *ctx;
-    unsigned char msg[32];
-    unsigned char sig[64];
+    secp256k1_scratch_space *scratch;
+    unsigned char msg[RECOVER_AMOUNT][32];
+    const unsigned char *msgs_ptrs[RECOVER_AMOUNT];
+    unsigned char sig[RECOVER_AMOUNT][64];
+    secp256k1_ecdsa_signature sig_arr[RECOVER_AMOUNT];
+    const secp256k1_ecdsa_signature* sigs_ptrs[RECOVER_AMOUNT];
+    secp256k1_pubkey keys_arr[RECOVER_AMOUNT*4];
+    size_t pubkeys_n[RECOVER_AMOUNT];
 } bench_recover_data;
 
 void bench_recover(void* arg) {
@@ -25,36 +34,71 @@ void bench_recover(void* arg) {
         int j;
         size_t pubkeylen = 33;
         secp256k1_ecdsa_recoverable_signature sig;
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(data->ctx, &sig, data->sig, i % 2));
-        CHECK(secp256k1_ecdsa_recover(data->ctx, &pubkey, &sig, data->msg));
+        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(data->ctx, &sig, data->sig[0], i % 2));
+        CHECK(secp256k1_ecdsa_recover(data->ctx, &pubkey, &sig, data->msg[0]));
         CHECK(secp256k1_ec_pubkey_serialize(data->ctx, pubkeyc, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
         for (j = 0; j < 32; j++) {
-            data->sig[j + 32] = data->msg[j];    /* Move former message to S. */
-            data->msg[j] = data->sig[j];         /* Move former R to message. */
-            data->sig[j] = pubkeyc[j + 1];       /* Move recovered pubkey X coordinate to R (which must be a valid X coordinate). */
+            data->sig[0][j + 32] = data->msg[0][j];    /* Move former message to S. */
+            data->msg[0][j] = data->sig[0][j];         /* Move former R to message. */
+            data->sig[0][j] = pubkeyc[j + 1];       /* Move recovered pubkey X coordinate to R (which must be a valid X coordinate). */
         }
+      if (i < RECOVER_AMOUNT) {
+        memcpy(data->sig[i], data->sig[0], 64);
+        memcpy(data->msg[i], data->msg[0], 32);
+      }
     }
+}
+
+
+void bench_recover_batch(void* arg) {
+  size_t i, j, k;
+  bench_recover_data *data = (bench_recover_data*)arg;
+  unsigned char pubkeyc[33];
+
+
+  for (i = 0; i < 200; i++) {
+    size_t pubkeylen = 33;
+    for (j = 0; j < RECOVER_AMOUNT; j++) {
+      CHECK(secp256k1_ecdsa_signature_parse_compact(data->ctx, &data->sig_arr[j], data->sig[j]));
+    }
+    CHECK(secp256k1_ecdsa_recover_batch(data->ctx, data->scratch, data->keys_arr, data->pubkeys_n, data->sigs_ptrs, data->msgs_ptrs, RECOVER_AMOUNT));
+
+    for (j = 0; j < RECOVER_AMOUNT; j++) {
+      CHECK(data->pubkeys_n[j]>0);
+      for (k = 0; k < data->pubkeys_n[j]; k++) {
+        CHECK(secp256k1_ec_pubkey_serialize(data->ctx, pubkeyc, &pubkeylen, &data->keys_arr[(j*4)+k], SECP256K1_EC_COMPRESSED));
+      }
+    }
+  }
 }
 
 void bench_recover_setup(void* arg) {
     int i;
     bench_recover_data *data = (bench_recover_data*)arg;
 
+    for (i = 0; i < RECOVER_AMOUNT; i++) {
+      data->sigs_ptrs[i] = &data->sig_arr[i];
+      data->msgs_ptrs[i] = data->msg[i];
+    }
     for (i = 0; i < 32; i++) {
-        data->msg[i] = 1 + i;
+        data->msg[0][i] = 1 + i;
     }
     for (i = 0; i < 64; i++) {
-        data->sig[i] = 65 + i;
+        data->sig[0][i] = 65 + i;
     }
 }
 
 int main(void) {
     bench_recover_data data;
+    char name[64];
 
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    data.scratch = secp256k1_scratch_space_create(data.ctx, 4 * RECOVER_AMOUNT * (104+152+16+BREATHING_OFFSET));
 
     run_benchmark("ecdsa_recover", bench_recover, bench_recover_setup, NULL, &data, 10, 20000);
+    sprintf(name, "ecdsa_recover_batch: %d", RECOVER_AMOUNT);
 
+    run_benchmark(name, bench_recover_batch, bench_recover_setup, NULL, &data, 10, RECOVER_AMOUNT*200);
     secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/src/field.h
+++ b/src/field.h
@@ -87,6 +87,10 @@ static void secp256k1_fe_mul_int(secp256k1_fe *r, int a);
 /** Adds a field element to another. The result has the sum of the inputs' magnitudes as magnitude. */
 static void secp256k1_fe_add(secp256k1_fe *r, const secp256k1_fe *a);
 
+/** Sets a field element to be the sum of two others.
+ * The result has the sum of the inputs' magnitudes as magnitude.*/
+static void secp256k1_fe_copy_add(secp256k1_fe *r, const secp256k1_fe *b, const secp256k1_fe *a);
+
 /** Sets a field element to be the product of two others. Requires the inputs' magnitudes to be at most 8.
  *  The output magnitude is 1 (but not guaranteed to be normalized). */
 static void secp256k1_fe_mul(secp256k1_fe *r, const secp256k1_fe *a, const secp256k1_fe * SECP256K1_RESTRICT b);

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -443,6 +443,29 @@ SECP256K1_INLINE static void secp256k1_fe_add(secp256k1_fe *r, const secp256k1_f
 #endif
 }
 
+
+SECP256K1_INLINE static void secp256k1_fe_copy_add(secp256k1_fe *r, const secp256k1_fe *b, const secp256k1_fe *a) {
+#ifdef VERIFY
+  secp256k1_fe_verify(a);
+#endif
+  r->n[0] = a->n[0] + b->n[0];
+  r->n[1] = a->n[1] + b->n[1];
+  r->n[2] = a->n[2] + b->n[2];
+  r->n[3] = a->n[3] + b->n[3];
+  r->n[4] = a->n[4] + b->n[4];
+  r->n[5] = a->n[5] + b->n[5];
+  r->n[6] = a->n[6] + b->n[6];
+  r->n[7] = a->n[7] + b->n[7];
+  r->n[8] = a->n[8] + b->n[8];
+  r->n[9] = a->n[9] + b->n[9];
+
+#ifdef VERIFY
+  r->magnitude = b->magnitude + a->magnitude;
+    r->normalized = 0;
+    secp256k1_fe_verify(r);
+#endif
+}
+
 #if defined(USE_EXTERNAL_ASM)
 
 /* External assembler implementation */

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -414,6 +414,22 @@ SECP256K1_INLINE static void secp256k1_fe_add(secp256k1_fe *r, const secp256k1_f
 #endif
 }
 
+SECP256K1_INLINE static void secp256k1_fe_copy_add(secp256k1_fe *r, const secp256k1_fe *b, const secp256k1_fe *a) {
+#ifdef VERIFY
+  secp256k1_fe_verify(a);
+#endif
+  r->n[0] = b->n[0] + a->n[0];
+  r->n[1] = b->n[1] + a->n[1];
+  r->n[2] = b->n[2] + a->n[2];
+  r->n[3] = b->n[3] + a->n[3];
+  r->n[4] = b->n[4] + a->n[4];
+#ifdef VERIFY
+    r->magnitude = b->magnitude + a->magnitude;
+    r->normalized = 0;
+    secp256k1_fe_verify(r);
+#endif
+}
+
 static void secp256k1_fe_mul(secp256k1_fe *r, const secp256k1_fe *a, const secp256k1_fe * SECP256K1_RESTRICT b) {
 #ifdef VERIFY
     VERIFY_CHECK(a->magnitude <= 8);

--- a/src/group.h
+++ b/src/group.h
@@ -105,6 +105,9 @@ static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, s
 /** Set r equal to the sum of a and b. If rzr is non-NULL, r->z = a->z * *rzr (a cannot be infinity in that case). */
 static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr);
 
+/** Set r equal to the sum of a and b. And set n equal to a-b If rzr is non-NULL, r->z = a->z * *rzr (a cannot be infinity in that case). */
+static void secp256k1_gej_add_neg_var(secp256k1_gej *r, secp256k1_gej *n, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr);
+
 /** Set r equal to the sum of a and b (with b given in affine coordinates, and not infinity). */
 static void secp256k1_gej_add_ge(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b);
 

--- a/src/group.h
+++ b/src/group.h
@@ -99,6 +99,9 @@ static int secp256k1_gej_has_quad_y_var(const secp256k1_gej *a);
  * a may not be zero. Constant time. */
 static void secp256k1_gej_double_nonzero(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr);
 
+/** Compare if a affine element and a jacobian element are the same point without doing inverses. Requires the b->x and b->y to be weakly normalized */
+static int ge_equals_gej_var(const secp256k1_ge *a, const secp256k1_gej *b);
+
 /** Set r equal to the double of a. If rzr is not-NULL, r->z = a->z * *rzr (where infinity means an implicit z = 0). */
 static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr);
 

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -434,7 +434,7 @@ static void secp256k1_gej_add_neg_var(secp256k1_gej *r, secp256k1_gej *n, const 
     return;
   }
 
-  r->infinity = 0;
+  r->infinity = 0; n->infinity = 0;
   secp256k1_fe_sqr(&z22, &b->z);
   secp256k1_fe_sqr(&z12, &a->z);
   secp256k1_fe_mul(&u1, &a->x, &z22);
@@ -447,13 +447,13 @@ static void secp256k1_gej_add_neg_var(secp256k1_gej *r, secp256k1_gej *n, const 
   if (secp256k1_fe_normalizes_to_zero_var(&h)) {
     if (secp256k1_fe_normalizes_to_zero_var(&i)) {
       secp256k1_gej_double_var(r, a, rzr);
-      n->infinity = 1;
+      n->infinity = 1; /* if a==b then a-b==inf */
     } else {
       if (rzr != NULL) {
         secp256k1_fe_set_int(rzr, 0);
       }
+      secp256k1_gej_double_var(n, a, rzr); /*a is a complement of b, so a-b == a*2 */
       r->infinity = 1;
-      n->infinity = 1;
     }
     return;
   }

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -416,6 +416,68 @@ static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, cons
     secp256k1_fe_add(&r->y, &h3);
 }
 
+static void secp256k1_gej_add_neg_var(secp256k1_gej *r, secp256k1_gej *n, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr) {
+  /* Operations: 14 mul, 5 sqr, 2 normalize, 18 mul_int/add/negate */
+  secp256k1_fe z22, z12, u1, u2, s1, s2, h, i, in, i2, in2, h2, h3, t;
+
+  if (a->infinity) {
+    VERIFY_CHECK(rzr == NULL);
+    *r = *b;
+    return;
+  }
+
+  if (b->infinity) {
+    if (rzr != NULL) {
+      secp256k1_fe_set_int(rzr, 1);
+    }
+    *r = *a;
+    return;
+  }
+
+  r->infinity = 0;
+  secp256k1_fe_sqr(&z22, &b->z);
+  secp256k1_fe_sqr(&z12, &a->z);
+  secp256k1_fe_mul(&u1, &a->x, &z22);
+  secp256k1_fe_mul(&u2, &b->x, &z12);
+  secp256k1_fe_mul(&s1, &a->y, &z22); secp256k1_fe_mul(&s1, &s1, &b->z);
+  secp256k1_fe_mul(&s2, &b->y, &z12); secp256k1_fe_mul(&s2, &s2, &a->z);
+  secp256k1_fe_negate(&h, &u1, 1); secp256k1_fe_add(&h, &u2);
+  secp256k1_fe_negate(&i, &s1, 1); secp256k1_fe_add(&i, &s2);
+  in = s1; secp256k1_fe_add(&in, &s2); secp256k1_fe_negate(&in, &in, 2);
+  if (secp256k1_fe_normalizes_to_zero_var(&h)) {
+    if (secp256k1_fe_normalizes_to_zero_var(&i)) {
+      secp256k1_gej_double_var(r, a, rzr);
+      n->infinity = 1;
+    } else {
+      if (rzr != NULL) {
+        secp256k1_fe_set_int(rzr, 0);
+      }
+      r->infinity = 1;
+      n->infinity = 1;
+    }
+    return;
+  }
+  secp256k1_fe_sqr(&i2, &i); secp256k1_fe_sqr(&in2, &in);
+  secp256k1_fe_sqr(&h2, &h);
+  secp256k1_fe_mul(&h3, &h, &h2);
+  secp256k1_fe_mul(&h, &h, &b->z);
+  if (rzr != NULL) {
+    *rzr = h;
+  }
+  secp256k1_fe_mul(&r->z, &a->z, &h);
+  n->z = r->z;
+  secp256k1_fe_mul(&t, &u1, &h2);
+
+  r->x = t; secp256k1_fe_mul_int(&r->x, 2); secp256k1_fe_add(&r->x, &h3); secp256k1_fe_negate(&r->x, &r->x, 3);
+  n->x = r->x; secp256k1_fe_add(&n->x, &in2);
+  secp256k1_fe_add(&r->x, &i2);
+
+  secp256k1_fe_negate(&r->y, &r->x, 5); secp256k1_fe_add(&r->y, &t); secp256k1_fe_mul(&r->y, &r->y, &i);
+  secp256k1_fe_negate(&n->y, &n->x, 5); secp256k1_fe_add(&n->y, &t); secp256k1_fe_mul(&n->y, &n->y, &in);
+  secp256k1_fe_mul(&h3, &h3, &s1); secp256k1_fe_negate(&h3, &h3, 1);
+  secp256k1_fe_add(&r->y, &h3); secp256k1_fe_add(&n->y, &h3);
+}
+
 static void secp256k1_gej_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, secp256k1_fe *rzr) {
     /* 8 mul, 3 sqr, 4 normalize, 12 mul_int/add/negate */
     secp256k1_fe z12, u1, u2, s1, s2, h, i, i2, h2, h3, t;

--- a/src/modules/recovery/main_impl.h
+++ b/src/modules/recovery/main_impl.h
@@ -150,10 +150,8 @@ static int secp256k1_ecdsa_sig_recover_four(const secp256k1_ecmult_context *ctx,
       secp256k1_gej_set_ge(&xj2, &gex);
 
       secp256k1_ecmult(ctx, &xj2, &xj2, &u2, NULL);
-      secp256k1_gej_neg(&xj2n, &xj2);
 
-      secp256k1_gej_add_var(&xj2, &xj2, &u1j, NULL);
-      secp256k1_gej_add_var(&xj2n, &xj2n, &u1j, NULL);
+      secp256k1_gej_add_neg_var(&xj2, &xj2n, &u1j, &xj2, NULL);
 
       if (!secp256k1_gej_is_infinity(&xj2)) {
         memcpy(&out[*n], &xj2n, sizeof(out[*n]));
@@ -170,10 +168,7 @@ static int secp256k1_ecdsa_sig_recover_four(const secp256k1_ecmult_context *ctx,
     secp256k1_gej_set_ge(&xj1, &gex);
     secp256k1_ecmult(ctx, &xj1, &xj1, &u2, NULL);
 
-    secp256k1_gej_neg(&xj1n, &xj1);
-
-    secp256k1_gej_add_var(&xj1, &xj1, &u1j, NULL);
-    secp256k1_gej_add_var(&xj1n, &xj1n, &u1j, NULL);
+    secp256k1_gej_add_neg_var(&xj1, &xj1n, &u1j, &xj1, NULL);
 
     if (!secp256k1_gej_is_infinity(&xj1)) {
       memcpy(&out[*n], &xj1, sizeof(out[*n]));

--- a/src/modules/recovery/main_impl.h
+++ b/src/modules/recovery/main_impl.h
@@ -284,7 +284,6 @@ int secp256k1_ecdsa_recover_batch(const secp256k1_context* ctx, secp256k1_scratc
     return 0;
   }
 
-  j = 0;
   for (i = 0; i < n; ++i) {
     secp256k1_ecdsa_signature_load(ctx, &rs[i], &ss[i], sigs[i]);
     if (secp256k1_scalar_is_zero(&rs[i]) || secp256k1_scalar_is_zero(&ss[i])) {

--- a/src/modules/recovery/tests_impl.h
+++ b/src/modules/recovery/tests_impl.h
@@ -147,6 +147,57 @@ void test_ecdsa_recovery_api(void) {
     secp256k1_context_destroy(both);
 }
 
+#define N_AMOUNT 10
+void test_ecdsa_recovery_batch(void) {
+  size_t i,j,k, curr, pubkeys_n[N_AMOUNT];
+  secp256k1_pubkey pubkeys[N_AMOUNT*4];
+  const secp256k1_ecdsa_signature* sigs_ptrs[N_AMOUNT];
+  secp256k1_ecdsa_signature sigs[N_AMOUNT];
+  unsigned char msgs[N_AMOUNT][32];
+  const unsigned char *msgs_arr[N_AMOUNT];
+  unsigned char privkey[32] = "My fun and valid superSecret key";
+  int found;
+  secp256k1_scratch_space *scratch = secp256k1_scratch_space_create(ctx, 4*N_AMOUNT * (104+152+16+16));
+  CHECK(scratch != NULL);
+
+  for (i = 0; i < N_AMOUNT; ++i) {
+    {
+      secp256k1_scalar rand_scalar;
+      random_scalar_order_test(&rand_scalar);
+      secp256k1_scalar_get_b32(msgs[i], &rand_scalar);
+    }
+    msgs_arr[i] = msgs[i];
+    CHECK(secp256k1_ecdsa_sign(ctx, &sigs[i], msgs[i], privkey, NULL, NULL));
+    sigs_ptrs[i] = &sigs[i];
+  }
+  CHECK(secp256k1_ecdsa_recover_batch(ctx, scratch, pubkeys, pubkeys_n, sigs_ptrs, msgs_arr, N_AMOUNT));
+
+
+  for (i = 0; i < N_AMOUNT; ++i) {
+    curr = i*4;
+    found = 0;
+    for (j = 0; j < pubkeys_n[i]; j++) {
+      for (k = 0; k < pubkeys_n[0]; k++) {
+        if(memcmp(&pubkeys[k], &pubkeys[curr+j], sizeof(secp256k1_pubkey)) == 0) found++;
+      }
+    }
+   CHECK(found >= 1);
+  }
+  CHECK(secp256k1_ec_pubkey_create(ctx, &pubkeys[N_AMOUNT], privkey));
+
+  found = 0;
+  for (i = 0; i < pubkeys_n[0]; ++i) {
+    if(memcmp(&pubkeys[i], &pubkeys[N_AMOUNT], sizeof(secp256k1_pubkey)) == 0) found = 1;
+  }
+  CHECK(found == 1);
+  memset(&sigs[2].data, 0, 64);
+  CHECK(!secp256k1_ecdsa_recover_batch(ctx, scratch, pubkeys, pubkeys_n, sigs_ptrs, msgs_arr, N_AMOUNT));
+  CHECK(pubkeys_n[2] == 0);
+
+  CHECK(secp256k1_ecdsa_recover_batch(ctx, scratch, NULL, NULL, NULL, NULL, 0));
+
+}
+
 void test_ecdsa_recovery_end_to_end(void) {
     unsigned char extra[32] = {0x00};
     unsigned char privkey[32];
@@ -207,6 +258,7 @@ void test_ecdsa_recovery_end_to_end(void) {
 
 /* Tests several edge cases. */
 void test_ecdsa_recovery_edge_cases(void) {
+  secp256k1_scratch_space *scratch = secp256k1_scratch_space_create(ctx, 4*(104+152+16+16));
     const unsigned char msg32[32] = {
         'T', 'h', 'i', 's', ' ', 'i', 's', ' ',
         'a', ' ', 'v', 'e', 'r', 'y', ' ', 's',
@@ -241,7 +293,11 @@ void test_ecdsa_recovery_edge_cases(void) {
     secp256k1_ecdsa_recoverable_signature rsig;
     secp256k1_ecdsa_signature sig;
     int recid;
-
+    size_t amount;
+    size_t *pubkeys_n = &amount;
+    const secp256k1_ecdsa_signature *const psig = &sig;
+    const unsigned char *const pmsg32 = msg32;
+    secp256k1_pubkey four_pubkeys[4];
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 0));
     CHECK(!secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 1));
@@ -250,6 +306,13 @@ void test_ecdsa_recovery_edge_cases(void) {
     CHECK(!secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 3));
     CHECK(!secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
+
+    CHECK(secp256k1_ecdsa_signature_parse_compact(ctx, &sig, sig64));
+    CHECK(secp256k1_ecdsa_recover_batch(ctx, scratch, four_pubkeys, pubkeys_n, &psig, &pmsg32, 1));
+    CHECK(amount == 1);
+    CHECK(secp256k1_ecdsa_signature_parse_compact(ctx, &sig, sigb64));
+    CHECK(secp256k1_ecdsa_recover_batch(ctx, scratch, four_pubkeys, pubkeys_n, &psig, &pmsg32, 1));
+    CHECK(amount == 4);
 
     for (recid = 0; recid < 4; recid++) {
         int i;
@@ -388,6 +451,7 @@ void run_recovery_tests(void) {
         test_ecdsa_recovery_end_to_end();
     }
     test_ecdsa_recovery_edge_cases();
+    test_ecdsa_recovery_batch();
 }
 
 #endif /* SECP256K1_MODULE_RECOVERY_TESTS_H */

--- a/src/scalar.h
+++ b/src/scalar.h
@@ -63,6 +63,9 @@ static void secp256k1_scalar_inverse(secp256k1_scalar *r, const secp256k1_scalar
 /** Compute the inverse of a scalar (modulo the group order), without constant-time guarantee. */
 static void secp256k1_scalar_inverse_var(secp256k1_scalar *r, const secp256k1_scalar *a);
 
+/** Calculate the (modular) inverses of a batch of scalars. The inputs and outputs must not overlap in memory. */
+static void secp256k1_scalar_inv_all_var(secp256k1_scalar *r, const secp256k1_scalar *a, size_t len);
+
 /** Compute the complement of a scalar (modulo the group order). */
 static void secp256k1_scalar_negate(secp256k1_scalar *r, const secp256k1_scalar *a);
 

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -222,6 +222,33 @@ SECP256K1_INLINE static int secp256k1_scalar_is_even(const secp256k1_scalar *a) 
 }
 #endif
 
+static void secp256k1_scalar_inv_all_var(secp256k1_scalar *r, const secp256k1_scalar *a, size_t len) {
+  secp256k1_scalar u;
+  size_t i;
+  if (len < 1) {
+    return;
+  }
+
+  VERIFY_CHECK((r + len <= a) || (a + len <= r));
+
+  r[0] = a[0];
+
+  i = 0;
+  while (++i < len) {
+    secp256k1_scalar_mul(&r[i], &r[i - 1], &a[i]);
+  }
+
+  secp256k1_scalar_inverse_var(&u, &r[--i]);
+
+  while (i > 0) {
+    size_t j = i--;
+    secp256k1_scalar_mul(&r[j], &r[i], &u);
+    secp256k1_scalar_mul(&u, &u, &a[j]);
+  }
+
+  r[0] = u;
+}
+
 static void secp256k1_scalar_inverse_var(secp256k1_scalar *r, const secp256k1_scalar *x) {
 #if defined(USE_SCALAR_INV_BUILTIN)
     secp256k1_scalar_inverse(r, x);

--- a/src/tests.c
+++ b/src/tests.c
@@ -5166,6 +5166,26 @@ void run_ecdsa_openssl(void) {
 # include "modules/recovery/tests_impl.h"
 #endif
 
+void run_ec_add_neg(void) {
+  int ncount;
+  secp256k1_ge age, bge;
+  secp256k1_gej a, b;
+  secp256k1_gej bn, ab1, ab2, anb1, anb2;
+
+  for (ncount = 0; ncount < count; ncount++) {
+    random_group_element_test(&age); random_group_element_test(&bge);
+    secp256k1_gej_set_ge(&a, &age); secp256k1_gej_set_ge(&b, &bge);
+
+    secp256k1_gej_neg(&bn, &b);
+    secp256k1_gej_add_var(&ab1, &a, &b, NULL);
+    secp256k1_gej_add_var(&anb1, &a, &bn, NULL);
+    secp256k1_gej_add_neg_var(&ab2, &anb2, &a, &b, NULL);
+
+    secp256k1_ge_set_gej(&age, &ab1); ge_equals_gej(&age, &ab2);
+    secp256k1_ge_set_gej(&bge, &anb1); ge_equals_gej(&bge, &anb2);
+  }
+}
+
 int main(int argc, char **argv) {
     unsigned char seed16[16] = {0};
     unsigned char run32[32] = {0};
@@ -5258,6 +5278,7 @@ int main(int argc, char **argv) {
     run_ecmult_const_tests();
     run_ecmult_multi_tests();
     run_ec_combine();
+    run_ec_add_neg();
 
     /* endomorphism tests */
 #ifdef USE_ENDOMORPHISM


### PR DESCRIPTION
Hi,
The idea was proposed by @roconnor-blockstream https://github.com/bitcoin/bitcoin/issues/15621

Basically the idea is to change the cost of verification of `k-of-n` from `n` verifications(amount of pubkeys) to `k` recoveries (amount of signatures).


Currently the performance aren't great: (no gmp, no endo(bitcoin's default))
```
$ ./becnch_recover
ecdsa_recover: min 66.2us / avg 68.4us / max 74.5us
ecdsa_recover_batch: 10: min 84.5us / avg 85.1us / max 85.8us
$ ./bench_verify 
ecdsa_verify: min 58.0us / avg 59.2us / max 60.2us
ecdsa_verify_openssl: min 334us / avg 340us / max 346us
```

Although it's already improved by batching the `gej->ge` conversions and by batching the `Rx` inversions.
This can be further optimized using a suggestion from @sipa to pass in the public keys and then match against them using something like:
```
static int ge_equals_gej_var(const secp256k1_ge *a, const secp256k1_gej *b) {
  secp256k1_fe z2s;
  secp256k1_fe u1, s1;
  if (a->infinity && b->infinity) {
    return 1;
  } else if (a->infinity || b->infinity) {
    return 0;
  }

#ifdef VERIFY
  VERIFY_CHECK(b->x.magnitude == 1);
  VERIFY_CHECK(b->y.magnitude == 1);
  secp256k1_fe_verify(&b->x);
  secp256k1_fe_verify(&b->y);
#endif

  /* Check a.x * b.z^2 == b.x && a.y * b.z^3 == b.y, to avoid inverses. */
  secp256k1_fe_sqr(&z2s, &b->z);
  secp256k1_fe_mul(&u1, &a->x, &z2s);
  secp256k1_fe_mul(&s1, &a->y, &z2s); secp256k1_fe_mul(&s1, &s1, &b->z);
  return secp256k1_fe_equal_var(&u1, &b->x) && secp256k1_fe_equal_var(&s1, &b->y);
}
```

And then matching through the list (need to think how to do it the most efficiently because it's still 2 mul and a sqrt).

Other idea might be a way to batch `secp256k1_gej_add_var(&xj2, &xj2, &u1j, NULL);` which is basically computing `A = R+X, B=R-X`.
I don't have a concrete suggestion into how to batch that yet but it needs some thought. 

This is still a work in progress as we would want to see good performance before even considering this, although it's already going to provide a performance boost in cases that `k < 7/10*n` (2-of-3 and up) but i'm not sure differentiating these cases is a great idea(more complexity to consensus code)

Edit: For reference @0xb10c thankfully provided me with some stats on multisig. currently 9.2% of all historic UTXOs are multisig. with the following distribution(ordered from least used to most): (Thanks! @0xb10c)
```
4-of-8: 1
1-of-14: 1
11-of-11: 1
13-of-13: 1
6-of-15: 1
4-of-11: 1
6-of-10: 2
1-of-8: 2
1-of-10: 2
6-of-8: 2
8-of-10: 2
7-of-12: 2
3-of-10: 2
2-of-12: 3
5-of-15: 3
5-of-10: 4
8-of-9: 5
12-of-12: 5
1-of-9: 7
12-of-15: 8
6-of-11: 8
6-of-7: 9
10-of-15: 11
3-of-9: 11
5-of-9: 12
6-of-9: 13
2-of-10: 14
3-of-15: 21
1-of-15: 27
5-of-6: 28
6-of-6: 41
9-of-9: 51
2-of-14: 66
8-of-15: 70
2-of-15: 74
7-of-7: 98
15-of-15: 102
1-of-12: 117
5-of-8: 120
10-of-10: 144
8-of-8: 150
3-of-8: 169
6-of-13: 250
11-of-15: 280
5-of-7: 306
2-of-7: 322
4-of-9: 431
2-of-8: 600
5-of-5: 711
2-of-9: 1024
1-of-7: 1801
4-of-7: 2174
4-of-4: 2870
1-of-5: 3216
1-of-4: 3702
1-of-6: 6260
4-of-5: 10719
3-of-7: 16731
2-of-5: 20763
4-of-6: 21304
3-of-6: 24457
3-of-3: 29275
1-of-3: 39495
2-of-4: 310673
1-of-1: 478276
2-of-6: 511406
3-of-5: 624550
1-of-2: 651491
3-of-4: 3849322
2-of-2: 25711364
2-of-3: 73384150
Total inputs: 1143408605
Total multisig inputs: 105709334
ms inputs / inputs 0.0924510568992963
``` 