### PR TITLE
Add ecmult_gen, ecmult_const and ecmult to benchmark

### DIFF
--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -232,7 +232,7 @@ static void bench_ecmult_multi_teardown(void* arg, int iters) {
 
 static void generate_scalar(uint32_t num, secp256k1_scalar* scalar) {
     secp256k1_sha256 sha256;
-    unsigned char c[11] = {'e', 'c', 'm', 'u', 'l', 't', 0, 0, 0, 0};
+    unsigned char c[10] = {'e', 'c', 'm', 'u', 'l', 't', 0, 0, 0, 0};
     unsigned char buf[32];
     int overflow = 0;
     c[6] = num;

--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -18,12 +18,28 @@
 
 #define POINTS 32768
 
+void help(char **argv) {
+    printf("Benchmark EC multiplication algorithms\n");
+    printf("\n");
+    printf("Usage: %s <help|pippenger_wnaf|strauss_wnaf|simple>\n", argv[0]);
+    printf("The output shows the number of multiplied and summed points right after the\n");
+    printf("function name. The letter 'g' indicates that one of the points is the generator.\n");
+    printf("The benchmarks are divided by the number of points.\n");
+    printf("\n");
+    printf("default (ecmult_multi): picks pippenger_wnaf or strauss_wnaf depending on the\n");
+    printf("                        batch size\n");
+    printf("pippenger_wnaf:         for all batch sizes\n");
+    printf("strauss_wnaf:           for all batch sizes\n");
+    printf("simple:                 multiply and sum each point individually\n");
+}
+
 typedef struct {
     /* Setup once in advance */
     secp256k1_context* ctx;
     secp256k1_scratch_space* scratch;
     secp256k1_scalar* scalars;
     secp256k1_ge* pubkeys;
+    secp256k1_gej* pubkeys_gej;
     secp256k1_scalar* seckeys;
     secp256k1_gej* expected_output;
     secp256k1_ecmult_multi_func ecmult_multi;
@@ -45,6 +61,128 @@ typedef struct {
 static void hash_into_offset(bench_data* data, size_t x) {
     data->offset1 = (x * 0x537b7f6f + 0x8f66a481) % POINTS;
     data->offset2 = (x * 0x7f6f537b + 0x6a1a8f49) % POINTS;
+}
+
+/* Check correctness of the benchmark by computing
+ * sum(outputs) ?= (sum(scalars_gen) + sum(seckeys)*sum(scalars))*G */
+static void bench_ecmult_teardown_helper(bench_data* data, size_t* seckey_offset, size_t* scalar_offset, size_t* scalar_gen_offset, int iters) {
+    int i;
+    secp256k1_gej sum_output, tmp;
+    secp256k1_scalar sum_scalars;
+
+    secp256k1_gej_set_infinity(&sum_output);
+    secp256k1_scalar_clear(&sum_scalars);
+    for (i = 0; i < iters; ++i) {
+        secp256k1_gej_add_var(&sum_output, &sum_output, &data->output[i], NULL);
+        if (scalar_gen_offset != NULL) {
+            secp256k1_scalar_add(&sum_scalars, &sum_scalars, &data->scalars[(*scalar_gen_offset+i) % POINTS]);
+        }
+        if (seckey_offset != NULL) {
+            secp256k1_scalar s = data->seckeys[(*seckey_offset+i) % POINTS];
+            secp256k1_scalar_mul(&s, &s, &data->scalars[(*scalar_offset+i) % POINTS]);
+            secp256k1_scalar_add(&sum_scalars, &sum_scalars, &s);
+        }
+    }
+    secp256k1_ecmult_gen(&data->ctx->ecmult_gen_ctx, &tmp, &sum_scalars);
+    secp256k1_gej_neg(&tmp, &tmp);
+    secp256k1_gej_add_var(&tmp, &tmp, &sum_output, NULL);
+    CHECK(secp256k1_gej_is_infinity(&tmp));
+}
+
+static void bench_ecmult_setup(void* arg) {
+    bench_data* data = (bench_data*)arg;
+    /* Re-randomize offset to ensure that we're using different scalars and
+     * group elements in each run. */
+    hash_into_offset(data, data->offset1);
+}
+
+static void bench_ecmult_gen(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    int i;
+
+    for (i = 0; i < iters; ++i) {
+        secp256k1_ecmult_gen(&data->ctx->ecmult_gen_ctx, &data->output[i], &data->scalars[(data->offset1+i) % POINTS]);
+    }
+}
+
+static void bench_ecmult_gen_teardown(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    bench_ecmult_teardown_helper(data, NULL, NULL, &data->offset1, iters);
+}
+
+static void bench_ecmult_const(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    int i;
+
+    for (i = 0; i < iters; ++i) {
+        secp256k1_ecmult_const(&data->output[i], &data->pubkeys[(data->offset1+i) % POINTS], &data->scalars[(data->offset2+i) % POINTS], 256);
+    }
+}
+
+static void bench_ecmult_const_teardown(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    bench_ecmult_teardown_helper(data, &data->offset1, &data->offset2, NULL, iters);
+}
+
+static void bench_ecmult_1(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    int i;
+
+    for (i = 0; i < iters; ++i) {
+        secp256k1_ecmult(&data->ctx->ecmult_ctx, &data->output[i], &data->pubkeys_gej[(data->offset1+i) % POINTS], &data->scalars[(data->offset2+i) % POINTS], NULL);
+    }
+}
+
+static void bench_ecmult_1_teardown(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    bench_ecmult_teardown_helper(data, &data->offset1, &data->offset2, NULL, iters);
+}
+
+static void bench_ecmult_1g(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    secp256k1_scalar zero;
+    int i;
+
+    secp256k1_scalar_set_int(&zero, 0);
+    for (i = 0; i < iters; ++i) {
+        secp256k1_ecmult(&data->ctx->ecmult_ctx, &data->output[i], NULL, &zero, &data->scalars[(data->offset1+i) % POINTS]);
+    }
+}
+
+static void bench_ecmult_1g_teardown(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    bench_ecmult_teardown_helper(data, NULL, NULL, &data->offset1, iters);
+}
+
+static void bench_ecmult_2g(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    int i;
+
+    for (i = 0; i < iters/2; ++i) {
+        secp256k1_ecmult(&data->ctx->ecmult_ctx, &data->output[i], &data->pubkeys_gej[(data->offset1+i) % POINTS], &data->scalars[(data->offset2+i) % POINTS], &data->scalars[(data->offset1+i) % POINTS]);
+    }
+}
+
+static void bench_ecmult_2g_teardown(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    bench_ecmult_teardown_helper(data, &data->offset1, &data->offset2, &data->offset1, iters/2);
+}
+
+static void run_ecmult_bench(bench_data* data, int iters) {
+    char str[32];
+    sprintf(str, "ecmult_gen");
+    run_benchmark(str, bench_ecmult_gen, bench_ecmult_setup, bench_ecmult_gen_teardown, data, 10, iters);
+    sprintf(str, "ecmult_const");
+    run_benchmark(str, bench_ecmult_const, bench_ecmult_setup, bench_ecmult_const_teardown, data, 10, iters);
+    /* ecmult with non generator point */
+    sprintf(str, "ecmult 1");
+    run_benchmark(str, bench_ecmult_1, bench_ecmult_setup, bench_ecmult_1_teardown, data, 10, iters);
+    /* ecmult with generator point */
+    sprintf(str, "ecmult 1g");
+    run_benchmark(str, bench_ecmult_1g, bench_ecmult_setup, bench_ecmult_1g_teardown, data, 10, iters);
+    /* ecmult with generator and non-generator point. The reported time is per point. */
+    sprintf(str, "ecmult 2g");
+    run_benchmark(str, bench_ecmult_2g, bench_ecmult_setup, bench_ecmult_2g_teardown, data, 10, 2*iters);
 }
 
 static int bench_ecmult_multi_callback(secp256k1_scalar* sc, secp256k1_ge* ge, size_t idx, void* arg) {
@@ -139,18 +277,19 @@ static void run_ecmult_multi_bench(bench_data* data, size_t count, int includes_
 int main(int argc, char **argv) {
     bench_data data;
     int i, p;
-    secp256k1_gej* pubkeys_gej;
     size_t scratch_size;
 
     int iters = get_iters(10000);
 
-    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
-    scratch_size = secp256k1_strauss_scratch_size(POINTS) + STRAUSS_SCRATCH_OBJECTS*16;
-    data.scratch = secp256k1_scratch_space_create(data.ctx, scratch_size);
     data.ecmult_multi = secp256k1_ecmult_multi_var;
 
     if (argc > 1) {
-        if(have_flag(argc, argv, "pippenger_wnaf")) {
+        if(have_flag(argc, argv, "-h")
+           || have_flag(argc, argv, "--help")
+           || have_flag(argc, argv, "help")) {
+            help(argv);
+            return 1;
+        } else if(have_flag(argc, argv, "pippenger_wnaf")) {
             printf("Using pippenger_wnaf:\n");
             data.ecmult_multi = secp256k1_ecmult_pippenger_batch_single;
         } else if(have_flag(argc, argv, "strauss_wnaf")) {
@@ -158,36 +297,45 @@ int main(int argc, char **argv) {
             data.ecmult_multi = secp256k1_ecmult_strauss_batch_single;
         } else if(have_flag(argc, argv, "simple")) {
             printf("Using simple algorithm:\n");
-            data.ecmult_multi = secp256k1_ecmult_multi_var;
-            secp256k1_scratch_space_destroy(data.ctx, data.scratch);
-            data.scratch = NULL;
         } else {
-            fprintf(stderr, "%s: unrecognized argument '%s'.\n", argv[0], argv[1]);
-            fprintf(stderr, "Use 'pippenger_wnaf', 'strauss_wnaf', 'simple' or no argument to benchmark a combined algorithm.\n");
+            fprintf(stderr, "%s: unrecognized argument '%s'.\n\n", argv[0], argv[1]);
+            help(argv);
             return 1;
         }
+    }
+
+    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    scratch_size = secp256k1_strauss_scratch_size(POINTS) + STRAUSS_SCRATCH_OBJECTS*16;
+    if (!have_flag(argc, argv, "simple")) {
+        data.scratch = secp256k1_scratch_space_create(data.ctx, scratch_size);
+    } else {
+        data.scratch = NULL;
     }
 
     /* Allocate stuff */
     data.scalars = malloc(sizeof(secp256k1_scalar) * POINTS);
     data.seckeys = malloc(sizeof(secp256k1_scalar) * POINTS);
     data.pubkeys = malloc(sizeof(secp256k1_ge) * POINTS);
+    data.pubkeys_gej = malloc(sizeof(secp256k1_gej) * POINTS);
     data.expected_output = malloc(sizeof(secp256k1_gej) * (iters + 1));
     data.output = malloc(sizeof(secp256k1_gej) * (iters + 1));
 
     /* Generate a set of scalars, and private/public keypairs. */
-    pubkeys_gej = malloc(sizeof(secp256k1_gej) * POINTS);
-    secp256k1_gej_set_ge(&pubkeys_gej[0], &secp256k1_ge_const_g);
+    secp256k1_gej_set_ge(&data.pubkeys_gej[0], &secp256k1_ge_const_g);
     secp256k1_scalar_set_int(&data.seckeys[0], 1);
     for (i = 0; i < POINTS; ++i) {
         generate_scalar(i, &data.scalars[i]);
         if (i) {
-            secp256k1_gej_double_var(&pubkeys_gej[i], &pubkeys_gej[i - 1], NULL);
+            secp256k1_gej_double_var(&data.pubkeys_gej[i], &data.pubkeys_gej[i - 1], NULL);
             secp256k1_scalar_add(&data.seckeys[i], &data.seckeys[i - 1], &data.seckeys[i - 1]);
         }
     }
-    secp256k1_ge_set_all_gej_var(data.pubkeys, pubkeys_gej, POINTS);
-    free(pubkeys_gej);
+    secp256k1_ge_set_all_gej_var(data.pubkeys, data.pubkeys_gej, POINTS);
+
+
+    /* Initialize offset1 and offset2 */
+    hash_into_offset(&data, 0);
+    run_ecmult_bench(&data, iters);
 
     for (i = 1; i <= 8; ++i) {
         run_ecmult_multi_bench(&data, i, 1, iters);
@@ -210,6 +358,7 @@ int main(int argc, char **argv) {
     secp256k1_context_destroy(data.ctx);
     free(data.scalars);
     free(data.pubkeys);
+    free(data.pubkeys_gej);
     free(data.seckeys);
     free(data.output);
     free(data.expected_output);


### PR DESCRIPTION
I was trying to determine the impact of ecmult_gen in schnorrsig signing and noticed that there is no way to bench this right now. The new benchmarks look like this:
```
$ ./bench_ecmult
ecmult_gen: min 20.9us / avg 21.2us / max 21.7us
ecmult_const: min 63.9us / avg 64.3us / max 64.8us
ecmult 1: min 49.4us / avg 49.7us / max 50.3us
ecmult 1g: min 39.8us / avg 40.0us / max 40.3us
ecmult 2g: min 27.2us / avg 27.3us / max 27.8us
ecmult_multi 1g: min 39.8us / avg 40.0us / max 40.2us
ecmult_multi 2g: min 27.2us / avg 27.4us / max 27.7us
ecmult_multi 3g: min 22.8us / avg 22.9us / max 23.1us
ecmult_multi 4g: min 20.6us / avg 20.8us / max 21.1us
ecmult_multi 5g: min 19.3us / avg 19.5us / max 19.7us
```

(Turns out ecmult_gen is 37% of the 55.8us that schnorrsig sign takes)