### PR TITLE
Provide pkg-config packages for optional modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -559,6 +559,9 @@ AM_CONDITIONAL([USE_JNI], [test x"$use_jni" = x"yes"])
 AM_CONDITIONAL([USE_EXTERNAL_ASM], [test x"$use_external_asm" = x"yes"])
 AM_CONDITIONAL([USE_ASM_ARM], [test x"$set_asm" = x"arm"])
 
+AM_COND_IF([ENABLE_MODULE_ECDH],     [AC_CONFIG_FILES([libsecp256k1-ecdh.pc])])
+AM_COND_IF([ENABLE_MODULE_RECOVERY], [AC_CONFIG_FILES([libsecp256k1-recovery.pc])])
+
 dnl make sure nothing new is exported so that we don't break the cache
 PKGCONFIG_PATH_TEMP="$PKG_CONFIG_PATH"
 unset PKG_CONFIG_PATH

--- a/libsecp256k1-ecdh.pc.in
+++ b/libsecp256k1-ecdh.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libsecp256k1-ecdh
+Description: ECDH shared secret computation module of libsecp256k1
+URL: https://github.com/bitcoin-core/secp256k1
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lsecp256k1
+Libs.private: @SECP_LIBS@
+

--- a/libsecp256k1-recovery.pc.in
+++ b/libsecp256k1-recovery.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libsecp256k1-recovery
+Description: ECDSA pubkey recovery module of libsecp256k1
+URL: https://github.com/bitcoin-core/secp256k1
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lsecp256k1
+Libs.private: @SECP_LIBS@
+

--- a/src/modules/ecdh/Makefile.am.include
+++ b/src/modules/ecdh/Makefile.am.include
@@ -1,3 +1,4 @@
+pkgconfig_DATA += libsecp256k1-ecdh.pc
 include_HEADERS += include/secp256k1_ecdh.h
 noinst_HEADERS += src/modules/ecdh/main_impl.h
 noinst_HEADERS += src/modules/ecdh/tests_impl.h

--- a/src/modules/recovery/Makefile.am.include
+++ b/src/modules/recovery/Makefile.am.include
@@ -1,3 +1,4 @@
+pkgconfig_DATA += libsecp256k1-recovery.pc
 include_HEADERS += include/secp256k1_recovery.h
 noinst_HEADERS += src/modules/recovery/main_impl.h
 noinst_HEADERS += src/modules/recovery/tests_impl.h


### PR DESCRIPTION
This makes it way easier for dependent projects
to probe whether libsecp256k1 was built with an
optional module they might require.

Fixes #666 