### PR TITLE
Add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,8 @@ Exhaustive tests
 With valgrind, you might need to increase the max stack size:
 
     $ valgrind --max-stackframe=2500000 ./exhaustive_tests
+
+Reporting a vulnerability
+------------
+
+See [SECURITY.md](SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report security issues send an email to secp256k1-security@bitcoincore.org (not for support).
+
+The following keys may be used to communicate sensitive information to developers:
+
+| Name | Fingerprint |
+|------|-------------|
+| Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
+| Andrew Poelstra | 699A 63EF C17A D3A9 A34C  FFC0 7AD0 A91C 40BD 0091 |
+| Tim Ruffing | 09E0 3F87 1092 E40E 106E  902B 33BC 86AB 80FF 5516 |
+
+You can import a key by running the following command with that individual’s fingerprint: `gpg --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.


### PR DESCRIPTION
Fixes #646 

WIP because the secp256k1-security@bitcoincore.org email address doesn't exist yet. But it seems like the right place for vulnerability reports. security@bitcoincore.org would have the downside that it perhaps reaches more people than necessary. Ideally secp256k1-security would just forward to the three maintainers listed in SECURITY.md. @sipa @apoelstra is it okay to put you there? Fwiw I'm opting out for now because three people should be enough.

@sipa do you know who to talk to about adding secp256k1-security@bitcoincore.org and the specifics about how it would work?