### PR TITLE
Make no-float policy explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Implementation details
   * Extensive testing infrastructure.
   * Structured to facilitate review and analysis.
   * Intended to be portable to any system with a C89 compiler and uint64_t support.
+  * No use of floating types, except in benchmarks.
   * Expose only higher level interfaces to minimize the API surface and improve application security. ("Be difficult to use insecurely.")
 * Field operations
   * Optimized implementation of arithmetic modulo the curve's field size (2^256 - 0x1000003D1).


### PR DESCRIPTION
We don't want floating types for various reasons, e.g.,
 - Their representation and often their behavior is implementation-defined.
 - Many targets don't support them.

Closes #683.