### PR TITLE
Fix issue where travis does not show the ./tests seed…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
         apt:
           packages:
             - valgrind
-    
+
 before_install: mkdir -p `dirname $GUAVA_JAR`
 install: if [ ! -f $GUAVA_JAR ]; then wget $GUAVA_URL -O $GUAVA_JAR; fi
 before_script: ./autogen.sh
@@ -93,4 +93,8 @@ script:
    make -j2 &&
    travis_wait 30 valgrind --error-exitcode=42 ./tests 16 &&
    travis_wait 30 valgrind --error-exitcode=42 ./exhaustive_tests;
-   fi 
+   fi
+
+after_script:
+    - cat ./tests.log
+    - cat ./exhaustive_tests.log

--- a/src/tests.c
+++ b/src/tests.c
@@ -5174,6 +5174,9 @@ int main(int argc, char **argv) {
      * diagnostic information. Happens right at the start of main because
      * setbuf must be used before any other operation on the stream. */
     setbuf(stdout, NULL);
+    /* Also disable buffering for stderr because it's not guaranteed that it's
+     * unbuffered on all systems. */
+    setbuf(stderr, NULL);
 
     /* find iteration count */
     if (argc > 1) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -5169,6 +5169,12 @@ void run_ecdsa_openssl(void) {
 int main(int argc, char **argv) {
     unsigned char seed16[16] = {0};
     unsigned char run32[32] = {0};
+
+    /* Disable buffering for stdout to improve reliability of getting
+     * diagnostic information. Happens right at the start of main because
+     * setbuf must be used before any other operation on the stream. */
+    setbuf(stdout, NULL);
+
     /* find iteration count */
     if (argc > 1) {
         count = strtol(argv[1], NULL, 0);


### PR DESCRIPTION
…by removing stdout buffering and always cat tests.log after a travis run. Fixes #645. 

I noticed that according to the [doc](https://www.gnu.org/software/automake/manual/html_node/Parallel-Test-Harness.html) tests.log should contain stdout as well as stderr. But it doesn't because stdout isn't flushed. I removed buffering completely to avoid having to call `fflush` twice.

Travis is instructed to always show the seed which seems helpful with `after_script` by `cat`ing `./tests.log`. In case the tests fail it looks like https://travis-ci.org/jonasnick/secp256k1/jobs/606446234.
