### PR TITLE
Add memory sanitizer test to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,34 @@ matrix:
           packages:
             - gcc-multilib
             - libgmp-dev:i386
+
+    # clang with memory sanitizer
+    #
+    # --disable-openssl-tests because openssl uses uninitialized memory. ASM
+    # and BIGNUM are disabled because clang memory sanitizer does not work
+    # with inline assembly (https://clang.llvm.org/docs/MemorySanitizer.html).
+    # The memory sanitizer is instructed to exit with a different exit code
+    # using MSAN_OPTIONS. This is because the default exit code is 77 - the
+    # same exit code that autotools make check interprets as a test that is
+    # supposed to be skipped.
+    #
+    # With endomorphism
+    - compiler: clang
+      env:
+        - CFLAGS="-fsanitize=memory -fno-omit-frame-pointer -g"
+        - ASM=no BIGNUM=no EXTRAFLAGS="--disable-openssl-tests"
+        - EXPERIMENTAL=yes RECOVERY=yes ECDH=yes
+        - MSAN_OPTIONS=exitcode=42
+        - ENDOMORPHISM=yes
+    # Memory sanitizer without endomorphism
+    - compiler: clang
+      env:
+        - CFLAGS="-fsanitize=memory -fno-omit-frame-pointer -g"
+        - ASM=no BIGNUM=no EXTRAFLAGS="--disable-openssl-tests"
+        - EXPERIMENTAL=yes RECOVERY=yes ECDH=yes
+        - MSAN_OPTIONS=exitcode=42
+        - ENDOMORPHISM=no
+
 before_install: mkdir -p `dirname $GUAVA_JAR`
 install: if [ ! -f $GUAVA_JAR ]; then wget $GUAVA_URL -O $GUAVA_JAR; fi
 before_script: ./autogen.sh


### PR DESCRIPTION
In #558 there was an unintialized memory read (in the tests). This happened in all travis test configs but only a single test configuration produced an error in a verify check. In order to catch issues with uninitialized memory reliably, this PR adds a test configuration with the clang memory sanitizer to travis. The memory sanitizer errors out when running with the unfixed schnorrsig PR.

The result of running this PR with an additional commit that adds an uninitialized memory can be viewed at https://travis-ci.org/jonasnick/secp256k1/jobs/607352962
