### PR TITLE
Add valgrind check to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,10 +61,21 @@ matrix:
           packages:
             - gcc-multilib
             - libgmp-dev:i386
+    - compiler: gcc
+      env:
+        - FIELD=auto  BIGNUM=no  SCALAR=auto  ENDOMORPHISM=yes  STATICPRECOMPUTATION=yes  ASM=x86_64
+        - EXPERIMENTAL=no ECDH=no  RECOVERY=no VALGRIND=yes EXTRAFLAGS="--disable-openssl-tests CPPFLAGS=-DVALGRIND"  HOST= BUILD= JNI=no
+      addons:
+        apt:
+          packages:
+            - valgrind
+    
 before_install: mkdir -p `dirname $GUAVA_JAR`
 install: if [ ! -f $GUAVA_JAR ]; then wget $GUAVA_URL -O $GUAVA_JAR; fi
 before_script: ./autogen.sh
 script:
  - if [ -n "$HOST" ]; then export USE_HOST="--host=$HOST"; fi
  - if [ "x$HOST" = "xi686-linux-gnu" ]; then export CC="$CC -m32"; fi
- - ./configure --enable-experimental=$EXPERIMENTAL --enable-endomorphism=$ENDOMORPHISM --with-field=$FIELD --with-bignum=$BIGNUM --with-asm=$ASM --with-scalar=$SCALAR --enable-ecmult-static-precomputation=$STATICPRECOMPUTATION --with-ecmult-gen-precision=$ECMULTGENPRECISION --enable-module-ecdh=$ECDH --enable-module-recovery=$RECOVERY --enable-jni=$JNI $EXTRAFLAGS $USE_HOST && make -j2 $BUILD
+ - ./configure --enable-experimental=$EXPERIMENTAL --enable-endomorphism=$ENDOMORPHISM --with-field=$FIELD --with-bignum=$BIGNUM --with-asm=$ASM --with-scalar=$SCALAR --enable-ecmult-static-precomputation=$STATICPRECOMPUTATION --with-ecmult-gen-precision=$ECMULTGENPRECISION --enable-module-ecdh=$ECDH --enable-module-recovery=$RECOVERY --enable-jni=$JNI $EXTRAFLAGS $USE_HOST
+ - if [ -n "$BUILD" ]; then make -j2 $BUILD; fi
+ - if [ -n "$VALGRIND" ]; then make -j2 && travis_wait 30 valgrind --error-exitcode=42 ./tests 8; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,16 @@ matrix:
             - libgmp-dev:i386
     - compiler: gcc
       env:
-        - FIELD=auto  BIGNUM=no  SCALAR=auto  ENDOMORPHISM=yes  STATICPRECOMPUTATION=yes  ASM=x86_64
-        - EXPERIMENTAL=no ECDH=no  RECOVERY=no VALGRIND=yes EXTRAFLAGS="--disable-openssl-tests CPPFLAGS=-DVALGRIND"  HOST= BUILD= JNI=no
+        - BIGNUM=no  ENDOMORPHISM=yes  ASM=x86_64 EXPERIMENTAL=yes ECDH=yes  RECOVERY=yes
+        - VALGRIND=yes EXTRAFLAGS="--disable-openssl-tests CPPFLAGS=-DVALGRIND" BUILD=
+      addons:
+        apt:
+          packages:
+            - valgrind
+    - compiler: gcc
+      env: # The same as above but without endomorphism.
+        - BIGNUM=no  ENDOMORPHISM=no  ASM=x86_64 EXPERIMENTAL=yes ECDH=yes  RECOVERY=yes
+        - VALGRIND=yes EXTRAFLAGS="--disable-openssl-tests CPPFLAGS=-DVALGRIND" BUILD=
       addons:
         apt:
           packages:
@@ -73,9 +81,16 @@ matrix:
 before_install: mkdir -p `dirname $GUAVA_JAR`
 install: if [ ! -f $GUAVA_JAR ]; then wget $GUAVA_URL -O $GUAVA_JAR; fi
 before_script: ./autogen.sh
+
 script:
  - if [ -n "$HOST" ]; then export USE_HOST="--host=$HOST"; fi
  - if [ "x$HOST" = "xi686-linux-gnu" ]; then export CC="$CC -m32"; fi
  - ./configure --enable-experimental=$EXPERIMENTAL --enable-endomorphism=$ENDOMORPHISM --with-field=$FIELD --with-bignum=$BIGNUM --with-asm=$ASM --with-scalar=$SCALAR --enable-ecmult-static-precomputation=$STATICPRECOMPUTATION --with-ecmult-gen-precision=$ECMULTGENPRECISION --enable-module-ecdh=$ECDH --enable-module-recovery=$RECOVERY --enable-jni=$JNI $EXTRAFLAGS $USE_HOST
  - if [ -n "$BUILD" ]; then make -j2 $BUILD; fi
- - if [ -n "$VALGRIND" ]; then make -j2 && travis_wait 30 valgrind --error-exitcode=42 ./tests 8; fi
+ - # travis_wait extends the 10 minutes without output allowed (https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received)
+ - # the `--error-exitcode` is required to make the test fail if valgrind found errors, otherwise it'll return 0 (http://valgrind.org/docs/manual/manual-core.html)
+ - if [ -n "$VALGRIND" ]; then
+   make -j2 &&
+   travis_wait 30 valgrind --error-exitcode=42 ./tests 16 &&
+   travis_wait 30 valgrind --error-exitcode=42 ./exhaustive_tests;
+   fi 


### PR DESCRIPTION
As discussed in https://github.com/bitcoin-core/secp256k1/pull/687
This adds valgrind check to the repo.

It doesn't run on recovery+ecdh because of the time.
No openssl because of uninitialized mem.
I debated between with and without ASM, but decided with ASM because it might be more fragile(?).

I wasn't sure if I should pass `-DVALGRIND` via `CFLAGS` or `CPPFLAGS`, it seems like because this is only C then there shouldn't even be `CPPFLAGS` but looks like we use `CPPFLAGS` in other places for the preprocessor definitions.

If people are worried about the time it takes we can mark it as `allow_failure` although I don't think it's a problem here because there's only a handful of PRs and they're usually open for weeks.
