### PR TITLE
Clarify that a secp256k1_ecdh_hash_function must return 0 or 1

### DIFF
--- a/include/secp256k1_ecdh.h
+++ b/include/secp256k1_ecdh.h
@@ -7,18 +7,21 @@
 extern "C" {
 #endif
 
-/** A pointer to a function that applies hash function to a point
+/** A pointer to a function that hashes an EC point to obtain an ECDH secret
  *
- *  Returns: 1 if a point was successfully hashed. 0 will cause ecdh to fail
- *  Out:    output:     pointer to an array to be filled by the function
- *  In:     x:          pointer to a 32-byte x coordinate
- *          y:          pointer to a 32-byte y coordinate
- *          data:       Arbitrary data pointer that is passed through
+ *  Returns: 1 if the point was successfully hashed.
+ *           0 will cause secp256k1_ecdh to fail and return 0.
+ *           Other return values are not allowed, and the behaviour of
+ *           secp256k1_ecdh is undefined for other return values.
+ *  Out:     output:     pointer to an array to be filled by the function
+ *  In:      x32:        pointer to a 32-byte x coordinate
+ *           y32:        pointer to a 32-byte y coordinate
+ *           data:       arbitrary data pointer that is passed through
  */
 typedef int (*secp256k1_ecdh_hash_function)(
   unsigned char *output,
-  const unsigned char *x,
-  const unsigned char *y,
+  const unsigned char *x32,
+  const unsigned char *y32,
   void *data
 );
 
@@ -26,13 +29,14 @@ typedef int (*secp256k1_ecdh_hash_function)(
  * Populates the output parameter with 32 bytes. */
 SECP256K1_API extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_sha256;
 
-/** A default ecdh hash function (currently equal to secp256k1_ecdh_hash_function_sha256).
+/** A default ECDH hash function (currently equal to secp256k1_ecdh_hash_function_sha256).
  * Populates the output parameter with 32 bytes. */
 SECP256K1_API extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_default;
 
 /** Compute an EC Diffie-Hellman secret in constant time
+ *
  *  Returns: 1: exponentiation was successful
- *           0: scalar was invalid (zero or overflow)
+ *           0: scalar was invalid (zero or overflow) or hashfp returned 0
  *  Args:    ctx:        pointer to a context object (cannot be NULL)
  *  Out:     output:     pointer to an array to be filled by hashfp
  *  In:      pubkey:     a pointer to a secp256k1_pubkey containing an
@@ -40,7 +44,7 @@ SECP256K1_API extern const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_func
  *           privkey:    a 32-byte scalar with which to multiply the point
  *           hashfp:     pointer to a hash function. If NULL, secp256k1_ecdh_hash_function_sha256 is used
  *                       (in which case, 32 bytes will be written to output)
- *           data:       Arbitrary data pointer that is passed through to hashfp
+ *           data:       arbitrary data pointer that is passed through to hashfp
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh(
   const secp256k1_context* ctx,

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -10,14 +10,14 @@
 #include "include/secp256k1_ecdh.h"
 #include "ecmult_const_impl.h"
 
-static int ecdh_hash_function_sha256(unsigned char *output, const unsigned char *x, const unsigned char *y, void *data) {
-    unsigned char version = (y[31] & 0x01) | 0x02;
+static int ecdh_hash_function_sha256(unsigned char *output, const unsigned char *x32, const unsigned char *y32, void *data) {
+    unsigned char version = (y32[31] & 0x01) | 0x02;
     secp256k1_sha256 sha;
     (void)data;
 
     secp256k1_sha256_initialize(&sha);
     secp256k1_sha256_write(&sha, &version, 1);
-    secp256k1_sha256_write(&sha, x, 32);
+    secp256k1_sha256_write(&sha, x32, 32);
     secp256k1_sha256_finalize(&sha, output);
 
     return 1;


### PR DESCRIPTION
and improve style of the ECDH docs.