### PR TITLE
Context isn't freed in the ECDH benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler:
   - gcc
 env:
   global:
-    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  STATICPRECOMPUTATION=yes  ECMULTGENPRECISION=auto  ASM=no  BUILD=check  EXTRAFLAGS=  HOST=  ECDH=no  RECOVERY=no  EXPERIMENTAL=no CTIMETEST=yes
+    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  STATICPRECOMPUTATION=yes  ECMULTGENPRECISION=auto  ASM=no  BUILD=check  EXTRAFLAGS=  HOST=  ECDH=no  RECOVERY=no  EXPERIMENTAL=no CTIMETEST=yes BENCH=yes SECP256K1_BENCH_ITERS=2
   matrix:
     - SCALAR=32bit    RECOVERY=yes
     - SCALAR=32bit    FIELD=32bit       ECDH=yes  EXPERIMENTAL=yes
@@ -25,7 +25,7 @@ env:
     - BIGNUM=no
     - BIGNUM=no       ENDOMORPHISM=yes RECOVERY=yes EXPERIMENTAL=yes
     - BIGNUM=no       STATICPRECOMPUTATION=no
-    - BUILD=distcheck CTIMETEST=
+    - BUILD=distcheck CTIMETEST= BENCH=
     - EXTRAFLAGS=CPPFLAGS=-DDETERMINISTIC
     - EXTRAFLAGS=CFLAGS=-O0
     - ECMULTGENPRECISION=2
@@ -94,6 +94,12 @@ script:
    travis_wait 30 valgrind --error-exitcode=42 ./tests 16 &&
    travis_wait 30 valgrind --error-exitcode=42 ./exhaustive_tests;
    fi
+ - if [ -n "$BENCH" ]; then
+     if [ -n "$VALGRIND" ]; then EXEC='libtool --mode=execute valgrind --error-exitcode=42'; else EXEC= ; fi &&
+     $EXEC ./bench_ecmult &>> bench.log && $EXEC ./bench_internal &>> bench.log && $EXEC ./bench_sign &>> bench.log && $EXEC ./bench_verify &>> bench.log &&
+     if [ "$RECOVERY" == "yes" ]; then $EXEC ./bench_recover &>> bench.log; fi &&
+     if [ "$ECDH" == "yes" ]; then $EXEC ./bench_ecdh &>> bench.log; fi;
+   fi
  - if [ -n "$CTIMETEST" ]; then
    libtool --mode=execute valgrind  ./valgrind_ctime_test &> valgrind_ctime_test.log;
    fi
@@ -102,3 +108,4 @@ after_script:
     - cat ./tests.log
     - cat ./exhaustive_tests.log
     - cat ./valgrind_ctime_test.log
+    - cat ./bench.log

--- a/src/bench.h
+++ b/src/bench.h
@@ -73,7 +73,7 @@ void print_number(const int64_t x) {
     printf("%s", &buffer[ptr]);
 }
 
-void run_benchmark(char *name, void (*benchmark)(void*), void (*setup)(void*), void (*teardown)(void*), void* data, int count, int iter) {
+void run_benchmark(char *name, void (*benchmark)(void*, int), void (*setup)(void*), void (*teardown)(void*, int), void* data, int count, int iter) {
     int i;
     int64_t min = INT64_MAX;
     int64_t sum = 0;
@@ -84,10 +84,10 @@ void run_benchmark(char *name, void (*benchmark)(void*), void (*setup)(void*), v
             setup(data);
         }
         begin = gettime_i64();
-        benchmark(data);
+        benchmark(data, iter);
         total = gettime_i64() - begin;
         if (teardown != NULL) {
-            teardown(data);
+            teardown(data, iter);
         }
         if (total < min) {
             min = total;
@@ -119,6 +119,15 @@ int have_flag(int argc, char** argv, char *flag) {
         argv++;
     }
     return 0;
+}
+
+int get_iters(int default_iters) {
+    char* env = getenv("SECP256K1_BENCH_ITERS");
+    if (env) {
+        return strtol(env, NULL, 0);
+    } else {
+        return default_iters;
+    }
 }
 
 #endif /* SECP256K1_BENCH_H */

--- a/src/bench_ecdh.c
+++ b/src/bench_ecdh.c
@@ -28,8 +28,6 @@ static void bench_ecdh_setup(void* arg) {
         0xa2, 0xba, 0xd1, 0x84, 0xf8, 0x83, 0xc6, 0x9f
     };
 
-    /* create a context with no capabilities */
-    data->ctx = secp256k1_context_create(SECP256K1_FLAGS_TYPE_CONTEXT);
     for (i = 0; i < 32; i++) {
         data->scalar[i] = i + 1;
     }
@@ -49,6 +47,11 @@ static void bench_ecdh(void* arg) {
 int main(void) {
     bench_ecdh_data data;
 
+    /* create a context with no capabilities */
+    data.ctx = secp256k1_context_create(SECP256K1_FLAGS_TYPE_CONTEXT);
+
     run_benchmark("ecdh", bench_ecdh, bench_ecdh_setup, NULL, &data, 10, 20000);
+
+    secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/src/bench_ecdh.c
+++ b/src/bench_ecdh.c
@@ -34,12 +34,12 @@ static void bench_ecdh_setup(void* arg) {
     CHECK(secp256k1_ec_pubkey_parse(data->ctx, &data->point, point, sizeof(point)) == 1);
 }
 
-static void bench_ecdh(void* arg) {
+static void bench_ecdh(void* arg, int iters) {
     int i;
     unsigned char res[32];
     bench_ecdh_data *data = (bench_ecdh_data*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         CHECK(secp256k1_ecdh(data->ctx, res, &data->point, data->scalar, NULL, NULL) == 1);
     }
 }
@@ -47,10 +47,12 @@ static void bench_ecdh(void* arg) {
 int main(void) {
     bench_ecdh_data data;
 
+    int iters = get_iters(20000);
+
     /* create a context with no capabilities */
     data.ctx = secp256k1_context_create(SECP256K1_FLAGS_TYPE_CONTEXT);
 
-    run_benchmark("ecdh", bench_ecdh, bench_ecdh_setup, NULL, &data, 10, 20000);
+    run_benchmark("ecdh", bench_ecdh, bench_ecdh_setup, NULL, &data, 10, iters);
 
     secp256k1_context_destroy(data.ctx);
     return 0;

--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -18,7 +18,6 @@
 #include "secp256k1.c"
 
 #define POINTS 32768
-#define ITERS 10000
 
 typedef struct {
     /* Setup once in advance */
@@ -55,13 +54,13 @@ static int bench_callback(secp256k1_scalar* sc, secp256k1_ge* ge, size_t idx, vo
     return 1;
 }
 
-static void bench_ecmult(void* arg) {
+static void bench_ecmult(void* arg, int iters) {
     bench_data* data = (bench_data*)arg;
 
-    size_t count = data->count;
     int includes_g = data->includes_g;
-    size_t iters = 1 + ITERS / count;
-    size_t iter;
+    int iter;
+    int count = data->count;
+    iters = iters / data->count;
 
     for (iter = 0; iter < iters; ++iter) {
         data->ecmult_multi(&data->ctx->error_callback, &data->ctx->ecmult_ctx, data->scratch, &data->output[iter], data->includes_g ? &data->scalars[data->offset1] : NULL, bench_callback, arg, count - includes_g);
@@ -76,10 +75,10 @@ static void bench_ecmult_setup(void* arg) {
     data->offset2 = (data->count * 0x7f6f537b + 0x6a1a8f49) % POINTS;
 }
 
-static void bench_ecmult_teardown(void* arg) {
+static void bench_ecmult_teardown(void* arg, int iters) {
     bench_data* data = (bench_data*)arg;
-    size_t iters = 1 + ITERS / data->count;
-    size_t iter;
+    int iter;
+    iters = iters / data->count;
     /* Verify the results in teardown, to avoid doing comparisons while benchmarking. */
     for (iter = 0; iter < iters; ++iter) {
         secp256k1_gej tmp;
@@ -104,10 +103,10 @@ static void generate_scalar(uint32_t num, secp256k1_scalar* scalar) {
     CHECK(!overflow);
 }
 
-static void run_test(bench_data* data, size_t count, int includes_g) {
+static void run_test(bench_data* data, size_t count, int includes_g, int num_iters) {
     char str[32];
     static const secp256k1_scalar zero = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
-    size_t iters = 1 + ITERS / count;
+    size_t iters = 1 + num_iters / count;
     size_t iter;
 
     data->count = count;
@@ -130,7 +129,7 @@ static void run_test(bench_data* data, size_t count, int includes_g) {
 
     /* Run the benchmark. */
     sprintf(str, includes_g ? "ecmult_%ig" : "ecmult_%i", (int)count);
-    run_benchmark(str, bench_ecmult, bench_ecmult_setup, bench_ecmult_teardown, data, 10, count * (1 + ITERS / count));
+    run_benchmark(str, bench_ecmult, bench_ecmult_setup, bench_ecmult_teardown, data, 10, count * iters);
 }
 
 int main(int argc, char **argv) {
@@ -138,6 +137,8 @@ int main(int argc, char **argv) {
     int i, p;
     secp256k1_gej* pubkeys_gej;
     size_t scratch_size;
+
+    int iters = get_iters(10000);
 
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     scratch_size = secp256k1_strauss_scratch_size(POINTS) + STRAUSS_SCRATCH_OBJECTS*16;
@@ -167,8 +168,8 @@ int main(int argc, char **argv) {
     data.scalars = malloc(sizeof(secp256k1_scalar) * POINTS);
     data.seckeys = malloc(sizeof(secp256k1_scalar) * POINTS);
     data.pubkeys = malloc(sizeof(secp256k1_ge) * POINTS);
-    data.expected_output = malloc(sizeof(secp256k1_gej) * (ITERS + 1));
-    data.output = malloc(sizeof(secp256k1_gej) * (ITERS + 1));
+    data.expected_output = malloc(sizeof(secp256k1_gej) * (iters + 1));
+    data.output = malloc(sizeof(secp256k1_gej) * (iters + 1));
 
     /* Generate a set of scalars, and private/public keypairs. */
     pubkeys_gej = malloc(sizeof(secp256k1_gej) * POINTS);
@@ -185,14 +186,20 @@ int main(int argc, char **argv) {
     free(pubkeys_gej);
 
     for (i = 1; i <= 8; ++i) {
-        run_test(&data, i, 1);
+        run_test(&data, i, 1, iters);
     }
 
-    for (p = 0; p <= 11; ++p) {
-        for (i = 9; i <= 16; ++i) {
-            run_test(&data, i << p, 1);
+    /* This is disabled with low count of iterations because the loop runs 77 times even with iters=1
+    * and the higher it goes the longer the computation takes(more points)
+    * So we don't run this benchmark with low iterations to prevent slow down */
+     if (iters > 2) {
+        for (p = 0; p <= 11; ++p) {
+            for (i = 9; i <= 16; ++i) {
+                run_test(&data, i << p, 1, iters);
+            }
         }
     }
+
     if (data.scratch != NULL) {
         secp256k1_scratch_space_destroy(data.ctx, data.scratch);
     }

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -56,271 +56,271 @@ void bench_setup(void* arg) {
     memcpy(data->data + 32, init_y, 32);
 }
 
-void bench_scalar_add(void* arg) {
+void bench_scalar_add(void* arg, int iters) {
     int i, j = 0;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 2000000; i++) {
+    for (i = 0; i < iters; i++) {
         j += secp256k1_scalar_add(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }
-    CHECK(j <= 2000000);
+    CHECK(j <= iters);
 }
 
-void bench_scalar_negate(void* arg) {
+void bench_scalar_negate(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 2000000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_scalar_negate(&data->scalar_x, &data->scalar_x);
     }
 }
 
-void bench_scalar_sqr(void* arg) {
+void bench_scalar_sqr(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_scalar_sqr(&data->scalar_x, &data->scalar_x);
     }
 }
 
-void bench_scalar_mul(void* arg) {
+void bench_scalar_mul(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_scalar_mul(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }
 }
 
 #ifdef USE_ENDOMORPHISM
-void bench_scalar_split(void* arg) {
+void bench_scalar_split(void* arg, int iters) {
     int i, j = 0;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_scalar_split_lambda(&data->scalar_x, &data->scalar_y, &data->scalar_x);
         j += secp256k1_scalar_add(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }
-    CHECK(j <= 20000);
+    CHECK(j <= iters);
 }
 #endif
 
-void bench_scalar_inverse(void* arg) {
+void bench_scalar_inverse(void* arg, int iters) {
     int i, j = 0;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 2000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_scalar_inverse(&data->scalar_x, &data->scalar_x);
         j += secp256k1_scalar_add(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }
-    CHECK(j <= 2000);
+    CHECK(j <= iters);
 }
 
-void bench_scalar_inverse_var(void* arg) {
+void bench_scalar_inverse_var(void* arg, int iters) {
     int i, j = 0;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 2000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_scalar_inverse_var(&data->scalar_x, &data->scalar_x);
         j += secp256k1_scalar_add(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }
-    CHECK(j <= 2000);
+    CHECK(j <= iters);
 }
 
-void bench_field_normalize(void* arg) {
+void bench_field_normalize(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 2000000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_fe_normalize(&data->fe_x);
     }
 }
 
-void bench_field_normalize_weak(void* arg) {
+void bench_field_normalize_weak(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 2000000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_fe_normalize_weak(&data->fe_x);
     }
 }
 
-void bench_field_mul(void* arg) {
+void bench_field_mul(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_fe_mul(&data->fe_x, &data->fe_x, &data->fe_y);
     }
 }
 
-void bench_field_sqr(void* arg) {
+void bench_field_sqr(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_fe_sqr(&data->fe_x, &data->fe_x);
     }
 }
 
-void bench_field_inverse(void* arg) {
+void bench_field_inverse(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_fe_inv(&data->fe_x, &data->fe_x);
         secp256k1_fe_add(&data->fe_x, &data->fe_y);
     }
 }
 
-void bench_field_inverse_var(void* arg) {
+void bench_field_inverse_var(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_fe_inv_var(&data->fe_x, &data->fe_x);
         secp256k1_fe_add(&data->fe_x, &data->fe_y);
     }
 }
 
-void bench_field_sqrt(void* arg) {
+void bench_field_sqrt(void* arg, int iters) {
     int i, j = 0;
     bench_inv *data = (bench_inv*)arg;
     secp256k1_fe t;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         t = data->fe_x;
         j += secp256k1_fe_sqrt(&data->fe_x, &t);
         secp256k1_fe_add(&data->fe_x, &data->fe_y);
     }
-    CHECK(j <= 20000);
+    CHECK(j <= iters);
 }
 
-void bench_group_double_var(void* arg) {
+void bench_group_double_var(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_gej_double_var(&data->gej_x, &data->gej_x, NULL);
     }
 }
 
-void bench_group_add_var(void* arg) {
+void bench_group_add_var(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_gej_add_var(&data->gej_x, &data->gej_x, &data->gej_y, NULL);
     }
 }
 
-void bench_group_add_affine(void* arg) {
+void bench_group_add_affine(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_gej_add_ge(&data->gej_x, &data->gej_x, &data->ge_y);
     }
 }
 
-void bench_group_add_affine_var(void* arg) {
+void bench_group_add_affine_var(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_gej_add_ge_var(&data->gej_x, &data->gej_x, &data->ge_y, NULL);
     }
 }
 
-void bench_group_jacobi_var(void* arg) {
+void bench_group_jacobi_var(void* arg, int iters) {
     int i, j = 0;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         j += secp256k1_gej_has_quad_y_var(&data->gej_x);
     }
-    CHECK(j == 20000);
+    CHECK(j == iters);
 }
 
-void bench_ecmult_wnaf(void* arg) {
+void bench_ecmult_wnaf(void* arg, int iters) {
     int i, bits = 0, overflow = 0;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         bits += secp256k1_ecmult_wnaf(data->wnaf, 256, &data->scalar_x, WINDOW_A);
         overflow += secp256k1_scalar_add(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }
     CHECK(overflow >= 0);
-    CHECK(bits <= 256*20000);
+    CHECK(bits <= 256*iters);
 }
 
-void bench_wnaf_const(void* arg) {
+void bench_wnaf_const(void* arg, int iters) {
     int i, bits = 0, overflow = 0;
     bench_inv *data = (bench_inv*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         bits += secp256k1_wnaf_const(data->wnaf, &data->scalar_x, WINDOW_A, 256);
         overflow += secp256k1_scalar_add(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }
     CHECK(overflow >= 0);
-    CHECK(bits <= 256*20000);
+    CHECK(bits <= 256*iters);
 }
 
 
-void bench_sha256(void* arg) {
+void bench_sha256(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
     secp256k1_sha256 sha;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_sha256_initialize(&sha);
         secp256k1_sha256_write(&sha, data->data, 32);
         secp256k1_sha256_finalize(&sha, data->data);
     }
 }
 
-void bench_hmac_sha256(void* arg) {
+void bench_hmac_sha256(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
     secp256k1_hmac_sha256 hmac;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_hmac_sha256_initialize(&hmac, data->data, 32);
         secp256k1_hmac_sha256_write(&hmac, data->data, 32);
         secp256k1_hmac_sha256_finalize(&hmac, data->data);
     }
 }
 
-void bench_rfc6979_hmac_sha256(void* arg) {
+void bench_rfc6979_hmac_sha256(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
     secp256k1_rfc6979_hmac_sha256 rng;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_rfc6979_hmac_sha256_initialize(&rng, data->data, 64);
         secp256k1_rfc6979_hmac_sha256_generate(&rng, data->data, 32);
     }
 }
 
-void bench_context_verify(void* arg) {
+void bench_context_verify(void* arg, int iters) {
     int i;
     (void)arg;
-    for (i = 0; i < 20; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_context_destroy(secp256k1_context_create(SECP256K1_CONTEXT_VERIFY));
     }
 }
 
-void bench_context_sign(void* arg) {
+void bench_context_sign(void* arg, int iters) {
     int i;
     (void)arg;
-    for (i = 0; i < 200; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_context_destroy(secp256k1_context_create(SECP256K1_CONTEXT_SIGN));
     }
 }
 
 #ifndef USE_NUM_NONE
-void bench_num_jacobi(void* arg) {
+void bench_num_jacobi(void* arg, int iters) {
     int i, j = 0;
     bench_inv *data = (bench_inv*)arg;
     secp256k1_num nx, norder;
@@ -329,51 +329,53 @@ void bench_num_jacobi(void* arg) {
     secp256k1_scalar_order_get_num(&norder);
     secp256k1_scalar_get_num(&norder, &data->scalar_y);
 
-    for (i = 0; i < 200000; i++) {
+    for (i = 0; i < iters; i++) {
         j += secp256k1_num_jacobi(&nx, &norder);
     }
-    CHECK(j <= 200000);
+    CHECK(j <= iters);
 }
 #endif
 
 int main(int argc, char **argv) {
     bench_inv data;
-    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "add")) run_benchmark("scalar_add", bench_scalar_add, bench_setup, NULL, &data, 10, 2000000);
-    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "negate")) run_benchmark("scalar_negate", bench_scalar_negate, bench_setup, NULL, &data, 10, 2000000);
-    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "sqr")) run_benchmark("scalar_sqr", bench_scalar_sqr, bench_setup, NULL, &data, 10, 200000);
-    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "mul")) run_benchmark("scalar_mul", bench_scalar_mul, bench_setup, NULL, &data, 10, 200000);
+    int iters = get_iters(20000);
+
+    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "add")) run_benchmark("scalar_add", bench_scalar_add, bench_setup, NULL, &data, 10, iters*100);
+    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "negate")) run_benchmark("scalar_negate", bench_scalar_negate, bench_setup, NULL, &data, 10, iters*100);
+    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "sqr")) run_benchmark("scalar_sqr", bench_scalar_sqr, bench_setup, NULL, &data, 10, iters*10);
+    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "mul")) run_benchmark("scalar_mul", bench_scalar_mul, bench_setup, NULL, &data, 10, iters*10);
 #ifdef USE_ENDOMORPHISM
-    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "split")) run_benchmark("scalar_split", bench_scalar_split, bench_setup, NULL, &data, 10, 20000);
+    if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "split")) run_benchmark("scalar_split", bench_scalar_split, bench_setup, NULL, &data, 10, iters);
 #endif
     if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "inverse")) run_benchmark("scalar_inverse", bench_scalar_inverse, bench_setup, NULL, &data, 10, 2000);
     if (have_flag(argc, argv, "scalar") || have_flag(argc, argv, "inverse")) run_benchmark("scalar_inverse_var", bench_scalar_inverse_var, bench_setup, NULL, &data, 10, 2000);
 
-    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize", bench_field_normalize, bench_setup, NULL, &data, 10, 2000000);
-    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize_weak", bench_field_normalize_weak, bench_setup, NULL, &data, 10, 2000000);
-    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "sqr")) run_benchmark("field_sqr", bench_field_sqr, bench_setup, NULL, &data, 10, 200000);
-    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "mul")) run_benchmark("field_mul", bench_field_mul, bench_setup, NULL, &data, 10, 200000);
-    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "inverse")) run_benchmark("field_inverse", bench_field_inverse, bench_setup, NULL, &data, 10, 20000);
-    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "inverse")) run_benchmark("field_inverse_var", bench_field_inverse_var, bench_setup, NULL, &data, 10, 20000);
-    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "sqrt")) run_benchmark("field_sqrt", bench_field_sqrt, bench_setup, NULL, &data, 10, 20000);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize", bench_field_normalize, bench_setup, NULL, &data, 10, iters*100);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize_weak", bench_field_normalize_weak, bench_setup, NULL, &data, 10, iters*100);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "sqr")) run_benchmark("field_sqr", bench_field_sqr, bench_setup, NULL, &data, 10, iters*10);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "mul")) run_benchmark("field_mul", bench_field_mul, bench_setup, NULL, &data, 10, iters*10);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "inverse")) run_benchmark("field_inverse", bench_field_inverse, bench_setup, NULL, &data, 10, iters);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "inverse")) run_benchmark("field_inverse_var", bench_field_inverse_var, bench_setup, NULL, &data, 10, iters);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "sqrt")) run_benchmark("field_sqrt", bench_field_sqrt, bench_setup, NULL, &data, 10, iters);
 
-    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "double")) run_benchmark("group_double_var", bench_group_double_var, bench_setup, NULL, &data, 10, 200000);
-    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_var", bench_group_add_var, bench_setup, NULL, &data, 10, 200000);
-    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_affine", bench_group_add_affine, bench_setup, NULL, &data, 10, 200000);
-    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_affine_var", bench_group_add_affine_var, bench_setup, NULL, &data, 10, 200000);
-    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "jacobi")) run_benchmark("group_jacobi_var", bench_group_jacobi_var, bench_setup, NULL, &data, 10, 20000);
+    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "double")) run_benchmark("group_double_var", bench_group_double_var, bench_setup, NULL, &data, 10, iters*10);
+    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_var", bench_group_add_var, bench_setup, NULL, &data, 10, iters*10);
+    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_affine", bench_group_add_affine, bench_setup, NULL, &data, 10, iters*10);
+    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_affine_var", bench_group_add_affine_var, bench_setup, NULL, &data, 10, iters*10);
+    if (have_flag(argc, argv, "group") || have_flag(argc, argv, "jacobi")) run_benchmark("group_jacobi_var", bench_group_jacobi_var, bench_setup, NULL, &data, 10, iters);
 
-    if (have_flag(argc, argv, "ecmult") || have_flag(argc, argv, "wnaf")) run_benchmark("wnaf_const", bench_wnaf_const, bench_setup, NULL, &data, 10, 20000);
-    if (have_flag(argc, argv, "ecmult") || have_flag(argc, argv, "wnaf")) run_benchmark("ecmult_wnaf", bench_ecmult_wnaf, bench_setup, NULL, &data, 10, 20000);
+    if (have_flag(argc, argv, "ecmult") || have_flag(argc, argv, "wnaf")) run_benchmark("wnaf_const", bench_wnaf_const, bench_setup, NULL, &data, 10, iters);
+    if (have_flag(argc, argv, "ecmult") || have_flag(argc, argv, "wnaf")) run_benchmark("ecmult_wnaf", bench_ecmult_wnaf, bench_setup, NULL, &data, 10, iters);
 
-    if (have_flag(argc, argv, "hash") || have_flag(argc, argv, "sha256")) run_benchmark("hash_sha256", bench_sha256, bench_setup, NULL, &data, 10, 20000);
-    if (have_flag(argc, argv, "hash") || have_flag(argc, argv, "hmac")) run_benchmark("hash_hmac_sha256", bench_hmac_sha256, bench_setup, NULL, &data, 10, 20000);
-    if (have_flag(argc, argv, "hash") || have_flag(argc, argv, "rng6979")) run_benchmark("hash_rfc6979_hmac_sha256", bench_rfc6979_hmac_sha256, bench_setup, NULL, &data, 10, 20000);
+    if (have_flag(argc, argv, "hash") || have_flag(argc, argv, "sha256")) run_benchmark("hash_sha256", bench_sha256, bench_setup, NULL, &data, 10, iters);
+    if (have_flag(argc, argv, "hash") || have_flag(argc, argv, "hmac")) run_benchmark("hash_hmac_sha256", bench_hmac_sha256, bench_setup, NULL, &data, 10, iters);
+    if (have_flag(argc, argv, "hash") || have_flag(argc, argv, "rng6979")) run_benchmark("hash_rfc6979_hmac_sha256", bench_rfc6979_hmac_sha256, bench_setup, NULL, &data, 10, iters);
 
-    if (have_flag(argc, argv, "context") || have_flag(argc, argv, "verify")) run_benchmark("context_verify", bench_context_verify, bench_setup, NULL, &data, 10, 20);
-    if (have_flag(argc, argv, "context") || have_flag(argc, argv, "sign")) run_benchmark("context_sign", bench_context_sign, bench_setup, NULL, &data, 10, 200);
+    if (have_flag(argc, argv, "context") || have_flag(argc, argv, "verify")) run_benchmark("context_verify", bench_context_verify, bench_setup, NULL, &data, 10, 1 + iters/1000);
+    if (have_flag(argc, argv, "context") || have_flag(argc, argv, "sign")) run_benchmark("context_sign", bench_context_sign, bench_setup, NULL, &data, 10, 1 + iters/100);
 
 #ifndef USE_NUM_NONE
-    if (have_flag(argc, argv, "num") || have_flag(argc, argv, "jacobi")) run_benchmark("num_jacobi", bench_num_jacobi, bench_setup, NULL, &data, 10, 200000);
+    if (have_flag(argc, argv, "num") || have_flag(argc, argv, "jacobi")) run_benchmark("num_jacobi", bench_num_jacobi, bench_setup, NULL, &data, 10, iters*10);
 #endif
     return 0;
 }

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -15,13 +15,13 @@ typedef struct {
     unsigned char sig[64];
 } bench_recover_data;
 
-void bench_recover(void* arg) {
+void bench_recover(void* arg, int iters) {
     int i;
     bench_recover_data *data = (bench_recover_data*)arg;
     secp256k1_pubkey pubkey;
     unsigned char pubkeyc[33];
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         int j;
         size_t pubkeylen = 33;
         secp256k1_ecdsa_recoverable_signature sig;
@@ -51,9 +51,11 @@ void bench_recover_setup(void* arg) {
 int main(void) {
     bench_recover_data data;
 
+    int iters = get_iters(20000);
+
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
 
-    run_benchmark("ecdsa_recover", bench_recover, bench_recover_setup, NULL, &data, 10, 20000);
+    run_benchmark("ecdsa_recover", bench_recover, bench_recover_setup, NULL, &data, 10, iters);
 
     secp256k1_context_destroy(data.ctx);
     return 0;

--- a/src/bench_sign.c
+++ b/src/bench_sign.c
@@ -26,12 +26,12 @@ static void bench_sign_setup(void* arg) {
     }
 }
 
-static void bench_sign_run(void* arg) {
+static void bench_sign_run(void* arg, int iters) {
     int i;
     bench_sign *data = (bench_sign*)arg;
 
     unsigned char sig[74];
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         size_t siglen = 74;
         int j;
         secp256k1_ecdsa_signature signature;
@@ -47,9 +47,11 @@ static void bench_sign_run(void* arg) {
 int main(void) {
     bench_sign data;
 
+    int iters = get_iters(20000);
+
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
 
-    run_benchmark("ecdsa_sign", bench_sign_run, bench_sign_setup, NULL, &data, 10, 20000);
+    run_benchmark("ecdsa_sign", bench_sign_run, bench_sign_setup, NULL, &data, 10, iters);
 
     secp256k1_context_destroy(data.ctx);
     return 0;

--- a/src/bench_verify.c
+++ b/src/bench_verify.c
@@ -17,6 +17,7 @@
 #include <openssl/obj_mac.h>
 #endif
 
+
 typedef struct {
     secp256k1_context *ctx;
     unsigned char msg[32];
@@ -30,11 +31,11 @@ typedef struct {
 #endif
 } benchmark_verify_t;
 
-static void benchmark_verify(void* arg) {
+static void benchmark_verify(void* arg, int iters) {
     int i;
     benchmark_verify_t* data = (benchmark_verify_t*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         secp256k1_pubkey pubkey;
         secp256k1_ecdsa_signature sig;
         data->sig[data->siglen - 1] ^= (i & 0xFF);
@@ -50,11 +51,11 @@ static void benchmark_verify(void* arg) {
 }
 
 #ifdef ENABLE_OPENSSL_TESTS
-static void benchmark_verify_openssl(void* arg) {
+static void benchmark_verify_openssl(void* arg, int iters) {
     int i;
     benchmark_verify_t* data = (benchmark_verify_t*)arg;
 
-    for (i = 0; i < 20000; i++) {
+    for (i = 0; i < iters; i++) {
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
@@ -85,6 +86,8 @@ int main(void) {
     secp256k1_ecdsa_signature sig;
     benchmark_verify_t data;
 
+    int iters = get_iters(20000);
+
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
     for (i = 0; i < 32; i++) {
@@ -100,10 +103,10 @@ int main(void) {
     data.pubkeylen = 33;
     CHECK(secp256k1_ec_pubkey_serialize(data.ctx, data.pubkey, &data.pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
 
-    run_benchmark("ecdsa_verify", benchmark_verify, NULL, NULL, &data, 10, 20000);
+    run_benchmark("ecdsa_verify", benchmark_verify, NULL, NULL, &data, 10, iters);
 #ifdef ENABLE_OPENSSL_TESTS
     data.ec_group = EC_GROUP_new_by_curve_name(NID_secp256k1);
-    run_benchmark("ecdsa_verify_openssl", benchmark_verify_openssl, NULL, NULL, &data, 10, 20000);
+    run_benchmark("ecdsa_verify_openssl", benchmark_verify_openssl, NULL, NULL, &data, 10, iters);
     EC_GROUP_free(data.ec_group);
 #endif
 


### PR DESCRIPTION
Hi,
Currently the context is leaked in `bench_ecdh`.
Wanted to prevent this happening in the future by adding it to the valgrind run in travis.
for that I made `run_benchmark` pass the number of iterations as a variable into the benchmarks so that the iteration number it uses to print results actually matches the one used in the benchmark.
and added a way to pass `-DITERS=N` to change the baseline number of iterations used in the benchmarks(so that we can run the benchmarks with `ITERS=1` under travis to make sure they compile, run, don't leak or have UB)
