### PR TITLE
Add valgrind constant-time test to `make check`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ libtool
 *.lo
 *.o
 *~
+*.log
+*.trs
 src/libsecp256k1-config.h
 src/libsecp256k1-config.h.in
 src/ecmult_static_context.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
     packages:
       - libgmp-dev
       - valgrind
-      - libtool-bin
 compiler:
   - clang
   - gcc
@@ -41,7 +40,6 @@ matrix:
             - gcc-multilib
             - libgmp-dev:i386
             - valgrind
-            - libtool-bin
             - libc6-dbg:i386
     - compiler: clang
       env: HOST=i686-linux-gnu
@@ -50,7 +48,6 @@ matrix:
           packages:
             - gcc-multilib
             - valgrind
-            - libtool-bin
             - libc6-dbg:i386
     - compiler: gcc
       env: HOST=i686-linux-gnu ENDOMORPHISM=yes
@@ -59,7 +56,6 @@ matrix:
           packages:
             - gcc-multilib
             - valgrind
-            - libtool-bin
             - libc6-dbg:i386
     - compiler: gcc
       env: HOST=i686-linux-gnu
@@ -69,7 +65,6 @@ matrix:
             - gcc-multilib
             - libgmp-dev:i386
             - valgrind
-            - libtool-bin
             - libc6-dbg:i386
     - compiler: gcc
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler:
   - gcc
 env:
   global:
-    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  STATICPRECOMPUTATION=yes  ECMULTGENPRECISION=auto  ASM=no  BUILD=check  EXTRAFLAGS=  HOST=  ECDH=no  RECOVERY=no  EXPERIMENTAL=no CTIMETEST=yes BENCH=yes SECP256K1_BENCH_ITERS=2
+    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  STATICPRECOMPUTATION=yes  ECMULTGENPRECISION=auto  ASM=no  BUILD=check  EXTRAFLAGS=  HOST=  ECDH=no  RECOVERY=no  EXPERIMENTAL=no BENCH=yes SECP256K1_BENCH_ITERS=2
   matrix:
     - SCALAR=32bit    RECOVERY=yes
     - SCALAR=32bit    FIELD=32bit       ECDH=yes  EXPERIMENTAL=yes
@@ -25,7 +25,7 @@ env:
     - BIGNUM=no
     - BIGNUM=no       ENDOMORPHISM=yes RECOVERY=yes EXPERIMENTAL=yes
     - BIGNUM=no       STATICPRECOMPUTATION=no
-    - BUILD=distcheck CTIMETEST= BENCH=
+    - BUILD=distcheck BENCH=
     - EXTRAFLAGS=CPPFLAGS=-DDETERMINISTIC
     - EXTRAFLAGS=CFLAGS=-O0
     - ECMULTGENPRECISION=2
@@ -87,6 +87,8 @@ script:
  - if [ "x$HOST" = "xi686-linux-gnu" ]; then export CC="$CC -m32"; fi
  - ./configure --enable-experimental=$EXPERIMENTAL --enable-endomorphism=$ENDOMORPHISM --with-field=$FIELD --with-bignum=$BIGNUM --with-asm=$ASM --with-scalar=$SCALAR --enable-ecmult-static-precomputation=$STATICPRECOMPUTATION --with-ecmult-gen-precision=$ECMULTGENPRECISION --enable-module-ecdh=$ECDH --enable-module-recovery=$RECOVERY $EXTRAFLAGS $USE_HOST
  - if [ -n "$BUILD" ]; then make -j2 $BUILD; fi
+ - # Verify that `make check` has not skipped any tests, which should never happen on Travis.
+ - grep --quiet '^# SKIP. *0$' test-suite.log
  - # travis_wait extends the 10 minutes without output allowed (https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received)
  - # the `--error-exitcode` is required to make the test fail if valgrind found errors, otherwise it'll return 0 (http://valgrind.org/docs/manual/manual-core.html)
  - if [ -n "$VALGRIND" ]; then
@@ -100,12 +102,10 @@ script:
      if [ "$RECOVERY" == "yes" ]; then $EXEC ./bench_recover &>> bench.log; fi &&
      if [ "$ECDH" == "yes" ]; then $EXEC ./bench_ecdh &>> bench.log; fi;
    fi
- - if [ -n "$CTIMETEST" ]; then
-   libtool --mode=execute valgrind  ./valgrind_ctime_test &> valgrind_ctime_test.log;
-   fi
 
 after_script:
+    - cat ./test-suite.log
     - cat ./tests.log
     - cat ./exhaustive_tests.log
-    - cat ./valgrind_ctime_test.log
+    - cat ./valgrind_ctime_test.sh.log
     - cat ./bench.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,7 @@ tests_CPPFLAGS = -DSECP256K1_BUILD -I$(top_srcdir)/src -I$(top_srcdir)/include $
 if VALGRIND_ENABLED
 tests_CPPFLAGS += -DVALGRIND
 noinst_PROGRAMS += valgrind_ctime_test
+TESTS += valgrind_ctime_test.sh
 valgrind_ctime_test_SOURCES = src/valgrind_ctime_test.c
 valgrind_ctime_test_LDADD = libsecp256k1.la $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB)
 endif
@@ -141,7 +142,7 @@ src/ecmult_static_context.h: $(gen_context_BIN)
 CLEANFILES = $(gen_context_BIN) src/ecmult_static_context.h
 endif
 
-EXTRA_DIST = autogen.sh src/gen_context.c src/basic-config.h
+EXTRA_DIST = autogen.sh valgrind_ctime_test.sh src/gen_context.c src/basic-config.h
 
 if ENABLE_MODULE_ECDH
 include src/modules/ecdh/Makefile.am.include

--- a/src/valgrind_ctime_test.c
+++ b/src/valgrind_ctime_test.c
@@ -27,7 +27,7 @@ int main(void) {
 
     if (!RUNNING_ON_VALGRIND) {
         fprintf(stderr, "This test can only usefully be run inside valgrind.\n");
-        fprintf(stderr, "Usage: libtool --mode=execute valgrind ./valgrind_ctime_test\n");
+        fprintf(stderr, "Usage: ./libtool --mode=execute valgrind ./valgrind_ctime_test\n");
         exit(99); /* indicates "ERROR" in make check */
     }
 

--- a/src/valgrind_ctime_test.c
+++ b/src/valgrind_ctime_test.c
@@ -28,7 +28,7 @@ int main(void) {
     if (!RUNNING_ON_VALGRIND) {
         fprintf(stderr, "This test can only usefully be run inside valgrind.\n");
         fprintf(stderr, "Usage: libtool --mode=execute valgrind ./valgrind_ctime_test\n");
-        exit(1);
+        exit(99); /* indicates "ERROR" in make check */
     }
 
     /** In theory, testing with a single secret input should be sufficient:

--- a/valgrind_ctime_test.sh
+++ b/valgrind_ctime_test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+libtool --mode=execute valgrind --error-exitcode=1 ./valgrind_ctime_test "$@"
+ret=$?
+
+case $ret in
+    127) # "command not found", i.e., either libtool or valgrind not installed
+        exit 77 # map this to "SKIP" (=77) for make check
+        ;;
+    *)
+        exit $ret
+        ;;
+esac

--- a/valgrind_ctime_test.sh
+++ b/valgrind_ctime_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-libtool --mode=execute valgrind --error-exitcode=1 ./valgrind_ctime_test "$@"
+./libtool --mode=execute valgrind --error-exitcode=1 ./valgrind_ctime_test "$@"
 ret=$?
 
 case $ret in


### PR DESCRIPTION
I'm not sure about the second commit. The local `./libtool` works for me and I see no reason why we should use the system libtool.  Let's see what travis says.  

@gmaxwell  
I don't understand really `libtool --mode=execute` to be honest.  Can you explain why we need this here?