### PR TITLE
build: fix OpenSSL EC detection on macOS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,8 @@ if USE_BENCHMARK
 noinst_PROGRAMS += bench_verify bench_sign bench_internal bench_ecmult
 bench_verify_SOURCES = src/bench_verify.c
 bench_verify_LDADD = libsecp256k1.la $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB)
+# SECP_TEST_INCLUDES are only used here for CRYPTO_CPPFLAGS
+bench_verify_CPPFLAGS = -DSECP256K1_BUILD $(SECP_TEST_INCLUDES)
 bench_sign_SOURCES = src/bench_sign.c
 bench_sign_LDADD = libsecp256k1.la $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB)
 bench_internal_SOURCES = src/bench_internal.c

--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -38,6 +38,8 @@ AC_DEFUN([SECP_OPENSSL_CHECK],[
   fi
 if test x"$has_libcrypto" = x"yes" && test x"$has_openssl_ec" = x; then
   AC_MSG_CHECKING(for EC functions in libcrypto)
+  CPPFLAGS_TEMP="$CPPFLAGS"
+  CPPFLAGS="$CRYPTO_CPPFLAGS $CPPFLAGS"
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     #include <openssl/ec.h>
     #include <openssl/ecdsa.h>
@@ -51,6 +53,7 @@ if test x"$has_libcrypto" = x"yes" && test x"$has_openssl_ec" = x; then
     ECDSA_SIG_free(sig_openssl);
   ]])],[has_openssl_ec=yes],[has_openssl_ec=no])
   AC_MSG_RESULT([$has_openssl_ec])
+  CPPFLAGS="$CPPFLAGS_TEMP"
 fi
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ case $host_os in
          if test x$openssl_prefix != x; then
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
+           CRYPTO_CPPFLAGS="-I$openssl_prefix/include"
          fi
          if test x$gmp_prefix != x; then
            GMP_CPPFLAGS="-I$gmp_prefix/include"
@@ -451,7 +452,7 @@ if test x"$use_tests" = x"yes"; then
   if test x"$has_openssl_ec" = x"yes"; then
     if test x"$enable_openssl_tests" != x"no"; then
       AC_DEFINE(ENABLE_OPENSSL_TESTS, 1, [Define this symbol if OpenSSL EC functions are available])
-      SECP_TEST_INCLUDES="$SSL_CFLAGS $CRYPTO_CFLAGS"
+      SECP_TEST_INCLUDES="$SSL_CFLAGS $CRYPTO_CFLAGS $CRYPTO_CPPFLAGS"
       SECP_TEST_LIBS="$CRYPTO_LIBS"
 
       case $host in


### PR DESCRIPTION
Fixes #734.

The first commit fixes OpenSSL EC detection on macOS, by making `CRYPTO_CPPFLAGS` available during configure. Similar to how `GMP_CPPFLAGS` are used.

The second commit, which I'd like feedback on, fixes a compilation error:
```bash
  CC       src/bench_verify.o
src/bench_verify.c:15:10: fatal error: 'openssl/bn.h' file not found
#include <openssl/bn.h>
         ^~~~~~~~~~~~~~
1 error generated.
```

as `CRYPTO_CPPFLAGS` are then needed in bench_verify, and are not included otherwise. 

Not sure if this is the way you'd like to fix this, as its a bit of a hack for macOS.

