### PR TITLE
remove dead store in ecdsa_signature_parse_der_lax

### DIFF
--- a/contrib/lax_der_parsing.c
+++ b/contrib/lax_der_parsing.c
@@ -112,7 +112,6 @@ int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_
         return 0;
     }
     spos = pos;
-    pos += slen;
 
     /* Ignore leading zeroes in R */
     while (rlen > 0 && input[rpos] == 0) {


### PR DESCRIPTION
This change was made in bitcoin/bitcoin without upstreaming. So this is
a followup to the comment here: https://github.com/bitcoin/bitcoin/pull/19228#issuecomment-641795558.

See also: https://github.com/bitcoin/bitcoin/pull/11073.