### PR TITLE
Undef HAVE___INT128 in basic-config.h to fix gen_context compilation

### DIFF
--- a/src/basic-config.h
+++ b/src/basic-config.h
@@ -25,6 +25,7 @@
 #undef USE_SCALAR_INV_BUILTIN
 #undef USE_SCALAR_INV_NUM
 #undef ECMULT_WINDOW_SIZE
+#undef HAVE___INT128 /* used in util.h */
 
 #define USE_NUM_NONE 1
 #define USE_FIELD_INV_BUILTIN 1


### PR DESCRIPTION
Fixes #768.