### PR TITLE
Get rid of autoconf check for endianness

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -493,8 +493,6 @@ if test x"$enable_module_recovery" = x"yes"; then
   AC_DEFINE(ENABLE_MODULE_RECOVERY, 1, [Define this symbol to enable the ECDSA pubkey recovery module])
 fi
 
-AC_C_BIGENDIAN()
-
 if test x"$use_external_asm" = x"yes"; then
   AC_DEFINE(USE_EXTERNAL_ASM, 1, [Define this symbol if an external (non-inline) assembly implementation is used])
 fi

--- a/src/hash_impl.h
+++ b/src/hash_impl.h
@@ -27,11 +27,11 @@
     (h) = t1 + t2; \
 } while(0)
 
-#ifdef WORDS_BIGENDIAN
-#define BE32(x) (x)
-#else
-#define BE32(p) ((((p) & 0xFF) << 24) | (((p) & 0xFF00) << 8) | (((p) & 0xFF0000) >> 8) | (((p) & 0xFF000000) >> 24))
-#endif
+/* swap byte order on a LE system, identity function on a BE system */
+SECP256K1_INLINE static uint32_t be32(uint32_t n) {
+    unsigned char *p = (unsigned char *)&n;
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
 
 static void secp256k1_sha256_initialize(secp256k1_sha256 *hash) {
     hash->s[0] = 0x6a09e667ul;
@@ -50,22 +50,22 @@ static void secp256k1_sha256_transform(uint32_t* s, const uint32_t* chunk) {
     uint32_t a = s[0], b = s[1], c = s[2], d = s[3], e = s[4], f = s[5], g = s[6], h = s[7];
     uint32_t w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15;
 
-    Round(a, b, c, d, e, f, g, h, 0x428a2f98, w0 = BE32(chunk[0]));
-    Round(h, a, b, c, d, e, f, g, 0x71374491, w1 = BE32(chunk[1]));
-    Round(g, h, a, b, c, d, e, f, 0xb5c0fbcf, w2 = BE32(chunk[2]));
-    Round(f, g, h, a, b, c, d, e, 0xe9b5dba5, w3 = BE32(chunk[3]));
-    Round(e, f, g, h, a, b, c, d, 0x3956c25b, w4 = BE32(chunk[4]));
-    Round(d, e, f, g, h, a, b, c, 0x59f111f1, w5 = BE32(chunk[5]));
-    Round(c, d, e, f, g, h, a, b, 0x923f82a4, w6 = BE32(chunk[6]));
-    Round(b, c, d, e, f, g, h, a, 0xab1c5ed5, w7 = BE32(chunk[7]));
-    Round(a, b, c, d, e, f, g, h, 0xd807aa98, w8 = BE32(chunk[8]));
-    Round(h, a, b, c, d, e, f, g, 0x12835b01, w9 = BE32(chunk[9]));
-    Round(g, h, a, b, c, d, e, f, 0x243185be, w10 = BE32(chunk[10]));
-    Round(f, g, h, a, b, c, d, e, 0x550c7dc3, w11 = BE32(chunk[11]));
-    Round(e, f, g, h, a, b, c, d, 0x72be5d74, w12 = BE32(chunk[12]));
-    Round(d, e, f, g, h, a, b, c, 0x80deb1fe, w13 = BE32(chunk[13]));
-    Round(c, d, e, f, g, h, a, b, 0x9bdc06a7, w14 = BE32(chunk[14]));
-    Round(b, c, d, e, f, g, h, a, 0xc19bf174, w15 = BE32(chunk[15]));
+    Round(a, b, c, d, e, f, g, h, 0x428a2f98, w0 = be32(chunk[0]));
+    Round(h, a, b, c, d, e, f, g, 0x71374491, w1 = be32(chunk[1]));
+    Round(g, h, a, b, c, d, e, f, 0xb5c0fbcf, w2 = be32(chunk[2]));
+    Round(f, g, h, a, b, c, d, e, 0xe9b5dba5, w3 = be32(chunk[3]));
+    Round(e, f, g, h, a, b, c, d, 0x3956c25b, w4 = be32(chunk[4]));
+    Round(d, e, f, g, h, a, b, c, 0x59f111f1, w5 = be32(chunk[5]));
+    Round(c, d, e, f, g, h, a, b, 0x923f82a4, w6 = be32(chunk[6]));
+    Round(b, c, d, e, f, g, h, a, 0xab1c5ed5, w7 = be32(chunk[7]));
+    Round(a, b, c, d, e, f, g, h, 0xd807aa98, w8 = be32(chunk[8]));
+    Round(h, a, b, c, d, e, f, g, 0x12835b01, w9 = be32(chunk[9]));
+    Round(g, h, a, b, c, d, e, f, 0x243185be, w10 = be32(chunk[10]));
+    Round(f, g, h, a, b, c, d, e, 0x550c7dc3, w11 = be32(chunk[11]));
+    Round(e, f, g, h, a, b, c, d, 0x72be5d74, w12 = be32(chunk[12]));
+    Round(d, e, f, g, h, a, b, c, 0x80deb1fe, w13 = be32(chunk[13]));
+    Round(c, d, e, f, g, h, a, b, 0x9bdc06a7, w14 = be32(chunk[14]));
+    Round(b, c, d, e, f, g, h, a, 0xc19bf174, w15 = be32(chunk[15]));
 
     Round(a, b, c, d, e, f, g, h, 0xe49b69c1, w0 += sigma1(w14) + w9 + sigma0(w1));
     Round(h, a, b, c, d, e, f, g, 0xefbe4786, w1 += sigma1(w15) + w10 + sigma0(w2));
@@ -152,12 +152,12 @@ static void secp256k1_sha256_finalize(secp256k1_sha256 *hash, unsigned char *out
     uint32_t sizedesc[2];
     uint32_t out[8];
     int i = 0;
-    sizedesc[0] = BE32(hash->bytes >> 29);
-    sizedesc[1] = BE32(hash->bytes << 3);
+    sizedesc[0] = be32(hash->bytes >> 29);
+    sizedesc[1] = be32(hash->bytes << 3);
     secp256k1_sha256_write(hash, pad, 1 + ((119 - (hash->bytes % 64)) % 64));
     secp256k1_sha256_write(hash, (const unsigned char*)sizedesc, 8);
     for (i = 0; i < 8; i++) {
-        out[i] = BE32(hash->s[i]);
+        out[i] = be32(hash->s[i]);
         hash->s[i] = 0;
     }
     memcpy(out32, (const unsigned char*)out, 32);
@@ -271,7 +271,6 @@ static void secp256k1_rfc6979_hmac_sha256_finalize(secp256k1_rfc6979_hmac_sha256
     rng->retry = 0;
 }
 
-#undef BE32
 #undef Round
 #undef sigma1
 #undef sigma0


### PR DESCRIPTION
This does not fix any particular issue but it's preferable to not
rely on autoconf. This avoids endianness mess for users on BE hosts
if they use their build without autoconf.