### PR TITLE
Fix some compile problems on weird/old compilers.

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -134,7 +134,7 @@ typedef int (*secp256k1_nonce_function)(
 #  else
 #   define SECP256K1_API
 #  endif
-# elif defined(__GNUC__) && defined(SECP256K1_BUILD)
+# elif defined(__GNUC__) && (__GNUC__ >= 4) && defined(SECP256K1_BUILD)
 #  define SECP256K1_API __attribute__ ((visibility ("default")))
 # else
 #  define SECP256K1_API

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -291,7 +291,7 @@ int secp256k1_ec_pubkey_serialize(const secp256k1_context* ctx, unsigned char *o
 
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(outputlen != NULL);
-    ARG_CHECK(*outputlen >= ((flags & SECP256K1_FLAGS_BIT_COMPRESSION) ? 33 : 65));
+    ARG_CHECK(*outputlen >= ((flags & SECP256K1_FLAGS_BIT_COMPRESSION) ? 33u : 65u));
     len = *outputlen;
     *outputlen = 0;
     ARG_CHECK(output != NULL);


### PR DESCRIPTION
The visibility attribute is a GCC 4+ feature.
GCC 2.95 also warns about the unsigned/signed comparision.