### PR TITLE
secp256k1_gej_double_nonzero supports infinity

### DIFF
--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -208,7 +208,7 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
         int n;
         int j;
         for (j = 0; j < WINDOW_A - 1; ++j) {
-            secp256k1_gej_double_nonzero(r, r);
+            secp256k1_gej_double(r, r);
         }
 
         n = wnaf_1[i];

--- a/src/group.h
+++ b/src/group.h
@@ -95,8 +95,8 @@ static int secp256k1_gej_is_infinity(const secp256k1_gej *a);
 /** Check whether a group element's y coordinate is a quadratic residue. */
 static int secp256k1_gej_has_quad_y_var(const secp256k1_gej *a);
 
-/** Set r equal to the double of a, a cannot be infinity. Constant time. */
-static void secp256k1_gej_double_nonzero(secp256k1_gej *r, const secp256k1_gej *a);
+/** Set r equal to the double of a. Constant time. */
+static void secp256k1_gej_double(secp256k1_gej *r, const secp256k1_gej *a);
 
 /** Set r equal to the double of a. If rzr is not-NULL this sets *rzr such that r->z == a->z * *rzr (where infinity means an implicit z = 0). */
 static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr);

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -303,7 +303,7 @@ static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
     return secp256k1_fe_equal_var(&y2, &x3);
 }
 
-static SECP256K1_INLINE void secp256k1_gej_double_nonzero(secp256k1_gej *r, const secp256k1_gej *a) {
+static SECP256K1_INLINE void secp256k1_gej_double(secp256k1_gej *r, const secp256k1_gej *a) {
     /* Operations: 3 mul, 4 sqr, 0 normalize, 12 mul_int/add/negate.
      *
      * Note that there is an implementation described at
@@ -313,8 +313,7 @@ static SECP256K1_INLINE void secp256k1_gej_double_nonzero(secp256k1_gej *r, cons
      */
     secp256k1_fe t1,t2,t3,t4;
 
-    VERIFY_CHECK(!secp256k1_gej_is_infinity(a));
-    r->infinity = 0;
+    r->infinity = a->infinity;
 
     secp256k1_fe_mul(&r->z, &a->z, &a->y);
     secp256k1_fe_mul_int(&r->z, 2);       /* Z' = 2*Y*Z (2) */
@@ -363,7 +362,7 @@ static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, s
         secp256k1_fe_mul_int(rzr, 2);
     }
 
-    secp256k1_gej_double_nonzero(r, a);
+    secp256k1_gej_double(r, a);
 }
 
 static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -2218,6 +2218,9 @@ void test_ge(void) {
                 /* Normal doubling. */
                 secp256k1_gej_double_var(&resj, &gej[i2], NULL);
                 ge_equals_gej(&ref, &resj);
+                /* Constant-time doubling. */
+                secp256k1_gej_double(&resj, &gej[i2]);
+                ge_equals_gej(&ref, &resj);
             }
 
             /* Test adding opposites. */

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -141,10 +141,8 @@ void test_exhaustive_addition(const secp256k1_ge *group, const secp256k1_gej *gr
     /* Check doubling */
     for (i = 0; i < order; i++) {
         secp256k1_gej tmp;
-        if (i > 0) {
-            secp256k1_gej_double_nonzero(&tmp, &groupj[i]);
-            ge_equals_gej(&group[(2 * i) % order], &tmp);
-        }
+        secp256k1_gej_double(&tmp, &groupj[i]);
+        ge_equals_gej(&group[(2 * i) % order], &tmp);
         secp256k1_gej_double_var(&tmp, &groupj[i], NULL);
         ge_equals_gej(&group[(2 * i) % order], &tmp);
     }


### PR DESCRIPTION
Our existing function `secp256k1_gej_double_nonzero` actually supports infinity if only it wouldn't check that the input isn't infinity.

Drop the check, rename it to `secp256k1_gej_double`, and adapt the tests.