### PR TITLE
travis: Fix argument quoting for ./configure

### DIFF
--- a/contrib/travis.sh
+++ b/contrib/travis.sh
@@ -3,10 +3,6 @@
 set -e
 set -x
 
-if [ -n "$HOST" ]
-then
-    export USE_HOST="--host=$HOST"
-fi
 if [ "$HOST" = "i686-linux-gnu" ]
 then
     export CC="$CC -m32"
@@ -20,7 +16,8 @@ fi
     --enable-experimental="$EXPERIMENTAL" --enable-endomorphism="$ENDOMORPHISM" \
     --with-field="$FIELD" --with-bignum="$BIGNUM" --with-asm="$ASM" --with-scalar="$SCALAR" \
     --enable-ecmult-static-precomputation="$STATICPRECOMPUTATION" --with-ecmult-gen-precision="$ECMULTGENPRECISION" \
-    --enable-module-ecdh="$ECDH" --enable-module-recovery="$RECOVERY" "$EXTRAFLAGS" "$USE_HOST"
+    --enable-module-ecdh="$ECDH" --enable-module-recovery="$RECOVERY" \
+    --host="$HOST" $EXTRAFLAGS
 
 if [ -n "$BUILD" ]
 then


### PR DESCRIPTION
When $USE_HOST or $EXTRAFLAGS are empty, we pass (due to quoting) an
empty string as a parameter to ./configure, which then believes we want
to use a deprecated syntax for specifing a host or a target and yells at us:
> configure: WARNING: you should use --build, --host, --target

The fixes are:
 - $EXTRAFLAGS could contain multiple flags and should not be quoted at all.
 - We can get rid of $USE_HOST by specifying --host="$HOST" directly.