### PR TITLE
removed dead assignment of "bits" var

### DIFF
--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -151,7 +151,6 @@ static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context *ctx, secp25
         secp256k1_ge_from_storage(&add, &adds);
         secp256k1_gej_add_ge(r, r, &add);
     }
-    bits = 0;
     secp256k1_ge_clear(&add);
     secp256k1_scalar_clear(&gnb);
 }


### PR DESCRIPTION
Toying around with Clang's "scan-build" static analyzer and found this dead assignment. If its meant to be a "zero out", the C/C++ specs state its up to the compiler to decide what to do with it. So by observing the "bits = 0" does nothing, it will just remove it from output. 

The `bits` is removed as the function is about to return.

Tests passing. 
Below is screenshot of scan-build logging the error:
![Screen Shot 2020-08-20 at 5 37 59 PM](https://user-images.githubusercontent.com/15861355/90828463-09b21580-e30c-11ea-8a1d-628be33d1326.png)
