### PR TITLE
Trivial: Add test logs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ libtool
 *.lo
 *.o
 *~
+*.log
+*.trs
 src/libsecp256k1-config.h
 src/libsecp256k1-config.h.in
 src/ecmult_static_context.h


### PR DESCRIPTION
Was just running the tests for https://github.com/bitcoin-core/secp256k1/pull/558 and noticed these logs weren't ignored