### PR TITLE
Exhaustive test improvements + exhaustive schnorrsig tests

### DIFF
--- a/sage/gen_exhaustive_groups.sage
+++ b/sage/gen_exhaustive_groups.sage
@@ -1,0 +1,129 @@
+# Define field size and field
+P = 2^256 - 2^32 - 977
+F = GF(P)
+BETA = F(0x7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c28719501ee)
+
+assert(BETA != F(1) and BETA^3 == F(1))
+
+orders_done = set()
+results = {}
+first = True
+for b in range(1, P):
+    # There are only 6 curves (up to isomorphism) of the form y^2=x^3+B. Stop once we have tried all.
+    if len(orders_done) == 6:
+        break
+
+    E = EllipticCurve(F, [0, b])
+    print("Analyzing curve y^2 = x^3 + %i" % b)
+    n = E.order()
+    # Skip curves with an order we've already tried
+    if n in orders_done:
+        print("- Isomorphic to earlier curve")
+        continue
+    orders_done.add(n)
+    # Skip curves isomorphic to the real secp256k1
+    if n.is_pseudoprime():
+        print(" - Isomorphic to secp256k1")
+        continue
+
+    print("- Finding subgroups")
+
+    # Find what prime subgroups exist
+    for f, _ in n.factor():
+        print("- Analyzing subgroup of order %i" % f)
+        # Skip subgroups of order >1000
+        if f < 4 or f > 1000:
+            print("  - Bad size")
+            continue
+
+        # Iterate over X coordinates until we find one that is on the curve, has order f,
+        # and for which curve isomorphism exists that maps it to X coordinate 1.
+        for x in range(1, P):
+            # Skip X coordinates not on the curve, and construct the full point otherwise.
+            if not E.is_x_coord(x):
+                continue
+            G = E.lift_x(F(x))
+
+            print("  - Analyzing (multiples of) point with X=%i" % x)
+
+            # Skip points whose order is not a multiple of f. Project the point to have
+            # order f otherwise.
+            if (G.order() % f):
+                print("    - Bad order")
+                continue
+            G = G * (G.order() // f)
+
+            # Find lambda for endomorphism. Skip if none can be found.
+            lam = None
+            for l in Integers(f)(1).nth_root(3, all=True):
+                if int(l)*G == E(BETA*G[0], G[1]):
+                    lam = int(l)
+                    break
+            if lam is None:
+                print("    - No endomorphism for this subgroup")
+                break
+
+            # Now look for an isomorphism of the curve that gives this point an X
+            # coordinate equal to 1.
+            # If (x,y) is on y^2 = x^3 + b, then (a^2*x, a^3*y) is on y^2 = x^3 + a^6*b.
+            # So look for m=a^2=1/x.
+            m = F(1)/G[0]
+            if not m.is_square():
+                print("    - No curve isomorphism maps it to a point with X=1")
+                continue
+            a = m.sqrt()
+            rb = a^6*b
+            RE = EllipticCurve(F, [0, rb])
+
+            # Use as generator twice the image of G under the above isormorphism.
+            # This means that generator*(1/2 mod f) will have X coordinate 1.
+            RG = RE(1, a^3*G[1]) * 2
+            # And even Y coordinate.
+            if int(RG[1]) % 2:
+                RG = -RG
+            assert(RG.order() == f)
+            assert(lam*RG == RE(BETA*RG[0], RG[1]))
+
+            # We have found curve RE:y^2=x^3+rb with generator RG of order f. Remember it
+            results[f] = {"b": rb, "G": RG, "lambda": lam}
+            print("    - Found solution")
+            break
+
+    print("")
+
+print("")
+print("")
+print("/* To be put in src/group_impl.h: */")
+first = True
+for f in sorted(results.keys()):
+    b = results[f]["b"]
+    G = results[f]["G"]
+    print("#  %s EXHAUSTIVE_TEST_ORDER == %i" % ("if" if first else "elif", f))
+    first = False
+    print("static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(")
+    print("    0x%08x, 0x%08x, 0x%08x, 0x%08x," % tuple((int(G[0]) >> (32 * (7 - i))) & 0xffffffff for i in range(4)))
+    print("    0x%08x, 0x%08x, 0x%08x, 0x%08x," % tuple((int(G[0]) >> (32 * (7 - i))) & 0xffffffff for i in range(4, 8)))
+    print("    0x%08x, 0x%08x, 0x%08x, 0x%08x," % tuple((int(G[1]) >> (32 * (7 - i))) & 0xffffffff for i in range(4)))
+    print("    0x%08x, 0x%08x, 0x%08x, 0x%08x" % tuple((int(G[1]) >> (32 * (7 - i))) & 0xffffffff for i in range(4, 8)))
+    print(");")
+    print("static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(")
+    print("    0x%08x, 0x%08x, 0x%08x, 0x%08x," % tuple((int(b) >> (32 * (7 - i))) & 0xffffffff for i in range(4)))
+    print("    0x%08x, 0x%08x, 0x%08x, 0x%08x" % tuple((int(b) >> (32 * (7 - i))) & 0xffffffff for i in range(4, 8)))
+    print(");")
+print("#  else")
+print("#    error No known generator for the specified exhaustive test group order.")
+print("#  endif")
+
+print("")
+print("")
+print("/* To be put in src/scalar_impl.h: */")
+first = True
+for f in sorted(results.keys()):
+    lam = results[f]["lambda"]
+    print("#  %s EXHAUSTIVE_TEST_ORDER == %i" % ("if" if first else "elif", f))
+    first = False
+    print("#    define EXHAUSTIVE_TEST_LAMBDA %i" % lam)
+print("#  else")
+print("#    error No known lambda for the specified exhaustive test group order.")
+print("#  endif")
+print("")

--- a/src/group.h
+++ b/src/group.h
@@ -139,4 +139,15 @@ static void secp256k1_ge_storage_cmov(secp256k1_ge_storage *r, const secp256k1_g
 /** Rescale a jacobian point by b which must be non-zero. Constant-time. */
 static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *b);
 
+/** Determine if a point (which is assumed to be on the curve) is in the correct (sub)group of the curve.
+ *
+ * In normal mode, the used group is secp256k1, which has cofactor=1 meaning that every point on the curve is in the
+ * group, and this function returns always true.
+ *
+ * When compiling in exhaustive test mode, a slightly different curve equation is used, leading to a group with a
+ * (very) small subgroup, and that subgroup is what is used for all cryptographic operations. In that mode, this
+ * function checks whether a point that is on the curve is in fact also in that subgroup.
+ */
+static int secp256k1_ge_is_in_correct_subgroup(const secp256k1_ge* ge);
+
 #endif /* SECP256K1_GROUP_H */

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -11,52 +11,38 @@
 #include "field.h"
 #include "group.h"
 
-/* These points can be generated in sage as follows:
+/* These exhaustive group test orders and generators are chosen such that:
+ * - The field size is equal to that of secp256k1, so field code is the same.
+ * - The curve equation is of the form y^2=x^3+B for some constant B.
+ * - The subgroup has a generator 2*P, where P.x=1.
+ * - The subgroup has size less than 1000 to permit exhaustive testing.
+ * - The subgroup admits an endomorphism of the form lambda*(x,y) == (beta*x,y).
  *
- * 0. Setup a worksheet with the following parameters.
- *   b = 4  # whatever secp256k1_fe_const_b will be set to
- *   F = FiniteField (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F)
- *   C = EllipticCurve ([F (0), F (b)])
- *
- * 1. Determine all the small orders available to you. (If there are
- *    no satisfactory ones, go back and change b.)
- *   print C.order().factor(limit=1000)
- *
- * 2. Choose an order as one of the prime factors listed in the above step.
- *    (You can also multiply some to get a composite order, though the
- *    tests will crash trying to invert scalars during signing.) We take a
- *    random point and scale it to drop its order to the desired value.
- *    There is some probability this won't work; just try again.
- *   order = 199
- *   P = C.random_point()
- *   P = (int(P.order()) / int(order)) * P
- *   assert(P.order() == order)
- *
- * 3. Print the values. You'll need to use a vim macro or something to
- *    split the hex output into 4-byte chunks.
- *   print "%x %x" % P.xy()
+ * These parameters are generated using sage/gen_exhaustive_groups.sage.
  */
 #if defined(EXHAUSTIVE_TEST_ORDER)
-#  if EXHAUSTIVE_TEST_ORDER == 199
+#  if EXHAUSTIVE_TEST_ORDER == 13
 static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
-    0xFA7CC9A7, 0x0737F2DB, 0xA749DD39, 0x2B4FB069,
-    0x3B017A7D, 0xA808C2F1, 0xFB12940C, 0x9EA66C18,
-    0x78AC123A, 0x5ED8AEF3, 0x8732BC91, 0x1F3A2868,
-    0x48DF246C, 0x808DAE72, 0xCFE52572, 0x7F0501ED
+    0xc3459c3d, 0x35326167, 0xcd86cce8, 0x07a2417f,
+    0x5b8bd567, 0xde8538ee, 0x0d507b0c, 0xd128f5bb,
+    0x8e467fec, 0xcd30000a, 0x6cc1184e, 0x25d382c2,
+    0xa2f4494e, 0x2fbe9abc, 0x8b64abac, 0xd005fb24
 );
-
-static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 4);
-
-#  elif EXHAUSTIVE_TEST_ORDER == 13
+static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(
+    0x3d3486b2, 0x159a9ca5, 0xc75638be, 0xb23a69bc,
+    0x946a45ab, 0x24801247, 0xb4ed2b8e, 0x26b6a417
+);
+#  elif EXHAUSTIVE_TEST_ORDER == 199
 static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
-    0xedc60018, 0xa51a786b, 0x2ea91f4d, 0x4c9416c0,
-    0x9de54c3b, 0xa1316554, 0x6cf4345c, 0x7277ef15,
-    0x54cb1b6b, 0xdc8c1273, 0x087844ea, 0x43f4603e,
-    0x0eaf9a43, 0xf6effe55, 0x939f806d, 0x37adf8ac
+    0x226e653f, 0xc8df7744, 0x9bacbf12, 0x7d1dcbf9,
+    0x87f05b2a, 0xe7edbd28, 0x1f564575, 0xc48dcf18,
+    0xa13872c2, 0xe933bb17, 0x5d9ffd5b, 0xb5b6e10c,
+    0x57fe3c00, 0xbaaaa15a, 0xe003ec3e, 0x9c269bae
 );
-
-static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 2);
-
+static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(
+    0x2cca28fa, 0xfc614b80, 0x2a3db42b, 0x00ba00b1,
+    0xbea8d943, 0xdace9ab2, 0x9536daea, 0x0074defb
+);
 #  else
 #    error No known generator for the specified exhaustive test group order.
 #  endif

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -14,7 +14,7 @@
 /* These points can be generated in sage as follows:
  *
  * 0. Setup a worksheet with the following parameters.
- *   b = 4  # whatever CURVE_B will be set to
+ *   b = 4  # whatever secp256k1_fe_const_b will be set to
  *   F = FiniteField (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F)
  *   C = EllipticCurve ([F (0), F (b)])
  *
@@ -45,7 +45,8 @@ static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0x48DF246C, 0x808DAE72, 0xCFE52572, 0x7F0501ED
 );
 
-static const int CURVE_B = 4;
+static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 4);
+
 #  elif EXHAUSTIVE_TEST_ORDER == 13
 static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0xedc60018, 0xa51a786b, 0x2ea91f4d, 0x4c9416c0,
@@ -53,7 +54,9 @@ static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0x54cb1b6b, 0xdc8c1273, 0x087844ea, 0x43f4603e,
     0x0eaf9a43, 0xf6effe55, 0x939f806d, 0x37adf8ac
 );
-static const int CURVE_B = 2;
+
+static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 2);
+
 #  else
 #    error No known generator for the specified exhaustive test group order.
 #  endif
@@ -68,7 +71,7 @@ static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0xFD17B448UL, 0xA6855419UL, 0x9C47D08FUL, 0xFB10D4B8UL
 );
 
-static const int CURVE_B = 7;
+static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 7);
 #endif
 
 static void secp256k1_ge_set_gej_zinv(secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zi) {
@@ -219,14 +222,13 @@ static void secp256k1_ge_clear(secp256k1_ge *r) {
 }
 
 static int secp256k1_ge_set_xquad(secp256k1_ge *r, const secp256k1_fe *x) {
-    secp256k1_fe x2, x3, c;
+    secp256k1_fe x2, x3;
     r->x = *x;
     secp256k1_fe_sqr(&x2, x);
     secp256k1_fe_mul(&x3, x, &x2);
     r->infinity = 0;
-    secp256k1_fe_set_int(&c, CURVE_B);
-    secp256k1_fe_add(&c, &x3);
-    return secp256k1_fe_sqrt(&r->y, &c);
+    secp256k1_fe_add(&x3, &secp256k1_fe_const_b);
+    return secp256k1_fe_sqrt(&r->y, &x3);
 }
 
 static int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int odd) {
@@ -270,15 +272,14 @@ static int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
 }
 
 static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
-    secp256k1_fe y2, x3, c;
+    secp256k1_fe y2, x3;
     if (a->infinity) {
         return 0;
     }
     /* y^2 = x^3 + 7 */
     secp256k1_fe_sqr(&y2, &a->y);
     secp256k1_fe_sqr(&x3, &a->x); secp256k1_fe_mul(&x3, &x3, &a->x);
-    secp256k1_fe_set_int(&c, CURVE_B);
-    secp256k1_fe_add(&x3, &c);
+    secp256k1_fe_add(&x3, &secp256k1_fe_const_b);
     secp256k1_fe_normalize_weak(&x3);
     return secp256k1_fe_equal_var(&y2, &x3);
 }

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -269,26 +269,6 @@ static int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
     return a->infinity;
 }
 
-static int secp256k1_gej_is_valid_var(const secp256k1_gej *a) {
-    secp256k1_fe y2, x3, z2, z6;
-    if (a->infinity) {
-        return 0;
-    }
-    /** y^2 = x^3 + 7
-     *  (Y/Z^3)^2 = (X/Z^2)^3 + 7
-     *  Y^2 / Z^6 = X^3 / Z^6 + 7
-     *  Y^2 = X^3 + 7*Z^6
-     */
-    secp256k1_fe_sqr(&y2, &a->y);
-    secp256k1_fe_sqr(&x3, &a->x); secp256k1_fe_mul(&x3, &x3, &a->x);
-    secp256k1_fe_sqr(&z2, &a->z);
-    secp256k1_fe_sqr(&z6, &z2); secp256k1_fe_mul(&z6, &z6, &z2);
-    secp256k1_fe_mul_int(&z6, CURVE_B);
-    secp256k1_fe_add(&x3, &z6);
-    secp256k1_fe_normalize_weak(&x3);
-    return secp256k1_fe_equal_var(&y2, &x3);
-}
-
 static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
     secp256k1_fe y2, x3, c;
     if (a->infinity) {

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -671,4 +671,25 @@ static int secp256k1_gej_has_quad_y_var(const secp256k1_gej *a) {
     return secp256k1_fe_is_quad_var(&yz);
 }
 
+static int secp256k1_ge_is_in_correct_subgroup(const secp256k1_ge* ge) {
+#ifdef EXHAUSTIVE_TEST_ORDER
+    secp256k1_gej out;
+    int i;
+
+    /* A very simple EC multiplication ladder that avoids a dependecy on ecmult. */
+    secp256k1_gej_set_infinity(&out);
+    for (i = 0; i < 32; ++i) {
+        secp256k1_gej_double_var(&out, &out, NULL);
+        if ((((uint32_t)EXHAUSTIVE_TEST_ORDER) >> (31 - i)) & 1) {
+            secp256k1_gej_add_ge_var(&out, &out, ge, NULL);
+        }
+    }
+    return secp256k1_gej_is_infinity(&out);
+#else
+    (void)ge;
+    /* The real secp256k1 group has cofactor 1, so the subgroup is the entire curve. */
+    return 1;
+#endif
+}
+
 #endif /* SECP256K1_GROUP_IMPL_H */

--- a/src/modules/extrakeys/Makefile.am.include
+++ b/src/modules/extrakeys/Makefile.am.include
@@ -1,3 +1,4 @@
 include_HEADERS += include/secp256k1_extrakeys.h
 noinst_HEADERS += src/modules/extrakeys/tests_impl.h
+noinst_HEADERS += src/modules/extrakeys/tests_exhaustive_impl.h
 noinst_HEADERS += src/modules/extrakeys/main_impl.h

--- a/src/modules/extrakeys/main_impl.h
+++ b/src/modules/extrakeys/main_impl.h
@@ -33,6 +33,9 @@ int secp256k1_xonly_pubkey_parse(const secp256k1_context* ctx, secp256k1_xonly_p
     if (!secp256k1_ge_set_xo_var(&pk, &x, 0)) {
         return 0;
     }
+    if (!secp256k1_ge_is_in_correct_subgroup(&pk)) {
+        return 0;
+    }
     secp256k1_xonly_pubkey_save(pubkey, &pk);
     return 1;
 }

--- a/src/modules/extrakeys/tests_exhaustive_impl.h
+++ b/src/modules/extrakeys/tests_exhaustive_impl.h
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (c) 2020 Pieter Wuille                                   *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+
+#ifndef _SECP256K1_MODULE_EXTRAKEYS_TESTS_EXHAUSTIVE_
+#define _SECP256K1_MODULE_EXTRAKEYS_TESTS_EXHAUSTIVE_
+
+#include "src/modules/extrakeys/main_impl.h"
+#include "include/secp256k1_extrakeys.h"
+
+static void test_exhaustive_extrakeys(const secp256k1_context *ctx, const secp256k1_ge* group) {
+    secp256k1_keypair keypair[EXHAUSTIVE_TEST_ORDER - 1];
+    secp256k1_pubkey pubkey[EXHAUSTIVE_TEST_ORDER - 1];
+    secp256k1_xonly_pubkey xonly_pubkey[EXHAUSTIVE_TEST_ORDER - 1];
+    int parities[EXHAUSTIVE_TEST_ORDER - 1];
+    unsigned char xonly_pubkey_bytes[EXHAUSTIVE_TEST_ORDER - 1][32];
+    int i;
+
+    for (i = 1; i < EXHAUSTIVE_TEST_ORDER; i++) {
+        secp256k1_fe fe;
+        secp256k1_scalar scalar_i;
+        unsigned char buf[33];
+        int parity;
+
+        secp256k1_scalar_set_int(&scalar_i, i);
+        secp256k1_scalar_get_b32(buf, &scalar_i);
+
+        /* Construct pubkey and keypair. */
+        CHECK(secp256k1_keypair_create(ctx, &keypair[i - 1], buf));
+        CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey[i - 1], buf));
+
+        /* Construct serialized xonly_pubkey from keypair. */
+        CHECK(secp256k1_keypair_xonly_pub(ctx, &xonly_pubkey[i - 1], &parities[i - 1], &keypair[i - 1]));
+        CHECK(secp256k1_xonly_pubkey_serialize(ctx, xonly_pubkey_bytes[i - 1], &xonly_pubkey[i - 1]));
+
+        /* Parse the xonly_pubkey back and verify it matches the previously serialized value. */
+        CHECK(secp256k1_xonly_pubkey_parse(ctx, &xonly_pubkey[i - 1], xonly_pubkey_bytes[i - 1]));
+        CHECK(secp256k1_xonly_pubkey_serialize(ctx, buf, &xonly_pubkey[i - 1]));
+        CHECK(memcmp(xonly_pubkey_bytes[i - 1], buf, 32) == 0);
+
+        /* Construct the xonly_pubkey from the pubkey, and verify it matches the same. */
+        CHECK(secp256k1_xonly_pubkey_from_pubkey(ctx, &xonly_pubkey[i - 1], &parity, &pubkey[i - 1]));
+        CHECK(parity == parities[i - 1]);
+        CHECK(secp256k1_xonly_pubkey_serialize(ctx, buf, &xonly_pubkey[i - 1]));
+        CHECK(memcmp(xonly_pubkey_bytes[i - 1], buf, 32) == 0);
+
+        /* Compare the xonly_pubkey bytes against the precomputed group. */
+        secp256k1_fe_set_b32(&fe, xonly_pubkey_bytes[i - 1]);
+        CHECK(secp256k1_fe_equal_var(&fe, &group[i].x));
+
+        /* Check the parity against the precomputed group. */
+        fe = group[i].y;
+        secp256k1_fe_normalize_var(&fe);
+        CHECK(secp256k1_fe_is_odd(&fe) == parities[i - 1]);
+
+        /* Verify that the higher half is identical to the lower half mirrored. */
+        if (i > EXHAUSTIVE_TEST_ORDER / 2) {
+            CHECK(memcmp(xonly_pubkey_bytes[i - 1], xonly_pubkey_bytes[EXHAUSTIVE_TEST_ORDER - i - 1], 32) == 0);
+            CHECK(parities[i - 1] == 1 - parities[EXHAUSTIVE_TEST_ORDER - i - 1]);
+        }
+    }
+
+    /* TODO: keypair/xonly_pubkey tweak tests */
+}
+
+#endif

--- a/src/modules/recovery/Makefile.am.include
+++ b/src/modules/recovery/Makefile.am.include
@@ -1,6 +1,7 @@
 include_HEADERS += include/secp256k1_recovery.h
 noinst_HEADERS += src/modules/recovery/main_impl.h
 noinst_HEADERS += src/modules/recovery/tests_impl.h
+noinst_HEADERS += src/modules/recovery/tests_exhaustive_impl.h
 if USE_BENCHMARK
 noinst_PROGRAMS += bench_recover
 bench_recover_SOURCES = src/bench_recover.c

--- a/src/modules/recovery/tests_exhaustive_impl.h
+++ b/src/modules/recovery/tests_exhaustive_impl.h
@@ -1,0 +1,140 @@
+/**********************************************************************
+ * Copyright (c) 2016 Andrew Poelstra                                 *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+
+#ifndef SECP256K1_MODULE_RECOVERY_EXHAUSTIVE_TESTS_H
+#define SECP256K1_MODULE_RECOVERY_EXHAUSTIVE_TESTS_H
+
+#include "src/modules/recovery/main_impl.h"
+#include "include/secp256k1_recovery.h"
+
+void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1_ge *group) {
+    int i, j, k;
+
+    /* Loop */
+    for (i = 1; i < EXHAUSTIVE_TEST_ORDER; i++) {  /* message */
+        for (j = 1; j < EXHAUSTIVE_TEST_ORDER; j++) {  /* key */
+            for (k = 1; k < EXHAUSTIVE_TEST_ORDER; k++) {  /* nonce */
+                const int starting_k = k;
+                secp256k1_fe r_dot_y_normalized;
+                secp256k1_ecdsa_recoverable_signature rsig;
+                secp256k1_ecdsa_signature sig;
+                secp256k1_scalar sk, msg, r, s, expected_r;
+                unsigned char sk32[32], msg32[32];
+                int expected_recid;
+                int recid;
+                secp256k1_scalar_set_int(&msg, i);
+                secp256k1_scalar_set_int(&sk, j);
+                secp256k1_scalar_get_b32(sk32, &sk);
+                secp256k1_scalar_get_b32(msg32, &msg);
+
+                secp256k1_ecdsa_sign_recoverable(ctx, &rsig, msg32, sk32, secp256k1_nonce_function_smallint, &k);
+
+                /* Check directly */
+                secp256k1_ecdsa_recoverable_signature_load(ctx, &r, &s, &recid, &rsig);
+                r_from_k(&expected_r, group, k);
+                CHECK(r == expected_r);
+                CHECK((k * s) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER ||
+                      (k * (EXHAUSTIVE_TEST_ORDER - s)) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER);
+                /* In computing the recid, there is an overflow condition that is disabled in
+                 * scalar_low_impl.h `secp256k1_scalar_set_b32` because almost every r.y value
+                 * will exceed the group order, and our signing code always holds out for r
+                 * values that don't overflow, so with a proper overflow check the tests would
+                 * loop indefinitely. */
+                r_dot_y_normalized = group[k].y;
+                secp256k1_fe_normalize(&r_dot_y_normalized);
+                /* Also the recovery id is flipped depending if we hit the low-s branch */
+                if ((k * s) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER) {
+                    expected_recid = secp256k1_fe_is_odd(&r_dot_y_normalized) ? 1 : 0;
+                } else {
+                    expected_recid = secp256k1_fe_is_odd(&r_dot_y_normalized) ? 0 : 1;
+                }
+                CHECK(recid == expected_recid);
+
+                /* Convert to a standard sig then check */
+                secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
+                secp256k1_ecdsa_signature_load(ctx, &r, &s, &sig);
+                /* Note that we compute expected_r *after* signing -- this is important
+                 * because our nonce-computing function function might change k during
+                 * signing. */
+                r_from_k(&expected_r, group, k);
+                CHECK(r == expected_r);
+                CHECK((k * s) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER ||
+                      (k * (EXHAUSTIVE_TEST_ORDER - s)) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER);
+
+                /* Overflow means we've tried every possible nonce */
+                if (k < starting_k) {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+void test_exhaustive_recovery_verify(const secp256k1_context *ctx, const secp256k1_ge *group) {
+    /* This is essentially a copy of test_exhaustive_verify, with recovery added */
+    int s, r, msg, key;
+    for (s = 1; s < EXHAUSTIVE_TEST_ORDER; s++) {
+        for (r = 1; r < EXHAUSTIVE_TEST_ORDER; r++) {
+            for (msg = 1; msg < EXHAUSTIVE_TEST_ORDER; msg++) {
+                for (key = 1; key < EXHAUSTIVE_TEST_ORDER; key++) {
+                    secp256k1_ge nonconst_ge;
+                    secp256k1_ecdsa_recoverable_signature rsig;
+                    secp256k1_ecdsa_signature sig;
+                    secp256k1_pubkey pk;
+                    secp256k1_scalar sk_s, msg_s, r_s, s_s;
+                    secp256k1_scalar s_times_k_s, msg_plus_r_times_sk_s;
+                    int recid = 0;
+                    int k, should_verify;
+                    unsigned char msg32[32];
+
+                    secp256k1_scalar_set_int(&s_s, s);
+                    secp256k1_scalar_set_int(&r_s, r);
+                    secp256k1_scalar_set_int(&msg_s, msg);
+                    secp256k1_scalar_set_int(&sk_s, key);
+                    secp256k1_scalar_get_b32(msg32, &msg_s);
+
+                    /* Verify by hand */
+                    /* Run through every k value that gives us this r and check that *one* works.
+                     * Note there could be none, there could be multiple, ECDSA is weird. */
+                    should_verify = 0;
+                    for (k = 0; k < EXHAUSTIVE_TEST_ORDER; k++) {
+                        secp256k1_scalar check_x_s;
+                        r_from_k(&check_x_s, group, k);
+                        if (r_s == check_x_s) {
+                            secp256k1_scalar_set_int(&s_times_k_s, k);
+                            secp256k1_scalar_mul(&s_times_k_s, &s_times_k_s, &s_s);
+                            secp256k1_scalar_mul(&msg_plus_r_times_sk_s, &r_s, &sk_s);
+                            secp256k1_scalar_add(&msg_plus_r_times_sk_s, &msg_plus_r_times_sk_s, &msg_s);
+                            should_verify |= secp256k1_scalar_eq(&s_times_k_s, &msg_plus_r_times_sk_s);
+                        }
+                    }
+                    /* nb we have a "high s" rule */
+                    should_verify &= !secp256k1_scalar_is_high(&s_s);
+
+                    /* We would like to try recovering the pubkey and checking that it matches,
+                     * but pubkey recovery is impossible in the exhaustive tests (the reason
+                     * being that there are 12 nonzero r values, 12 nonzero points, and no
+                     * overlap between the sets, so there are no valid signatures). */
+
+                    /* Verify by converting to a standard signature and calling verify */
+                    secp256k1_ecdsa_recoverable_signature_save(&rsig, &r_s, &s_s, recid);
+                    secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
+                    memcpy(&nonconst_ge, &group[sk_s], sizeof(nonconst_ge));
+                    secp256k1_pubkey_save(&pk, &nonconst_ge);
+                    CHECK(should_verify ==
+                          secp256k1_ecdsa_verify(ctx, &sig, msg32, &pk));
+                }
+            }
+        }
+    }
+}
+
+static void test_exhaustive_recovery(const secp256k1_context *ctx, const secp256k1_ge *group) {
+    test_exhaustive_recovery_sign(ctx, group);
+    test_exhaustive_recovery_verify(ctx, group);
+}
+
+#endif /* SECP256K1_MODULE_RECOVERY_EXHAUSTIVE_TESTS_H */

--- a/src/modules/recovery/tests_exhaustive_impl.h
+++ b/src/modules/recovery/tests_exhaustive_impl.h
@@ -12,10 +12,12 @@
 
 void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1_ge *group) {
     int i, j, k;
+    uint64_t iter = 0;
 
     /* Loop */
     for (i = 1; i < EXHAUSTIVE_TEST_ORDER; i++) {  /* message */
         for (j = 1; j < EXHAUSTIVE_TEST_ORDER; j++) {  /* key */
+            if (skip_section(&iter)) continue;
             for (k = 1; k < EXHAUSTIVE_TEST_ORDER; k++) {  /* nonce */
                 const int starting_k = k;
                 secp256k1_fe r_dot_y_normalized;
@@ -80,6 +82,7 @@ void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1
 void test_exhaustive_recovery_verify(const secp256k1_context *ctx, const secp256k1_ge *group) {
     /* This is essentially a copy of test_exhaustive_verify, with recovery added */
     int s, r, msg, key;
+    uint64_t iter = 0;
     for (s = 1; s < EXHAUSTIVE_TEST_ORDER; s++) {
         for (r = 1; r < EXHAUSTIVE_TEST_ORDER; r++) {
             for (msg = 1; msg < EXHAUSTIVE_TEST_ORDER; msg++) {
@@ -93,6 +96,8 @@ void test_exhaustive_recovery_verify(const secp256k1_context *ctx, const secp256
                     int recid = 0;
                     int k, should_verify;
                     unsigned char msg32[32];
+
+                    if (skip_section(&iter)) continue;
 
                     secp256k1_scalar_set_int(&s_s, s);
                     secp256k1_scalar_set_int(&r_s, r);

--- a/src/modules/schnorrsig/Makefile.am.include
+++ b/src/modules/schnorrsig/Makefile.am.include
@@ -1,6 +1,7 @@
 include_HEADERS += include/secp256k1_schnorrsig.h
 noinst_HEADERS += src/modules/schnorrsig/main_impl.h
 noinst_HEADERS += src/modules/schnorrsig/tests_impl.h
+noinst_HEADERS += src/modules/schnorrsig/tests_exhaustive_impl.h
 if USE_BENCHMARK
 noinst_PROGRAMS += bench_schnorrsig
 bench_schnorrsig_SOURCES = src/bench_schnorrsig.c

--- a/src/modules/schnorrsig/main_impl.h
+++ b/src/modules/schnorrsig/main_impl.h
@@ -108,6 +108,22 @@ static void secp256k1_schnorrsig_sha256_tagged(secp256k1_sha256 *sha) {
     sha->bytes = 64;
 }
 
+static void secp256k1_schnorrsig_challenge(secp256k1_scalar* e, const unsigned char *r32, const unsigned char *msg32, const unsigned char *pubkey32)
+{
+    unsigned char buf[32];
+    secp256k1_sha256 sha;
+
+    /* tagged hash(r.x, pk.x, msg32) */
+    secp256k1_schnorrsig_sha256_tagged(&sha);
+    secp256k1_sha256_write(&sha, r32, 32);
+    secp256k1_sha256_write(&sha, pubkey32, 32);
+    secp256k1_sha256_write(&sha, msg32, 32);
+    secp256k1_sha256_finalize(&sha, buf);
+    /* Set scalar e to the challenge hash modulo the curve order as per
+     * BIP340. */
+    secp256k1_scalar_set_b32(e, buf, NULL);
+}
+
 int secp256k1_schnorrsig_sign(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg32, const secp256k1_keypair *keypair, secp256k1_nonce_function_hardened noncefp, void *ndata) {
     secp256k1_scalar sk;
     secp256k1_scalar e;
@@ -115,7 +131,6 @@ int secp256k1_schnorrsig_sign(const secp256k1_context* ctx, unsigned char *sig64
     secp256k1_gej rj;
     secp256k1_ge pk;
     secp256k1_ge r;
-    secp256k1_sha256 sha;
     unsigned char buf[32] = { 0 };
     unsigned char pk_buf[32];
     unsigned char seckey[32];
@@ -159,16 +174,7 @@ int secp256k1_schnorrsig_sign(const secp256k1_context* ctx, unsigned char *sig64
     secp256k1_fe_normalize_var(&r.x);
     secp256k1_fe_get_b32(&sig64[0], &r.x);
 
-    /* tagged hash(r.x, pk.x, msg32) */
-    secp256k1_schnorrsig_sha256_tagged(&sha);
-    secp256k1_sha256_write(&sha, &sig64[0], 32);
-    secp256k1_sha256_write(&sha, pk_buf, sizeof(pk_buf));
-    secp256k1_sha256_write(&sha, msg32, 32);
-    secp256k1_sha256_finalize(&sha, buf);
-
-    /* Set scalar e to the challenge hash modulo the curve order as per
-     * BIP340. */
-    secp256k1_scalar_set_b32(&e, buf, NULL);
+    secp256k1_schnorrsig_challenge(&e, &sig64[0], msg32, pk_buf);
     secp256k1_scalar_mul(&e, &e, &sk);
     secp256k1_scalar_add(&e, &e, &k);
     secp256k1_scalar_get_b32(&sig64[32], &e);
@@ -189,7 +195,6 @@ int secp256k1_schnorrsig_verify(const secp256k1_context* ctx, const unsigned cha
     secp256k1_gej pkj;
     secp256k1_fe rx;
     secp256k1_ge r;
-    secp256k1_sha256 sha;
     unsigned char buf[32];
     int overflow;
 
@@ -212,13 +217,9 @@ int secp256k1_schnorrsig_verify(const secp256k1_context* ctx, const unsigned cha
         return 0;
     }
 
-    secp256k1_schnorrsig_sha256_tagged(&sha);
-    secp256k1_sha256_write(&sha, &sig64[0], 32);
+    /* Compute e. */
     secp256k1_fe_get_b32(buf, &pk.x);
-    secp256k1_sha256_write(&sha, buf, sizeof(buf));
-    secp256k1_sha256_write(&sha, msg32, 32);
-    secp256k1_sha256_finalize(&sha, buf);
-    secp256k1_scalar_set_b32(&e, buf, NULL);
+    secp256k1_schnorrsig_challenge(&e, &sig64[0], msg32, buf);
 
     /* Compute rj =  s*G + (-e)*pkj */
     secp256k1_scalar_negate(&e, &e);

--- a/src/modules/schnorrsig/tests_exhaustive_impl.h
+++ b/src/modules/schnorrsig/tests_exhaustive_impl.h
@@ -1,0 +1,206 @@
+/**********************************************************************
+ * Copyright (c) 2020 Pieter Wuille                                   *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+
+#ifndef _SECP256K1_MODULE_SCHNORRSIG_TESTS_EXHAUSTIVE_
+#define _SECP256K1_MODULE_SCHNORRSIG_TESTS_EXHAUSTIVE_
+
+#include "include/secp256k1_schnorrsig.h"
+#include "src/modules/schnorrsig/main_impl.h"
+
+static const unsigned char invalid_pubkey_bytes[][32] = {
+    /* 0 */
+    {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    },
+    /* 2 */
+    {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2
+    },
+    /* order */
+    {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ((EXHAUSTIVE_TEST_ORDER + 0UL) >> 24) & 0xFF,
+        ((EXHAUSTIVE_TEST_ORDER + 0UL) >> 16) & 0xFF,
+        ((EXHAUSTIVE_TEST_ORDER + 0UL) >> 8) & 0xFF,
+        (EXHAUSTIVE_TEST_ORDER + 0UL) & 0xFF
+    },
+    /* order + 1 */
+    {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ((EXHAUSTIVE_TEST_ORDER + 1UL) >> 24) & 0xFF,
+        ((EXHAUSTIVE_TEST_ORDER + 1UL) >> 16) & 0xFF,
+        ((EXHAUSTIVE_TEST_ORDER + 1UL) >> 8) & 0xFF,
+        (EXHAUSTIVE_TEST_ORDER + 1UL) & 0xFF
+    },
+    /* field size */
+    {
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF, 0xFC, 0x2F
+    },
+    /* field size + 1 (note that 1 is legal) */
+    {
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF, 0xFC, 0x30
+    },
+    /* 2^256 - 1 */
+    {
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    }
+};
+
+#define NUM_INVALID_KEYS (sizeof(invalid_pubkey_bytes) / sizeof(invalid_pubkey_bytes[0]))
+
+static int secp256k1_hardened_nonce_function_smallint(unsigned char *nonce32, const unsigned char *msg32,
+                                                      const unsigned char *key32, const unsigned char *xonly_pk32,
+                                                      const unsigned char *algo16, void* data) {
+    secp256k1_scalar s;
+    int *idata = data;
+    (void)msg32;
+    (void)key32;
+    (void)xonly_pk32;
+    (void)algo16;
+    secp256k1_scalar_set_int(&s, *idata);
+    secp256k1_scalar_get_b32(nonce32, &s);
+    return 1;
+}
+
+static void test_exhaustive_schnorrsig_verify(const secp256k1_context *ctx, const secp256k1_xonly_pubkey* pubkeys, unsigned char (*xonly_pubkey_bytes)[32], const int* parities) {
+    int d;
+    uint64_t iter = 0;
+    /* Iterate over the possible public keys to verify against (through their corresponding DL d). */
+    for (d = 1; d <= EXHAUSTIVE_TEST_ORDER / 2; ++d) {
+        int actual_d;
+        unsigned k;
+        unsigned char pk32[32];
+        memcpy(pk32, xonly_pubkey_bytes[d - 1], 32);
+        actual_d = parities[d - 1] ? EXHAUSTIVE_TEST_ORDER - d : d;
+        /* Iterate over the possible valid first 32 bytes in the signature, through their corresponding DL k.
+           Values above EXHAUSTIVE_TEST_ORDER/2 refer to the entries in invalid_pubkey_bytes. */
+        for (k = 1; k <= EXHAUSTIVE_TEST_ORDER / 2 + NUM_INVALID_KEYS; ++k) {
+            unsigned char sig64[64];
+            int actual_k = -1;
+            int e_done[EXHAUSTIVE_TEST_ORDER] = {0};
+            int e_count_done = 0;
+            if (skip_section(&iter)) continue;
+            if (k <= EXHAUSTIVE_TEST_ORDER / 2) {
+                memcpy(sig64, xonly_pubkey_bytes[k - 1], 32);
+                actual_k = parities[k - 1] ? EXHAUSTIVE_TEST_ORDER - k : k;
+            } else {
+                memcpy(sig64, invalid_pubkey_bytes[k - 1 - EXHAUSTIVE_TEST_ORDER / 2], 32);
+            }
+            /* Randomly generate messages until all challenges have been hit. */
+            while (e_count_done < EXHAUSTIVE_TEST_ORDER) {
+                secp256k1_scalar e;
+                unsigned char msg32[32];
+                secp256k1_rand256(msg32);
+                secp256k1_schnorrsig_challenge(&e, sig64, msg32, pk32);
+                /* Only do work if we hit a challenge we haven't tried before. */
+                if (!e_done[e]) {
+                    /* Iterate over the possible valid last 32 bytes in the signature.
+                       0..order=that s value; order+1=random bytes */
+                    int count_valid = 0, s;
+                    for (s = 0; s <= EXHAUSTIVE_TEST_ORDER + 1; ++s) {
+                        int expect_valid, valid;
+                        if (s <= EXHAUSTIVE_TEST_ORDER) {
+                            secp256k1_scalar s_s;
+                            secp256k1_scalar_set_int(&s_s, s);
+                            secp256k1_scalar_get_b32(sig64 + 32, &s_s);
+                            expect_valid = actual_k != -1 && s != EXHAUSTIVE_TEST_ORDER &&
+                                           (s_s == (actual_k + actual_d * e) % EXHAUSTIVE_TEST_ORDER);
+                        } else {
+                            secp256k1_rand256(sig64 + 32);
+                            expect_valid = 0;
+                        }
+                        valid = secp256k1_schnorrsig_verify(ctx, sig64, msg32, &pubkeys[d - 1]);
+                        CHECK(valid == expect_valid);
+                        count_valid += valid;
+                    }
+                    /* Exactly one s value must verify, unless R is illegal. */
+                    CHECK(count_valid == (actual_k != -1));
+                    /* Don't retry other messages that result in the same challenge. */
+                    e_done[e] = 1;
+                    ++e_count_done;
+                }
+            }
+        }
+    }
+}
+
+static void test_exhaustive_schnorrsig_sign(const secp256k1_context *ctx, unsigned char (*xonly_pubkey_bytes)[32], const secp256k1_keypair* keypairs, const int* parities) {
+    int d, k;
+    uint64_t iter = 0;
+    /* Loop over keys. */
+    for (d = 1; d < EXHAUSTIVE_TEST_ORDER; ++d) {
+        int actual_d = d;
+        if (parities[d - 1]) actual_d = EXHAUSTIVE_TEST_ORDER - d;
+        /* Loop over nonces. */
+        for (k = 1; k < EXHAUSTIVE_TEST_ORDER; ++k) {
+            int e_done[EXHAUSTIVE_TEST_ORDER] = {0};
+            int e_count_done = 0;
+            unsigned char msg32[32];
+            unsigned char sig64[64];
+            int actual_k = k;
+            if (skip_section(&iter)) continue;
+            if (parities[k - 1]) actual_k = EXHAUSTIVE_TEST_ORDER - k;
+            /* Generate random messages until all challenges have been tried. */
+            while (e_count_done < EXHAUSTIVE_TEST_ORDER) {
+                secp256k1_scalar e;
+                secp256k1_rand256(msg32);
+                secp256k1_schnorrsig_challenge(&e, xonly_pubkey_bytes[k - 1], msg32, xonly_pubkey_bytes[d - 1]);
+                /* Only do work if we hit a challenge we haven't tried before. */
+                if (!e_done[e]) {
+                    secp256k1_scalar expected_s = (actual_k + e * actual_d) % EXHAUSTIVE_TEST_ORDER;
+                    unsigned char expected_s_bytes[32];
+                    secp256k1_scalar_get_b32(expected_s_bytes, &expected_s);
+                    /* Invoke the real function to construct a signature. */
+                    CHECK(secp256k1_schnorrsig_sign(ctx, sig64, msg32, &keypairs[d - 1], secp256k1_hardened_nonce_function_smallint, &k));
+                    /* The first 32 bytes must match the xonly pubkey for the specified k. */
+                    CHECK(memcmp(sig64, xonly_pubkey_bytes[k - 1], 32) == 0);
+                    /* The last 32 bytes must match the expected s value. */
+                    CHECK(memcmp(sig64 + 32, expected_s_bytes, 32) == 0);
+                    /* Don't retry other messages that result in the same challenge. */
+                    e_done[e] = 1;
+                    ++e_count_done;
+                }
+            }
+        }
+    }
+}
+
+static void test_exhaustive_schnorrsig(const secp256k1_context *ctx) {
+    secp256k1_keypair keypair[EXHAUSTIVE_TEST_ORDER - 1];
+    secp256k1_xonly_pubkey xonly_pubkey[EXHAUSTIVE_TEST_ORDER - 1];
+    int parity[EXHAUSTIVE_TEST_ORDER - 1];
+    unsigned char xonly_pubkey_bytes[EXHAUSTIVE_TEST_ORDER - 1][32];
+    unsigned i;
+
+    /* Verify that all invalid_pubkey_bytes are actually invalid. */
+    for (i = 0; i < NUM_INVALID_KEYS; ++i) {
+        secp256k1_xonly_pubkey pk;
+        CHECK(!secp256k1_xonly_pubkey_parse(ctx, &pk, invalid_pubkey_bytes[i]));
+    }
+
+    /* Construct keypairs and xonly-pubkeys for the entire group. */
+    for (i = 1; i < EXHAUSTIVE_TEST_ORDER; ++i) {
+        secp256k1_scalar scalar_i;
+        unsigned char buf[32];
+        secp256k1_scalar_set_int(&scalar_i, i);
+        secp256k1_scalar_get_b32(buf, &scalar_i);
+        CHECK(secp256k1_keypair_create(ctx, &keypair[i - 1], buf));
+        CHECK(secp256k1_keypair_xonly_pub(ctx, &xonly_pubkey[i - 1], &parity[i - 1], &keypair[i - 1]));
+        CHECK(secp256k1_xonly_pubkey_serialize(ctx, xonly_pubkey_bytes[i - 1], &xonly_pubkey[i - 1]));
+    }
+
+    test_exhaustive_schnorrsig_sign(ctx, xonly_pubkey_bytes, keypair, parity);
+    test_exhaustive_schnorrsig_verify(ctx, xonly_pubkey, xonly_pubkey_bytes, parity);
+}
+
+#endif

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -253,6 +253,7 @@ static void secp256k1_scalar_inverse_var(secp256k1_scalar *r, const secp256k1_sc
 }
 
 #ifdef USE_ENDOMORPHISM
+/* These parameters are generated using sage/gen_exhaustive_groups.sage. */
 #if defined(EXHAUSTIVE_TEST_ORDER)
 #  if EXHAUSTIVE_TEST_ORDER == 13
 #    define EXHAUSTIVE_TEST_LAMBDA 9

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -254,6 +254,14 @@ static void secp256k1_scalar_inverse_var(secp256k1_scalar *r, const secp256k1_sc
 
 #ifdef USE_ENDOMORPHISM
 #if defined(EXHAUSTIVE_TEST_ORDER)
+#  if EXHAUSTIVE_TEST_ORDER == 13
+#    define EXHAUSTIVE_TEST_LAMBDA 9
+#  elif EXHAUSTIVE_TEST_ORDER == 199
+#    define EXHAUSTIVE_TEST_LAMBDA 92
+#  else
+#    error No known lambda for the specified exhaustive test group order.
+#  endif
+
 /**
  * Find k1 and k2 given k, such that k1 + k2 * lambda == k mod n; unlike in the
  * full case we don't bother making k1 and k2 be small, we just want them to be

--- a/src/scalar_low_impl.h
+++ b/src/scalar_low_impl.h
@@ -48,14 +48,17 @@ static void secp256k1_scalar_cadd_bit(secp256k1_scalar *r, unsigned int bit, int
 }
 
 static void secp256k1_scalar_set_b32(secp256k1_scalar *r, const unsigned char *b32, int *overflow) {
-    const int base = 0x100 % EXHAUSTIVE_TEST_ORDER;
     int i;
+    int over = 0;
     *r = 0;
     for (i = 0; i < 32; i++) {
-       *r = ((*r * base) + b32[i]) % EXHAUSTIVE_TEST_ORDER;
+        *r = (*r * 0x100) + b32[i];
+        if (*r >= EXHAUSTIVE_TEST_ORDER) {
+            over = 1;
+            *r %= EXHAUSTIVE_TEST_ORDER;
+        }
     }
-    /* just deny overflow, it basically always happens */
-    if (overflow) *overflow = 0;
+    if (overflow) *overflow = over;
 }
 
 static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar* a) {

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -284,6 +284,9 @@ int secp256k1_ec_pubkey_parse(const secp256k1_context* ctx, secp256k1_pubkey* pu
     if (!secp256k1_eckey_pubkey_parse(&Q, input, inputlen)) {
         return 0;
     }
+    if (!secp256k1_ge_is_in_correct_subgroup(&Q)) {
+        return 0;
+    }
     secp256k1_pubkey_save(pubkey, &Q);
     secp256k1_ge_clear(&Q);
     return 1;

--- a/src/testrand.h
+++ b/src/testrand.h
@@ -38,4 +38,10 @@ static void secp256k1_rand_bytes_test(unsigned char *bytes, size_t len);
 /** Flip a single random bit in a byte array */
 static void secp256k1_rand_flip(unsigned char *b, size_t len);
 
+/** Initialize the test RNG using (hex encoded) array up to 16 bytes, or randomly if hexseed is NULL. */
+static void secp256k1_rand_init(const char* hexseed);
+
+/** Print final test information. */
+static void secp256k1_rand_finish(void);
+
 #endif /* SECP256K1_TESTRAND_H */

--- a/src/testrand_impl.h
+++ b/src/testrand_impl.h
@@ -114,7 +114,7 @@ static void secp256k1_rand_flip(unsigned char *b, size_t len) {
 
 static void secp256k1_rand_init(const char* hexseed) {
     unsigned char seed16[16] = {0};
-    if (hexseed) {
+    if (hexseed && strlen(hexseed) != 0) {
         int pos = 0;
         while (pos < 16 && hexseed[0] != 0 && hexseed[1] != 0) {
             unsigned short sh;

--- a/src/tests.c
+++ b/src/tests.c
@@ -2615,7 +2615,6 @@ void test_point_times_order(const secp256k1_gej *point) {
     secp256k1_ecmult(&ctx->ecmult_ctx, &res2, point, &nx, &nx); /* calc res2 = (order - x) * point + (order - x) * G; */
     secp256k1_gej_add_var(&res1, &res1, &res2, NULL);
     CHECK(secp256k1_gej_is_infinity(&res1));
-    CHECK(secp256k1_gej_is_valid_var(&res1) == 0);
     secp256k1_ge_set_gej(&res3, &res1);
     CHECK(secp256k1_ge_is_infinity(&res3));
     CHECK(secp256k1_ge_is_valid_var(&res3) == 0);
@@ -2647,7 +2646,6 @@ void run_point_times_order(void) {
             secp256k1_gej j;
             CHECK(secp256k1_ge_is_valid_var(&p));
             secp256k1_gej_set_ge(&j, &p);
-            CHECK(secp256k1_gej_is_valid_var(&j));
             test_point_times_order(&j);
         }
         secp256k1_fe_sqr(&x, &x);

--- a/src/tests.c
+++ b/src/tests.c
@@ -5530,9 +5530,6 @@ void run_cmov_tests(void) {
 }
 
 int main(int argc, char **argv) {
-    unsigned char seed16[16] = {0};
-    unsigned char run32[32] = {0};
-
     /* Disable buffering for stdout to improve reliability of getting
      * diagnostic information. Happens right at the start of main because
      * setbuf must be used before any other operation on the stream. */
@@ -5545,43 +5542,10 @@ int main(int argc, char **argv) {
     if (argc > 1) {
         count = strtol(argv[1], NULL, 0);
     }
+    printf("test count = %i\n", count);
 
     /* find random seed */
-    if (argc > 2) {
-        int pos = 0;
-        const char* ch = argv[2];
-        while (pos < 16 && ch[0] != 0 && ch[1] != 0) {
-            unsigned short sh;
-            if ((sscanf(ch, "%2hx", &sh)) == 1) {
-                seed16[pos] = sh;
-            } else {
-                break;
-            }
-            ch += 2;
-            pos++;
-        }
-    } else {
-        FILE *frand = fopen("/dev/urandom", "r");
-        if ((frand == NULL) || fread(&seed16, 1, sizeof(seed16), frand) != sizeof(seed16)) {
-            uint64_t t = time(NULL) * (uint64_t)1337;
-            fprintf(stderr, "WARNING: could not read 16 bytes from /dev/urandom; falling back to insecure PRNG\n");
-            seed16[0] ^= t;
-            seed16[1] ^= t >> 8;
-            seed16[2] ^= t >> 16;
-            seed16[3] ^= t >> 24;
-            seed16[4] ^= t >> 32;
-            seed16[5] ^= t >> 40;
-            seed16[6] ^= t >> 48;
-            seed16[7] ^= t >> 56;
-        }
-        if (frand) {
-            fclose(frand);
-        }
-    }
-    secp256k1_rand_seed(seed16);
-
-    printf("test count = %i\n", count);
-    printf("random seed = %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", seed16[0], seed16[1], seed16[2], seed16[3], seed16[4], seed16[5], seed16[6], seed16[7], seed16[8], seed16[9], seed16[10], seed16[11], seed16[12], seed16[13], seed16[14], seed16[15]);
+    secp256k1_rand_init(argc > 2 ? argv[2] : NULL);
 
     /* initialize */
     run_context_tests(0);
@@ -5589,8 +5553,9 @@ int main(int argc, char **argv) {
     run_scratch_tests();
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     if (secp256k1_rand_bits(1)) {
-        secp256k1_rand256(run32);
-        CHECK(secp256k1_context_randomize(ctx, secp256k1_rand_bits(1) ? run32 : NULL));
+        unsigned char rand32[32];
+        secp256k1_rand256(rand32);
+        CHECK(secp256k1_context_randomize(ctx, secp256k1_rand_bits(1) ? rand32 : NULL));
     }
 
     run_rand_bits();
@@ -5678,8 +5643,7 @@ int main(int argc, char **argv) {
 
     run_cmov_tests();
 
-    secp256k1_rand256(run32);
-    printf("random run = %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", run32[0], run32[1], run32[2], run32[3], run32[4], run32[5], run32[6], run32[7], run32[8], run32[9], run32[10], run32[11], run32[12], run32[13], run32[14], run32[15]);
+    secp256k1_rand_finish();
 
     /* shutdown */
     secp256k1_context_destroy(ctx);

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -215,14 +215,14 @@ void test_exhaustive_ecmult_multi(const secp256k1_context *ctx, const secp256k1_
     secp256k1_scratch_destroy(&ctx->error_callback, scratch);
 }
 
-void r_from_k(secp256k1_scalar *r, const secp256k1_ge *group, int k) {
+void r_from_k(secp256k1_scalar *r, const secp256k1_ge *group, int k, int* overflow) {
     secp256k1_fe x;
     unsigned char x_bin[32];
     k %= EXHAUSTIVE_TEST_ORDER;
     x = group[k].x;
     secp256k1_fe_normalize(&x);
     secp256k1_fe_get_b32(x_bin, &x);
-    secp256k1_scalar_set_b32(r, x_bin, NULL);
+    secp256k1_scalar_set_b32(r, x_bin, overflow);
 }
 
 void test_exhaustive_verify(const secp256k1_context *ctx, const secp256k1_ge *group) {
@@ -250,7 +250,7 @@ void test_exhaustive_verify(const secp256k1_context *ctx, const secp256k1_ge *gr
                     should_verify = 0;
                     for (k = 0; k < EXHAUSTIVE_TEST_ORDER; k++) {
                         secp256k1_scalar check_x_s;
-                        r_from_k(&check_x_s, group, k);
+                        r_from_k(&check_x_s, group, k, NULL);
                         if (r_s == check_x_s) {
                             secp256k1_scalar_set_int(&s_times_k_s, k);
                             secp256k1_scalar_mul(&s_times_k_s, &s_times_k_s, &s_s);
@@ -297,7 +297,7 @@ void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_ge *grou
                 /* Note that we compute expected_r *after* signing -- this is important
                  * because our nonce-computing function function might change k during
                  * signing. */
-                r_from_k(&expected_r, group, k);
+                r_from_k(&expected_r, group, k, NULL);
                 CHECK(r == expected_r);
                 CHECK((k * s) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER ||
                       (k * (EXHAUSTIVE_TEST_ORDER - s)) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER);

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -353,6 +353,14 @@ int main(int argc, char** argv) {
     unsigned char rand32[32];
     secp256k1_context *ctx;
 
+    /* Disable buffering for stdout to improve reliability of getting
+     * diagnostic information. Happens right at the start of main because
+     * setbuf must be used before any other operation on the stream. */
+    setbuf(stdout, NULL);
+    /* Also disable buffering for stderr because it's not guaranteed that it's
+     * unbuffered on all systems. */
+    setbuf(stderr, NULL);
+
     printf("Exhaustive tests for order %lu\n", (unsigned long)EXHAUSTIVE_TEST_ORDER);
 
     /* find iteration count */

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -346,6 +346,14 @@ void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_ge *grou
 #include "src/modules/recovery/tests_exhaustive_impl.h"
 #endif
 
+#ifdef ENABLE_MODULE_EXTRAKEYS
+#include "src/modules/extrakeys/tests_exhaustive_impl.h"
+#endif
+
+#ifdef ENABLE_MODULE_SCHNORRSIG
+#include "src/modules/schnorrsig/tests_exhaustive_impl.h"
+#endif
+
 int main(int argc, char** argv) {
     int i;
     secp256k1_gej groupj[EXHAUSTIVE_TEST_ORDER];
@@ -432,6 +440,12 @@ int main(int argc, char** argv) {
 
 #ifdef ENABLE_MODULE_RECOVERY
         test_exhaustive_recovery(ctx, group);
+#endif
+#ifdef ENABLE_MODULE_EXTRAKEYS
+        test_exhaustive_extrakeys(ctx, group);
+#endif
+#ifdef ENABLE_MODULE_SCHNORRSIG
+        test_exhaustive_schnorrsig(ctx);
 #endif
 
         secp256k1_context_destroy(ctx);

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -18,7 +18,6 @@
 #ifndef EXHAUSTIVE_TEST_ORDER
 /* see group_impl.h for allowable values */
 #define EXHAUSTIVE_TEST_ORDER 13
-#define EXHAUSTIVE_TEST_LAMBDA 9   /* cube root of 1 mod 13 */
 #endif
 
 #include "include/secp256k1.h"

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -66,6 +66,15 @@ void random_fe(secp256k1_fe *x) {
 }
 /** END stolen from tests.c */
 
+static uint32_t num_cores = 1;
+static uint32_t this_core = 0;
+
+SECP256K1_INLINE static int skip_section(uint64_t* iter) {
+    if (num_cores == 1) return 0;
+    *iter += 0xe7037ed1a0b428dbULL;
+    return ((((uint32_t)*iter ^ (*iter >> 32)) * num_cores) >> 32) != this_core;
+}
+
 int secp256k1_nonce_function_smallint(unsigned char *nonce32, const unsigned char *msg32,
                                       const unsigned char *key32, const unsigned char *algo16,
                                       void *data, unsigned int attempt) {
@@ -99,6 +108,7 @@ void test_exhaustive_endomorphism(const secp256k1_ge *group) {
 
 void test_exhaustive_addition(const secp256k1_ge *group, const secp256k1_gej *groupj) {
     int i, j;
+    uint64_t iter = 0;
 
     /* Sanity-check (and check infinity functions) */
     CHECK(secp256k1_ge_is_infinity(&group[0]));
@@ -111,6 +121,7 @@ void test_exhaustive_addition(const secp256k1_ge *group, const secp256k1_gej *gr
     /* Check all addition formulae */
     for (j = 0; j < EXHAUSTIVE_TEST_ORDER; j++) {
         secp256k1_fe fe_inv;
+        if (skip_section(&iter)) continue;
         secp256k1_fe_inv(&fe_inv, &groupj[j].z);
         for (i = 0; i < EXHAUSTIVE_TEST_ORDER; i++) {
             secp256k1_ge zless_gej;
@@ -157,8 +168,10 @@ void test_exhaustive_addition(const secp256k1_ge *group, const secp256k1_gej *gr
 
 void test_exhaustive_ecmult(const secp256k1_context *ctx, const secp256k1_ge *group, const secp256k1_gej *groupj) {
     int i, j, r_log;
+    uint64_t iter = 0;
     for (r_log = 1; r_log < EXHAUSTIVE_TEST_ORDER; r_log++) {
         for (j = 0; j < EXHAUSTIVE_TEST_ORDER; j++) {
+            if (skip_section(&iter)) continue;
             for (i = 0; i < EXHAUSTIVE_TEST_ORDER; i++) {
                 secp256k1_gej tmp;
                 secp256k1_scalar na, ng;
@@ -191,11 +204,13 @@ static int ecmult_multi_callback(secp256k1_scalar *sc, secp256k1_ge *pt, size_t 
 
 void test_exhaustive_ecmult_multi(const secp256k1_context *ctx, const secp256k1_ge *group) {
     int i, j, k, x, y;
+    uint64_t iter = 0;
     secp256k1_scratch *scratch = secp256k1_scratch_create(&ctx->error_callback, 4096);
     for (i = 0; i < EXHAUSTIVE_TEST_ORDER; i++) {
         for (j = 0; j < EXHAUSTIVE_TEST_ORDER; j++) {
             for (k = 0; k < EXHAUSTIVE_TEST_ORDER; k++) {
                 for (x = 0; x < EXHAUSTIVE_TEST_ORDER; x++) {
+                    if (skip_section(&iter)) continue;
                     for (y = 0; y < EXHAUSTIVE_TEST_ORDER; y++) {
                         secp256k1_gej tmp;
                         secp256k1_scalar g_sc;
@@ -229,6 +244,7 @@ void r_from_k(secp256k1_scalar *r, const secp256k1_ge *group, int k, int* overfl
 
 void test_exhaustive_verify(const secp256k1_context *ctx, const secp256k1_ge *group) {
     int s, r, msg, key;
+    uint64_t iter = 0;
     for (s = 1; s < EXHAUSTIVE_TEST_ORDER; s++) {
         for (r = 1; r < EXHAUSTIVE_TEST_ORDER; r++) {
             for (msg = 1; msg < EXHAUSTIVE_TEST_ORDER; msg++) {
@@ -240,6 +256,8 @@ void test_exhaustive_verify(const secp256k1_context *ctx, const secp256k1_ge *gr
                     secp256k1_scalar s_times_k_s, msg_plus_r_times_sk_s;
                     int k, should_verify;
                     unsigned char msg32[32];
+
+                    if (skip_section(&iter)) continue;
 
                     secp256k1_scalar_set_int(&s_s, s);
                     secp256k1_scalar_set_int(&r_s, r);
@@ -279,10 +297,12 @@ void test_exhaustive_verify(const secp256k1_context *ctx, const secp256k1_ge *gr
 
 void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_ge *group) {
     int i, j, k;
+    uint64_t iter = 0;
 
     /* Loop */
     for (i = 1; i < EXHAUSTIVE_TEST_ORDER; i++) {  /* message */
         for (j = 1; j < EXHAUSTIVE_TEST_ORDER; j++) {  /* key */
+            if (skip_section(&iter)) continue;
             for (k = 1; k < EXHAUSTIVE_TEST_ORDER; k++) {  /* nonce */
                 const int starting_k = k;
                 secp256k1_ecdsa_signature sig;
@@ -343,6 +363,17 @@ int main(int argc, char** argv) {
 
     /* find random seed */
     secp256k1_rand_init(argc > 2 ? argv[2] : NULL);
+
+    /* set up split processing */
+    if (argc > 4) {
+        num_cores = strtol(argv[3], NULL, 0);
+        this_core = strtol(argv[4], NULL, 0);
+        if (num_cores < 1 || this_core >= num_cores) {
+            fprintf(stderr, "Usage: %s [count] [seed] [numcores] [thiscore]\n", argv[0]);
+            return 1;
+        }
+        printf("running tests for core %lu (out of [0..%lu])\n", (unsigned long)this_core, (unsigned long)num_cores - 1);
+    }
 
     while (count--) {
         /* Build context */

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -27,11 +27,6 @@
 #include "secp256k1.c"
 #include "testrand_impl.h"
 
-#ifdef ENABLE_MODULE_RECOVERY
-#include "src/modules/recovery/main_impl.h"
-#include "include/secp256k1_recovery.h"
-#endif
-
 /** stolen from tests.c */
 void ge_equals_ge(const secp256k1_ge *a, const secp256k1_ge *b) {
     CHECK(a->infinity == b->infinity);
@@ -327,127 +322,7 @@ void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_ge *grou
 }
 
 #ifdef ENABLE_MODULE_RECOVERY
-void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1_ge *group) {
-    int i, j, k;
-
-    /* Loop */
-    for (i = 1; i < EXHAUSTIVE_TEST_ORDER; i++) {  /* message */
-        for (j = 1; j < EXHAUSTIVE_TEST_ORDER; j++) {  /* key */
-            for (k = 1; k < EXHAUSTIVE_TEST_ORDER; k++) {  /* nonce */
-                const int starting_k = k;
-                secp256k1_fe r_dot_y_normalized;
-                secp256k1_ecdsa_recoverable_signature rsig;
-                secp256k1_ecdsa_signature sig;
-                secp256k1_scalar sk, msg, r, s, expected_r;
-                unsigned char sk32[32], msg32[32];
-                int expected_recid;
-                int recid;
-                secp256k1_scalar_set_int(&msg, i);
-                secp256k1_scalar_set_int(&sk, j);
-                secp256k1_scalar_get_b32(sk32, &sk);
-                secp256k1_scalar_get_b32(msg32, &msg);
-
-                secp256k1_ecdsa_sign_recoverable(ctx, &rsig, msg32, sk32, secp256k1_nonce_function_smallint, &k);
-
-                /* Check directly */
-                secp256k1_ecdsa_recoverable_signature_load(ctx, &r, &s, &recid, &rsig);
-                r_from_k(&expected_r, group, k);
-                CHECK(r == expected_r);
-                CHECK((k * s) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER ||
-                      (k * (EXHAUSTIVE_TEST_ORDER - s)) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER);
-                /* In computing the recid, there is an overflow condition that is disabled in
-                 * scalar_low_impl.h `secp256k1_scalar_set_b32` because almost every r.y value
-                 * will exceed the group order, and our signing code always holds out for r
-                 * values that don't overflow, so with a proper overflow check the tests would
-                 * loop indefinitely. */
-                r_dot_y_normalized = group[k].y;
-                secp256k1_fe_normalize(&r_dot_y_normalized);
-                /* Also the recovery id is flipped depending if we hit the low-s branch */
-                if ((k * s) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER) {
-                    expected_recid = secp256k1_fe_is_odd(&r_dot_y_normalized) ? 1 : 0;
-                } else {
-                    expected_recid = secp256k1_fe_is_odd(&r_dot_y_normalized) ? 0 : 1;
-                }
-                CHECK(recid == expected_recid);
-
-                /* Convert to a standard sig then check */
-                secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
-                secp256k1_ecdsa_signature_load(ctx, &r, &s, &sig);
-                /* Note that we compute expected_r *after* signing -- this is important
-                 * because our nonce-computing function function might change k during
-                 * signing. */
-                r_from_k(&expected_r, group, k);
-                CHECK(r == expected_r);
-                CHECK((k * s) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER ||
-                      (k * (EXHAUSTIVE_TEST_ORDER - s)) % EXHAUSTIVE_TEST_ORDER == (i + r * j) % EXHAUSTIVE_TEST_ORDER);
-
-                /* Overflow means we've tried every possible nonce */
-                if (k < starting_k) {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-void test_exhaustive_recovery_verify(const secp256k1_context *ctx, const secp256k1_ge *group) {
-    /* This is essentially a copy of test_exhaustive_verify, with recovery added */
-    int s, r, msg, key;
-    for (s = 1; s < EXHAUSTIVE_TEST_ORDER; s++) {
-        for (r = 1; r < EXHAUSTIVE_TEST_ORDER; r++) {
-            for (msg = 1; msg < EXHAUSTIVE_TEST_ORDER; msg++) {
-                for (key = 1; key < EXHAUSTIVE_TEST_ORDER; key++) {
-                    secp256k1_ge nonconst_ge;
-                    secp256k1_ecdsa_recoverable_signature rsig;
-                    secp256k1_ecdsa_signature sig;
-                    secp256k1_pubkey pk;
-                    secp256k1_scalar sk_s, msg_s, r_s, s_s;
-                    secp256k1_scalar s_times_k_s, msg_plus_r_times_sk_s;
-                    int recid = 0;
-                    int k, should_verify;
-                    unsigned char msg32[32];
-
-                    secp256k1_scalar_set_int(&s_s, s);
-                    secp256k1_scalar_set_int(&r_s, r);
-                    secp256k1_scalar_set_int(&msg_s, msg);
-                    secp256k1_scalar_set_int(&sk_s, key);
-                    secp256k1_scalar_get_b32(msg32, &msg_s);
-
-                    /* Verify by hand */
-                    /* Run through every k value that gives us this r and check that *one* works.
-                     * Note there could be none, there could be multiple, ECDSA is weird. */
-                    should_verify = 0;
-                    for (k = 0; k < EXHAUSTIVE_TEST_ORDER; k++) {
-                        secp256k1_scalar check_x_s;
-                        r_from_k(&check_x_s, group, k);
-                        if (r_s == check_x_s) {
-                            secp256k1_scalar_set_int(&s_times_k_s, k);
-                            secp256k1_scalar_mul(&s_times_k_s, &s_times_k_s, &s_s);
-                            secp256k1_scalar_mul(&msg_plus_r_times_sk_s, &r_s, &sk_s);
-                            secp256k1_scalar_add(&msg_plus_r_times_sk_s, &msg_plus_r_times_sk_s, &msg_s);
-                            should_verify |= secp256k1_scalar_eq(&s_times_k_s, &msg_plus_r_times_sk_s);
-                        }
-                    }
-                    /* nb we have a "high s" rule */
-                    should_verify &= !secp256k1_scalar_is_high(&s_s);
-
-                    /* We would like to try recovering the pubkey and checking that it matches,
-                     * but pubkey recovery is impossible in the exhaustive tests (the reason
-                     * being that there are 12 nonzero r values, 12 nonzero points, and no
-                     * overlap between the sets, so there are no valid signatures). */
-
-                    /* Verify by converting to a standard signature and calling verify */
-                    secp256k1_ecdsa_recoverable_signature_save(&rsig, &r_s, &s_s, recid);
-                    secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
-                    memcpy(&nonconst_ge, &group[sk_s], sizeof(nonconst_ge));
-                    secp256k1_pubkey_save(&pk, &nonconst_ge);
-                    CHECK(should_verify ==
-                          secp256k1_ecdsa_verify(ctx, &sig, msg32, &pk));
-                }
-            }
-        }
-    }
-}
+#include "src/modules/recovery/tests_exhaustive_impl.h"
 #endif
 
 int main(void) {
@@ -500,8 +375,7 @@ int main(void) {
     test_exhaustive_verify(ctx, group);
 
 #ifdef ENABLE_MODULE_RECOVERY
-    test_exhaustive_recovery_sign(ctx, group);
-    test_exhaustive_recovery_verify(ctx, group);
+    test_exhaustive_recovery(ctx, group);
 #endif
 
     secp256k1_context_destroy(ctx);


### PR DESCRIPTION
A few miscellaneous improvements:
* Just use EXHAUSTIVE_TEST_ORDER as order everywhere, rather than a variable
* Move exhaustive tests for recovery module to the recovery module directory
* Make `secp256k1_scalar_set_b32` detect overflow correctly for scalar_low (a comment in the recovery exhaustive test indicated why this was the case, but this looks incorrect).
* Change the small test groups so that they include a point with X coordinate 1.
* Initialize the RNG seed, allowing configurating from the cmdline, and report it.
* Permit changing the number of iterations (re-randomizing for each).
* Support splitting the work across cores from the cmdline.

And a big one:
* Add exhaustive tests for schnorrsig module (and limited ones for extrakeys).