### PR TITLE
Return false from secp256k1_gej_is_valid_var when z is 0

### DIFF
--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -271,7 +271,7 @@ static int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
 
 static int secp256k1_gej_is_valid_var(const secp256k1_gej *a) {
     secp256k1_fe y2, x3, z2, z6;
-    if (a->infinity) {
+    if (a->infinity || secp256k1_fe_is_zero(&a->z)) {
         return 0;
     }
     /** y^2 = x^3 + 7

--- a/src/tests.c
+++ b/src/tests.c
@@ -2419,6 +2419,12 @@ void test_add_neg_y_diff_x(void) {
     ge_equals_gej(&res, &sumj);
 }
 
+void test_cleared_gej_should_not_be_valid(void) {
+    secp256k1_gej gej;
+    secp256k1_gej_clear(&gej);
+    CHECK(secp256k1_gej_is_valid_var(&gej) == 0);
+}
+
 void run_ge(void) {
     int i;
     for (i = 0; i < count * 32; i++) {
@@ -2426,6 +2432,7 @@ void run_ge(void) {
     }
     test_add_neg_y_diff_x();
     test_intialized_inf();
+    test_cleared_gej_should_not_be_valid();
 }
 
 void test_ec_combine(void) {


### PR DESCRIPTION
Changes `secp256k1_gej_is_valid_var` to return false for cleared structs, which do not represent points on the curve.

Commits should probably be squashed to respect git bisect.

Context: https://github.com/zkSNACKs/WalletWasabi/pull/4430#issuecomment-698084278
