### PR TITLE
Switch to our own memcmp function

### DIFF
--- a/src/modules/ecdh/tests_impl.h
+++ b/src/modules/ecdh/tests_impl.h
@@ -80,7 +80,7 @@ void test_ecdh_generator_basepoint(void) {
         /* compute "explicitly" */
         CHECK(secp256k1_ec_pubkey_serialize(ctx, point_ser, &point_ser_len, &point[1], SECP256K1_EC_UNCOMPRESSED) == 1);
         /* compare */
-        CHECK(memcmp(output_ecdh, point_ser, 65) == 0);
+        CHECK(secp256k1_memcmp_var(output_ecdh, point_ser, 65) == 0);
 
         /* compute using ECDH function with default hash function */
         CHECK(secp256k1_ecdh(ctx, output_ecdh, &point[0], s_b32, NULL, NULL) == 1);
@@ -90,7 +90,7 @@ void test_ecdh_generator_basepoint(void) {
         secp256k1_sha256_write(&sha, point_ser, point_ser_len);
         secp256k1_sha256_finalize(&sha, output_ser);
         /* compare */
-        CHECK(memcmp(output_ecdh, output_ser, 32) == 0);
+        CHECK(secp256k1_memcmp_var(output_ecdh, output_ser, 32) == 0);
     }
 }
 

--- a/src/modules/extrakeys/main_impl.h
+++ b/src/modules/extrakeys/main_impl.h
@@ -121,7 +121,7 @@ int secp256k1_xonly_pubkey_tweak_add_check(const secp256k1_context* ctx, const u
     secp256k1_fe_normalize_var(&pk.y);
     secp256k1_fe_get_b32(pk_expected32, &pk.x);
 
-    return memcmp(&pk_expected32, tweaked_pubkey32, 32) == 0
+    return secp256k1_memcmp_var(&pk_expected32, tweaked_pubkey32, 32) == 0
             && secp256k1_fe_is_odd(&pk.y) == tweaked_pk_parity;
 }
 

--- a/src/modules/extrakeys/tests_impl.h
+++ b/src/modules/extrakeys/tests_impl.h
@@ -60,7 +60,7 @@ void test_xonly_pubkey(void) {
     sk[0] = 1;
     CHECK(secp256k1_ec_pubkey_create(ctx, &pk, sk) == 1);
     CHECK(secp256k1_xonly_pubkey_from_pubkey(ctx, &xonly_pk, &pk_parity, &pk) == 1);
-    CHECK(memcmp(&pk, &xonly_pk, sizeof(pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&pk, &xonly_pk, sizeof(pk)) == 0);
     CHECK(pk_parity == 0);
 
     /* Choose a secret key such that pubkey and xonly_pubkey are each others
@@ -68,7 +68,7 @@ void test_xonly_pubkey(void) {
     sk[0] = 2;
     CHECK(secp256k1_ec_pubkey_create(ctx, &pk, sk) == 1);
     CHECK(secp256k1_xonly_pubkey_from_pubkey(ctx, &xonly_pk, &pk_parity, &pk) == 1);
-    CHECK(memcmp(&xonly_pk, &pk, sizeof(xonly_pk)) != 0);
+    CHECK(secp256k1_memcmp_var(&xonly_pk, &pk, sizeof(xonly_pk)) != 0);
     CHECK(pk_parity == 1);
     secp256k1_pubkey_load(ctx, &pk1, &pk);
     secp256k1_pubkey_load(ctx, &pk2, (secp256k1_pubkey *) &xonly_pk);
@@ -81,7 +81,7 @@ void test_xonly_pubkey(void) {
     CHECK(secp256k1_xonly_pubkey_serialize(none, NULL, &xonly_pk) == 0);
     CHECK(ecount == 1);
     CHECK(secp256k1_xonly_pubkey_serialize(none, buf32, NULL) == 0);
-    CHECK(memcmp(buf32, zeros64, 32) == 0);
+    CHECK(secp256k1_memcmp_var(buf32, zeros64, 32) == 0);
     CHECK(ecount == 2);
     {
         /* A pubkey filled with 0s will fail to serialize due to pubkey_load
@@ -104,17 +104,17 @@ void test_xonly_pubkey(void) {
     CHECK(secp256k1_xonly_pubkey_from_pubkey(none, &xonly_pk, NULL, &pk) == 1);
     CHECK(secp256k1_xonly_pubkey_serialize(ctx, buf32, &xonly_pk) == 1);
     CHECK(secp256k1_xonly_pubkey_parse(ctx, &xonly_pk_tmp, buf32) == 1);
-    CHECK(memcmp(&xonly_pk, &xonly_pk_tmp, sizeof(xonly_pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&xonly_pk, &xonly_pk_tmp, sizeof(xonly_pk)) == 0);
 
     /* Test parsing invalid field elements */
     memset(&xonly_pk, 1, sizeof(xonly_pk));
     /* Overflowing field element */
     CHECK(secp256k1_xonly_pubkey_parse(none, &xonly_pk, ones32) == 0);
-    CHECK(memcmp(&xonly_pk, zeros64, sizeof(xonly_pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&xonly_pk, zeros64, sizeof(xonly_pk)) == 0);
     memset(&xonly_pk, 1, sizeof(xonly_pk));
     /* There's no point with x-coordinate 0 on secp256k1 */
     CHECK(secp256k1_xonly_pubkey_parse(none, &xonly_pk, zeros64) == 0);
-    CHECK(memcmp(&xonly_pk, zeros64, sizeof(xonly_pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&xonly_pk, zeros64, sizeof(xonly_pk)) == 0);
     /* If a random 32-byte string can not be parsed with ec_pubkey_parse
      * (because interpreted as X coordinate it does not correspond to a point on
      * the curve) then xonly_pubkey_parse should fail as well. */
@@ -125,7 +125,7 @@ void test_xonly_pubkey(void) {
         if (!secp256k1_ec_pubkey_parse(ctx, &pk, rand33, 33)) {
             memset(&xonly_pk, 1, sizeof(xonly_pk));
             CHECK(secp256k1_xonly_pubkey_parse(ctx, &xonly_pk, &rand33[1]) == 0);
-            CHECK(memcmp(&xonly_pk, zeros64, sizeof(xonly_pk)) == 0);
+            CHECK(secp256k1_memcmp_var(&xonly_pk, zeros64, sizeof(xonly_pk)) == 0);
         } else {
             CHECK(secp256k1_xonly_pubkey_parse(ctx, &xonly_pk, &rand33[1]) == 1);
         }
@@ -170,15 +170,15 @@ void test_xonly_pubkey_tweak(void) {
     CHECK(secp256k1_xonly_pubkey_tweak_add(verify, &output_pk, NULL, tweak) == 0);
     CHECK(ecount == 4);
     /* NULL internal_xonly_pk zeroes the output_pk */
-    CHECK(memcmp(&output_pk, zeros64, sizeof(output_pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&output_pk, zeros64, sizeof(output_pk)) == 0);
     CHECK(secp256k1_xonly_pubkey_tweak_add(verify, &output_pk, &internal_xonly_pk, NULL) == 0);
     CHECK(ecount == 5);
     /* NULL tweak zeroes the output_pk */
-    CHECK(memcmp(&output_pk, zeros64, sizeof(output_pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&output_pk, zeros64, sizeof(output_pk)) == 0);
 
     /* Invalid tweak zeroes the output_pk */
     CHECK(secp256k1_xonly_pubkey_tweak_add(verify, &output_pk, &internal_xonly_pk, overflows) == 0);
-    CHECK(memcmp(&output_pk, zeros64, sizeof(output_pk))  == 0);
+    CHECK(secp256k1_memcmp_var(&output_pk, zeros64, sizeof(output_pk))  == 0);
 
     /* A zero tweak is fine */
     CHECK(secp256k1_xonly_pubkey_tweak_add(verify, &output_pk, &internal_xonly_pk, zeros64) == 1);
@@ -193,7 +193,7 @@ void test_xonly_pubkey_tweak(void) {
         secp256k1_scalar_get_b32(tweak, &scalar_tweak);
         CHECK((secp256k1_xonly_pubkey_tweak_add(verify, &output_pk, &internal_xonly_pk, sk) == 0)
               || (secp256k1_xonly_pubkey_tweak_add(verify, &output_pk, &internal_xonly_pk, tweak) == 0));
-        CHECK(memcmp(&output_pk, zeros64, sizeof(output_pk)) == 0);
+        CHECK(secp256k1_memcmp_var(&output_pk, zeros64, sizeof(output_pk)) == 0);
     }
 
     /* Invalid pk with a valid tweak */
@@ -202,7 +202,7 @@ void test_xonly_pubkey_tweak(void) {
     ecount = 0;
     CHECK(secp256k1_xonly_pubkey_tweak_add(verify, &output_pk, &internal_xonly_pk, tweak) == 0);
     CHECK(ecount == 1);
-    CHECK(memcmp(&output_pk, zeros64, sizeof(output_pk))  == 0);
+    CHECK(secp256k1_memcmp_var(&output_pk, zeros64, sizeof(output_pk))  == 0);
 
     secp256k1_context_destroy(none);
     secp256k1_context_destroy(sign);
@@ -268,7 +268,7 @@ void test_xonly_pubkey_tweak_check(void) {
     /* Overflowing tweak not allowed */
     CHECK(secp256k1_xonly_pubkey_tweak_add_check(ctx, output_pk32, pk_parity, &internal_xonly_pk, overflows) == 0);
     CHECK(secp256k1_xonly_pubkey_tweak_add(ctx, &output_pk, &internal_xonly_pk, overflows) == 0);
-    CHECK(memcmp(&output_pk, zeros64, sizeof(output_pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&output_pk, zeros64, sizeof(output_pk)) == 0);
     CHECK(ecount == 5);
 
     secp256k1_context_destroy(none);
@@ -329,23 +329,23 @@ void test_keypair(void) {
     ecount = 0;
     secp256k1_rand256(sk);
     CHECK(secp256k1_keypair_create(none, &keypair, sk) == 0);
-    CHECK(memcmp(zeros96, &keypair, sizeof(keypair)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) == 0);
     CHECK(ecount == 1);
     CHECK(secp256k1_keypair_create(verify, &keypair, sk) == 0);
-    CHECK(memcmp(zeros96, &keypair, sizeof(keypair)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) == 0);
     CHECK(ecount == 2);
     CHECK(secp256k1_keypair_create(sign, &keypair, sk) == 1);
     CHECK(secp256k1_keypair_create(sign, NULL, sk) == 0);
     CHECK(ecount == 3);
     CHECK(secp256k1_keypair_create(sign, &keypair, NULL) == 0);
-    CHECK(memcmp(zeros96, &keypair, sizeof(keypair)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) == 0);
     CHECK(ecount == 4);
 
     /* Invalid secret key */
     CHECK(secp256k1_keypair_create(sign, &keypair, zeros96) == 0);
-    CHECK(memcmp(zeros96, &keypair, sizeof(keypair)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) == 0);
     CHECK(secp256k1_keypair_create(sign, &keypair, overflows) == 0);
-    CHECK(memcmp(zeros96, &keypair, sizeof(keypair)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) == 0);
 
     /* Test keypair_pub */
     ecount = 0;
@@ -356,18 +356,18 @@ void test_keypair(void) {
     CHECK(ecount == 1);
     CHECK(secp256k1_keypair_pub(none, &pk, NULL) == 0);
     CHECK(ecount == 2);
-    CHECK(memcmp(zeros96, &pk, sizeof(pk)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &pk, sizeof(pk)) == 0);
 
     /* Using an invalid keypair is fine for keypair_pub */
     memset(&keypair, 0, sizeof(keypair));
     CHECK(secp256k1_keypair_pub(none, &pk, &keypair) == 1);
-    CHECK(memcmp(zeros96, &pk, sizeof(pk)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &pk, sizeof(pk)) == 0);
 
     /* keypair holds the same pubkey as pubkey_create */
     CHECK(secp256k1_ec_pubkey_create(sign, &pk, sk) == 1);
     CHECK(secp256k1_keypair_create(sign, &keypair, sk) == 1);
     CHECK(secp256k1_keypair_pub(none, &pk_tmp, &keypair) == 1);
-    CHECK(memcmp(&pk, &pk_tmp, sizeof(pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&pk, &pk_tmp, sizeof(pk)) == 0);
 
     /** Test keypair_xonly_pub **/
     ecount = 0;
@@ -379,13 +379,13 @@ void test_keypair(void) {
     CHECK(secp256k1_keypair_xonly_pub(none, &xonly_pk, NULL, &keypair) == 1);
     CHECK(secp256k1_keypair_xonly_pub(none, &xonly_pk, &pk_parity, NULL) == 0);
     CHECK(ecount == 2);
-    CHECK(memcmp(zeros96, &xonly_pk, sizeof(xonly_pk)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &xonly_pk, sizeof(xonly_pk)) == 0);
     /* Using an invalid keypair will set the xonly_pk to 0 (first reset
      * xonly_pk). */
     CHECK(secp256k1_keypair_xonly_pub(none, &xonly_pk, &pk_parity, &keypair) == 1);
     memset(&keypair, 0, sizeof(keypair));
     CHECK(secp256k1_keypair_xonly_pub(none, &xonly_pk, &pk_parity, &keypair) == 0);
-    CHECK(memcmp(zeros96, &xonly_pk, sizeof(xonly_pk)) == 0);
+    CHECK(secp256k1_memcmp_var(zeros96, &xonly_pk, sizeof(xonly_pk)) == 0);
     CHECK(ecount == 3);
 
     /** keypair holds the same xonly pubkey as pubkey_create **/
@@ -393,7 +393,7 @@ void test_keypair(void) {
     CHECK(secp256k1_xonly_pubkey_from_pubkey(none, &xonly_pk, &pk_parity, &pk) == 1);
     CHECK(secp256k1_keypair_create(sign, &keypair, sk) == 1);
     CHECK(secp256k1_keypair_xonly_pub(none, &xonly_pk_tmp, &pk_parity_tmp, &keypair) == 1);
-    CHECK(memcmp(&xonly_pk, &xonly_pk_tmp, sizeof(pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&xonly_pk, &xonly_pk_tmp, sizeof(pk)) == 0);
     CHECK(pk_parity == pk_parity_tmp);
 
     secp256k1_context_destroy(none);
@@ -429,12 +429,12 @@ void test_keypair_add(void) {
     CHECK(secp256k1_keypair_xonly_tweak_add(verify, &keypair, NULL) == 0);
     CHECK(ecount == 4);
     /* This does not set the keypair to zeroes */
-    CHECK(memcmp(&keypair, zeros96, sizeof(keypair)) != 0);
+    CHECK(secp256k1_memcmp_var(&keypair, zeros96, sizeof(keypair)) != 0);
 
     /* Invalid tweak zeroes the keypair */
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk) == 1);
     CHECK(secp256k1_keypair_xonly_tweak_add(ctx, &keypair, overflows) == 0);
-    CHECK(memcmp(&keypair, zeros96, sizeof(keypair))  == 0);
+    CHECK(secp256k1_memcmp_var(&keypair, zeros96, sizeof(keypair))  == 0);
 
     /* A zero tweak is fine */
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk) == 1);
@@ -454,8 +454,8 @@ void test_keypair_add(void) {
         secp256k1_scalar_get_b32(tweak, &scalar_tweak);
         CHECK((secp256k1_keypair_xonly_tweak_add(ctx, &keypair, sk) == 0)
               || (secp256k1_keypair_xonly_tweak_add(ctx, &keypair_tmp, tweak) == 0));
-        CHECK(memcmp(&keypair, zeros96, sizeof(keypair)) == 0
-              || memcmp(&keypair_tmp, zeros96, sizeof(keypair_tmp)) == 0);
+        CHECK(secp256k1_memcmp_var(&keypair, zeros96, sizeof(keypair)) == 0
+              || secp256k1_memcmp_var(&keypair_tmp, zeros96, sizeof(keypair_tmp)) == 0);
     }
 
     /* Invalid keypair with a valid tweak */
@@ -464,7 +464,7 @@ void test_keypair_add(void) {
     ecount = 0;
     CHECK(secp256k1_keypair_xonly_tweak_add(verify, &keypair, tweak) == 0);
     CHECK(ecount == 1);
-    CHECK(memcmp(&keypair, zeros96, sizeof(keypair))  == 0);
+    CHECK(secp256k1_memcmp_var(&keypair, zeros96, sizeof(keypair))  == 0);
     /* Only seckey part of keypair invalid */
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk) == 1);
     memset(&keypair, 0, 32);
@@ -498,11 +498,11 @@ void test_keypair_add(void) {
         /* Check that the resulting pubkey matches xonly_pubkey_tweak_add */
         CHECK(secp256k1_keypair_pub(ctx, &output_pk_xy, &keypair) == 1);
         CHECK(secp256k1_xonly_pubkey_tweak_add(ctx, &output_pk_expected, &internal_pk, tweak) == 1);
-        CHECK(memcmp(&output_pk_xy, &output_pk_expected, sizeof(output_pk_xy)) == 0);
+        CHECK(secp256k1_memcmp_var(&output_pk_xy, &output_pk_expected, sizeof(output_pk_xy)) == 0);
 
         /* Check that the secret key in the keypair is tweaked correctly */
         CHECK(secp256k1_ec_pubkey_create(ctx, &output_pk_expected, &keypair.data[0]) == 1);
-        CHECK(memcmp(&output_pk_xy, &output_pk_expected, sizeof(output_pk_xy)) == 0);
+        CHECK(secp256k1_memcmp_var(&output_pk_xy, &output_pk_expected, sizeof(output_pk_xy)) == 0);
     }
     secp256k1_context_destroy(none);
     secp256k1_context_destroy(sign);

--- a/src/modules/recovery/tests_impl.h
+++ b/src/modules/recovery/tests_impl.h
@@ -184,7 +184,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[3], message, privkey, NULL, extra) == 1);
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
     CHECK(secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
-    CHECK(memcmp(&signature[4], &signature[0], 64) == 0);
+    CHECK(secp256k1_memcmp_var(&signature[4], &signature[0], 64) == 0);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
     memset(&rsignature[4], 0, sizeof(rsignature[4]));
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
@@ -193,7 +193,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     /* Parse compact (with recovery id) and recover. */
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 1);
-    CHECK(memcmp(&pubkey, &recpubkey, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, &recpubkey, sizeof(pubkey)) == 0);
     /* Serialize/destroy/parse signature and verify again. */
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
     sig[secp256k1_rand_bits(6)] += 1 + secp256k1_rand_int(255);
@@ -202,7 +202,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 0);
     /* Recover again */
     CHECK(secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 0 ||
-          memcmp(&pubkey, &recpubkey, sizeof(pubkey)) != 0);
+          secp256k1_memcmp_var(&pubkey, &recpubkey, sizeof(pubkey)) != 0);
 }
 
 /* Tests several edge cases. */

--- a/src/modules/schnorrsig/main_impl.h
+++ b/src/modules/schnorrsig/main_impl.h
@@ -68,7 +68,7 @@ static int nonce_function_bip340(unsigned char *nonce32, const unsigned char *ms
     /* Tag the hash with algo16 which is important to avoid nonce reuse across
      * algorithms. If this nonce function is used in BIP-340 signing as defined
      * in the spec, an optimized tagging implementation is used. */
-    if (memcmp(algo16, bip340_algo16, 16) == 0) {
+    if (secp256k1_memcmp_var(algo16, bip340_algo16, 16) == 0) {
         secp256k1_nonce_function_bip340_sha256_tagged(&sha);
     } else {
         int algo16_len = 16;

--- a/src/modules/schnorrsig/tests_impl.h
+++ b/src/modules/schnorrsig/tests_impl.h
@@ -17,7 +17,7 @@ void nonce_function_bip340_bitflip(unsigned char **args, size_t n_flip, size_t n
     CHECK(nonce_function_bip340(nonces[0], args[0], args[1], args[2], args[3], args[4]) == 1);
     secp256k1_rand_flip(args[n_flip], n_bytes);
     CHECK(nonce_function_bip340(nonces[1], args[0], args[1], args[2], args[3], args[4]) == 1);
-    CHECK(memcmp(nonces[0], nonces[1], 32) != 0);
+    CHECK(secp256k1_memcmp_var(nonces[0], nonces[1], 32) != 0);
 }
 
 /* Tests for the equality of two sha256 structs. This function only produces a
@@ -28,7 +28,7 @@ void test_sha256_eq(const secp256k1_sha256 *sha1, const secp256k1_sha256 *sha2) 
     CHECK((sha1->bytes & 0x3F) == 0);
 
     CHECK(sha1->bytes == sha2->bytes);
-    CHECK(memcmp(sha1->s, sha2->s, sizeof(sha1->s)) == 0);
+    CHECK(secp256k1_memcmp_var(sha1->s, sha2->s, sizeof(sha1->s)) == 0);
 }
 
 void run_nonce_function_bip340_tests(void) {
@@ -197,11 +197,11 @@ void test_schnorrsig_bip_vectors_check_signing(const unsigned char *sk, const un
 
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk));
     CHECK(secp256k1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, aux_rand));
-    CHECK(memcmp(sig, expected_sig, 64) == 0);
+    CHECK(secp256k1_memcmp_var(sig, expected_sig, 64) == 0);
 
     CHECK(secp256k1_xonly_pubkey_parse(ctx, &pk_expected, pk_serialized));
     CHECK(secp256k1_keypair_xonly_pub(ctx, &pk, NULL, &keypair));
-    CHECK(memcmp(&pk, &pk_expected, sizeof(pk)) == 0);
+    CHECK(secp256k1_memcmp_var(&pk, &pk_expected, sizeof(pk)) == 0);
     CHECK(secp256k1_schnorrsig_verify(ctx, sig, msg, &pk));
 }
 
@@ -682,12 +682,12 @@ void test_schnorrsig_sign(void) {
     /* Test different nonce functions */
     memset(sig, 1, sizeof(sig));
     CHECK(secp256k1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_failing, NULL) == 0);
-    CHECK(memcmp(sig, zeros64, sizeof(sig)) == 0);
+    CHECK(secp256k1_memcmp_var(sig, zeros64, sizeof(sig)) == 0);
     memset(&sig, 1, sizeof(sig));
     CHECK(secp256k1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_0, NULL) == 0);
-    CHECK(memcmp(sig, zeros64, sizeof(sig)) == 0);
+    CHECK(secp256k1_memcmp_var(sig, zeros64, sizeof(sig)) == 0);
     CHECK(secp256k1_schnorrsig_sign(ctx, sig, msg, &keypair, nonce_function_overflowing, NULL) == 1);
-    CHECK(memcmp(sig, zeros64, sizeof(sig)) != 0);
+    CHECK(secp256k1_memcmp_var(sig, zeros64, sizeof(sig)) != 0);
 }
 
 #define N_SIGS 3

--- a/src/scratch_impl.h
+++ b/src/scratch_impl.h
@@ -26,7 +26,7 @@ static secp256k1_scratch* secp256k1_scratch_create(const secp256k1_callback* err
 static void secp256k1_scratch_destroy(const secp256k1_callback* error_callback, secp256k1_scratch* scratch) {
     if (scratch != NULL) {
         VERIFY_CHECK(scratch->alloc_size == 0); /* all checkpoints should be applied */
-        if (memcmp(scratch->magic, "scratch", 8) != 0) {
+        if (secp256k1_memcmp_var(scratch->magic, "scratch", 8) != 0) {
             secp256k1_callback_call(error_callback, "invalid scratch space");
             return;
         }
@@ -36,7 +36,7 @@ static void secp256k1_scratch_destroy(const secp256k1_callback* error_callback, 
 }
 
 static size_t secp256k1_scratch_checkpoint(const secp256k1_callback* error_callback, const secp256k1_scratch* scratch) {
-    if (memcmp(scratch->magic, "scratch", 8) != 0) {
+    if (secp256k1_memcmp_var(scratch->magic, "scratch", 8) != 0) {
         secp256k1_callback_call(error_callback, "invalid scratch space");
         return 0;
     }
@@ -44,7 +44,7 @@ static size_t secp256k1_scratch_checkpoint(const secp256k1_callback* error_callb
 }
 
 static void secp256k1_scratch_apply_checkpoint(const secp256k1_callback* error_callback, secp256k1_scratch* scratch, size_t checkpoint) {
-    if (memcmp(scratch->magic, "scratch", 8) != 0) {
+    if (secp256k1_memcmp_var(scratch->magic, "scratch", 8) != 0) {
         secp256k1_callback_call(error_callback, "invalid scratch space");
         return;
     }
@@ -56,7 +56,7 @@ static void secp256k1_scratch_apply_checkpoint(const secp256k1_callback* error_c
 }
 
 static size_t secp256k1_scratch_max_allocation(const secp256k1_callback* error_callback, const secp256k1_scratch* scratch, size_t objects) {
-    if (memcmp(scratch->magic, "scratch", 8) != 0) {
+    if (secp256k1_memcmp_var(scratch->magic, "scratch", 8) != 0) {
         secp256k1_callback_call(error_callback, "invalid scratch space");
         return 0;
     }
@@ -81,7 +81,7 @@ static void *secp256k1_scratch_alloc(const secp256k1_callback* error_callback, s
     }
     size = rounded_size;
 
-    if (memcmp(scratch->magic, "scratch", 8) != 0) {
+    if (secp256k1_memcmp_var(scratch->magic, "scratch", 8) != 0) {
         secp256k1_callback_call(error_callback, "invalid scratch space");
         return NULL;
     }

--- a/src/selftest.h
+++ b/src/selftest.h
@@ -22,7 +22,7 @@ static int secp256k1_selftest_sha256(void) {
     secp256k1_sha256_initialize(&hasher);
     secp256k1_sha256_write(&hasher, (const unsigned char*)input63, 63);
     secp256k1_sha256_finalize(&hasher, out);
-    return memcmp(out, output32, 32) == 0;
+    return secp256k1_memcmp_var(out, output32, 32) == 0;
 }
 
 static int secp256k1_selftest(void) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -442,14 +442,14 @@ void run_sha256_tests(void) {
         secp256k1_sha256_initialize(&hasher);
         secp256k1_sha256_write(&hasher, (const unsigned char*)(inputs[i]), strlen(inputs[i]));
         secp256k1_sha256_finalize(&hasher, out);
-        CHECK(memcmp(out, outputs[i], 32) == 0);
+        CHECK(secp256k1_memcmp_var(out, outputs[i], 32) == 0);
         if (strlen(inputs[i]) > 0) {
             int split = secp256k1_rand_int(strlen(inputs[i]));
             secp256k1_sha256_initialize(&hasher);
             secp256k1_sha256_write(&hasher, (const unsigned char*)(inputs[i]), split);
             secp256k1_sha256_write(&hasher, (const unsigned char*)(inputs[i] + split), strlen(inputs[i]) - split);
             secp256k1_sha256_finalize(&hasher, out);
-            CHECK(memcmp(out, outputs[i], 32) == 0);
+            CHECK(secp256k1_memcmp_var(out, outputs[i], 32) == 0);
         }
     }
 }
@@ -486,14 +486,14 @@ void run_hmac_sha256_tests(void) {
         secp256k1_hmac_sha256_initialize(&hasher, (const unsigned char*)(keys[i]), strlen(keys[i]));
         secp256k1_hmac_sha256_write(&hasher, (const unsigned char*)(inputs[i]), strlen(inputs[i]));
         secp256k1_hmac_sha256_finalize(&hasher, out);
-        CHECK(memcmp(out, outputs[i], 32) == 0);
+        CHECK(secp256k1_memcmp_var(out, outputs[i], 32) == 0);
         if (strlen(inputs[i]) > 0) {
             int split = secp256k1_rand_int(strlen(inputs[i]));
             secp256k1_hmac_sha256_initialize(&hasher, (const unsigned char*)(keys[i]), strlen(keys[i]));
             secp256k1_hmac_sha256_write(&hasher, (const unsigned char*)(inputs[i]), split);
             secp256k1_hmac_sha256_write(&hasher, (const unsigned char*)(inputs[i] + split), strlen(inputs[i]) - split);
             secp256k1_hmac_sha256_finalize(&hasher, out);
-            CHECK(memcmp(out, outputs[i], 32) == 0);
+            CHECK(secp256k1_memcmp_var(out, outputs[i], 32) == 0);
         }
     }
 }
@@ -520,21 +520,21 @@ void run_rfc6979_hmac_sha256_tests(void) {
     secp256k1_rfc6979_hmac_sha256_initialize(&rng, key1, 64);
     for (i = 0; i < 3; i++) {
         secp256k1_rfc6979_hmac_sha256_generate(&rng, out, 32);
-        CHECK(memcmp(out, out1[i], 32) == 0);
+        CHECK(secp256k1_memcmp_var(out, out1[i], 32) == 0);
     }
     secp256k1_rfc6979_hmac_sha256_finalize(&rng);
 
     secp256k1_rfc6979_hmac_sha256_initialize(&rng, key1, 65);
     for (i = 0; i < 3; i++) {
         secp256k1_rfc6979_hmac_sha256_generate(&rng, out, 32);
-        CHECK(memcmp(out, out1[i], 32) != 0);
+        CHECK(secp256k1_memcmp_var(out, out1[i], 32) != 0);
     }
     secp256k1_rfc6979_hmac_sha256_finalize(&rng);
 
     secp256k1_rfc6979_hmac_sha256_initialize(&rng, key2, 64);
     for (i = 0; i < 3; i++) {
         secp256k1_rfc6979_hmac_sha256_generate(&rng, out, 32);
-        CHECK(memcmp(out, out2[i], 32) == 0);
+        CHECK(secp256k1_memcmp_var(out, out2[i], 32) == 0);
     }
     secp256k1_rfc6979_hmac_sha256_finalize(&rng);
 }
@@ -1158,7 +1158,7 @@ void run_scalar_tests(void) {
         secp256k1_scalar_set_b32(&scalar, bin, &overflow);
         CHECK(overflow == 0);
         secp256k1_scalar_get_b32(bin_tmp, &scalar);
-        CHECK(memcmp(bin, bin_tmp, 32) == 0);
+        CHECK(secp256k1_memcmp_var(bin, bin_tmp, 32) == 0);
 
         /* A scalar set to all 1s should overflow. */
         memset(bin, 0xFF, 32);
@@ -1846,18 +1846,18 @@ void run_field_convert(void) {
     CHECK(secp256k1_fe_equal_var(&fe, &fe2));
     /* Check conversion from fe. */
     secp256k1_fe_get_b32(b322, &fe);
-    CHECK(memcmp(b322, b32, 32) == 0);
+    CHECK(secp256k1_memcmp_var(b322, b32, 32) == 0);
     secp256k1_fe_to_storage(&fes2, &fe);
-    CHECK(memcmp(&fes2, &fes, sizeof(fes)) == 0);
+    CHECK(secp256k1_memcmp_var(&fes2, &fes, sizeof(fes)) == 0);
 }
 
-int fe_memcmp(const secp256k1_fe *a, const secp256k1_fe *b) {
+int fe_secp256k1_memcmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
     secp256k1_fe t = *b;
 #ifdef VERIFY
     t.magnitude = a->magnitude;
     t.normalized = a->normalized;
 #endif
-    return memcmp(a, &t, sizeof(secp256k1_fe));
+    return secp256k1_memcmp_var(a, &t, sizeof(secp256k1_fe));
 }
 
 void run_field_misc(void) {
@@ -1883,13 +1883,13 @@ void run_field_misc(void) {
         CHECK(x.normalized && x.magnitude == 1);
 #endif
         secp256k1_fe_cmov(&x, &x, 1);
-        CHECK(fe_memcmp(&x, &z) != 0);
-        CHECK(fe_memcmp(&x, &q) == 0);
+        CHECK(fe_secp256k1_memcmp_var(&x, &z) != 0);
+        CHECK(fe_secp256k1_memcmp_var(&x, &q) == 0);
         secp256k1_fe_cmov(&q, &z, 1);
 #ifdef VERIFY
         CHECK(!q.normalized && q.magnitude == z.magnitude);
 #endif
-        CHECK(fe_memcmp(&q, &z) == 0);
+        CHECK(fe_secp256k1_memcmp_var(&q, &z) == 0);
         secp256k1_fe_normalize_var(&x);
         secp256k1_fe_normalize_var(&z);
         CHECK(!secp256k1_fe_equal_var(&x, &z));
@@ -1913,9 +1913,9 @@ void run_field_misc(void) {
         secp256k1_fe_to_storage(&zs, &z);
         secp256k1_fe_storage_cmov(&zs, &xs, 0);
         secp256k1_fe_storage_cmov(&zs, &zs, 1);
-        CHECK(memcmp(&xs, &zs, sizeof(xs)) != 0);
+        CHECK(secp256k1_memcmp_var(&xs, &zs, sizeof(xs)) != 0);
         secp256k1_fe_storage_cmov(&ys, &xs, 1);
-        CHECK(memcmp(&xs, &ys, sizeof(xs)) == 0);
+        CHECK(secp256k1_memcmp_var(&xs, &ys, sizeof(xs)) == 0);
         secp256k1_fe_from_storage(&x, &xs);
         secp256k1_fe_from_storage(&y, &ys);
         secp256k1_fe_from_storage(&z, &zs);
@@ -2449,7 +2449,7 @@ void test_ec_combine(void) {
         secp256k1_ge_set_gej(&Q, &Qj);
         secp256k1_pubkey_save(&sd, &Q);
         CHECK(secp256k1_ec_pubkey_combine(ctx, &sd2, d, i) == 1);
-        CHECK(memcmp(&sd, &sd2, sizeof(sd)) == 0);
+        CHECK(secp256k1_memcmp_var(&sd, &sd2, sizeof(sd)) == 0);
     }
 }
 
@@ -3573,9 +3573,9 @@ void test_scalar_split(void) {
     }
 
     secp256k1_scalar_get_b32(tmp, &s1);
-    CHECK(memcmp(zero, tmp, 16) == 0);
+    CHECK(secp256k1_memcmp_var(zero, tmp, 16) == 0);
     secp256k1_scalar_get_b32(tmp, &slam);
-    CHECK(memcmp(zero, tmp, 16) == 0);
+    CHECK(secp256k1_memcmp_var(zero, tmp, 16) == 0);
 }
 
 void run_endomorphism_tests(void) {
@@ -3623,7 +3623,7 @@ void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, int yvali
                 CHECK(secp256k1_ec_pubkey_serialize(ctx, pubkeyo, &outl, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
                 VG_CHECK(pubkeyo, outl);
                 CHECK(outl == 33);
-                CHECK(memcmp(&pubkeyo[1], &pubkeyc[1], 32) == 0);
+                CHECK(secp256k1_memcmp_var(&pubkeyo[1], &pubkeyc[1], 32) == 0);
                 CHECK((pubkeyclen != 33) || (pubkeyo[0] == pubkeyc[0]));
                 if (ypass) {
                     /* This test isn't always done because we decode with alternative signs, so the y won't match. */
@@ -3639,7 +3639,7 @@ void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, int yvali
                     VG_CHECK(pubkeyo, outl);
                     CHECK(outl == 65);
                     CHECK(pubkeyo[0] == 4);
-                    CHECK(memcmp(&pubkeyo[1], input, 64) == 0);
+                    CHECK(secp256k1_memcmp_var(&pubkeyo[1], input, 64) == 0);
                 }
                 CHECK(ecount == 0);
             } else {
@@ -4008,7 +4008,7 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, orderc) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* Maximum value is too large, reject. */
     memset(ctmp, 255, 32);
     CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
@@ -4016,7 +4016,7 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* Zero is too small, reject. */
     memset(ctmp, 0, 32);
     CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
@@ -4024,7 +4024,7 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* One must be accepted. */
     ctmp[31] = 0x01;
     CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
@@ -4032,7 +4032,7 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 1);
     VG_CHECK(&pubkey, sizeof(pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     pubkey_one = pubkey;
     /* Group order + 1 is too large, reject. */
     memcpy(ctmp, orderc, 32);
@@ -4042,7 +4042,7 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* -1 must be accepted. */
     ctmp[31] = 0x40;
     CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
@@ -4050,20 +4050,20 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 1);
     VG_CHECK(&pubkey, sizeof(pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     pubkey_negone = pubkey;
     /* Tweak of zero leaves the value unchanged. */
     memset(ctmp2, 0, 32);
     CHECK(secp256k1_ec_seckey_tweak_add(ctx, ctmp, ctmp2) == 1);
-    CHECK(memcmp(orderc, ctmp, 31) == 0 && ctmp[31] == 0x40);
+    CHECK(secp256k1_memcmp_var(orderc, ctmp, 31) == 0 && ctmp[31] == 0x40);
     memcpy(&pubkey2, &pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
-    CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Multiply tweak of zero zeroizes the output. */
     CHECK(secp256k1_ec_seckey_tweak_mul(ctx, ctmp, ctmp2) == 0);
-    CHECK(memcmp(zeros, ctmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(zeros, ctmp, 32) == 0);
     CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, ctmp2) == 0);
-    CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* If seckey_tweak_add or seckey_tweak_mul are called with an overflowing
     seckey, the seckey is zeroized. */
@@ -4073,29 +4073,29 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_seckey_verify(ctx, ctmp2) == 1);
     CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
     CHECK(secp256k1_ec_seckey_tweak_add(ctx, ctmp, ctmp2) == 0);
-    CHECK(memcmp(zeros, ctmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(zeros, ctmp, 32) == 0);
     memcpy(ctmp, orderc, 32);
     CHECK(secp256k1_ec_seckey_tweak_mul(ctx, ctmp, ctmp2) == 0);
-    CHECK(memcmp(zeros, ctmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(zeros, ctmp, 32) == 0);
     /* If seckey_tweak_add or seckey_tweak_mul are called with an overflowing
     tweak, the seckey is zeroized. */
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x40;
     CHECK(secp256k1_ec_seckey_tweak_add(ctx, ctmp, orderc) == 0);
-    CHECK(memcmp(zeros, ctmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(zeros, ctmp, 32) == 0);
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x40;
     CHECK(secp256k1_ec_seckey_tweak_mul(ctx, ctmp, orderc) == 0);
-    CHECK(memcmp(zeros, ctmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(zeros, ctmp, 32) == 0);
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x40;
     /* If pubkey_tweak_add or pubkey_tweak_mul are called with an overflowing
     tweak, the pubkey is zeroized. */
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, orderc) == 0);
-    CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, orderc) == 0);
-    CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* If the resulting key in secp256k1_ec_seckey_tweak_add and
      * secp256k1_ec_pubkey_tweak_add is 0 the functions fail and in the latter
@@ -4105,25 +4105,25 @@ void run_eckey_edge_case_test(void) {
     memset(ctmp2, 0, 32);
     ctmp2[31] = 1;
     CHECK(secp256k1_ec_seckey_tweak_add(ctx, ctmp2, ctmp) == 0);
-    CHECK(memcmp(zeros, ctmp2, 32) == 0);
+    CHECK(secp256k1_memcmp_var(zeros, ctmp2, 32) == 0);
     ctmp2[31] = 1;
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 0);
-    CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* Tweak computation wraps and results in a key of 1. */
     ctmp2[31] = 2;
     CHECK(secp256k1_ec_seckey_tweak_add(ctx, ctmp2, ctmp) == 1);
-    CHECK(memcmp(ctmp2, zeros, 31) == 0 && ctmp2[31] == 1);
+    CHECK(secp256k1_memcmp_var(ctmp2, zeros, 31) == 0 && ctmp2[31] == 1);
     ctmp2[31] = 2;
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
     ctmp2[31] = 1;
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey2, ctmp2) == 1);
-    CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Tweak mul * 2 = 1+1. */
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
     ctmp2[31] = 2;
     CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey2, ctmp2) == 1);
-    CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Test argument errors. */
     ecount = 0;
     secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
@@ -4132,12 +4132,12 @@ void run_eckey_edge_case_test(void) {
     memset(&pubkey, 0, 32);
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 0);
     CHECK(ecount == 1);
-    CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     memset(&pubkey2, 0, 32);
     CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey2, ctmp2) == 0);
     CHECK(ecount == 2);
-    CHECK(memcmp(&pubkey2, zeros, sizeof(pubkey2)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey2, zeros, sizeof(pubkey2)) == 0);
     /* Plain argument errors. */
     ecount = 0;
     CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
@@ -4177,7 +4177,7 @@ void run_eckey_edge_case_test(void) {
     memset(&pubkey, 1, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, NULL) == 0);
     CHECK(ecount == 2);
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* secp256k1_ec_pubkey_combine tests. */
     ecount = 0;
     pubkeys[0] = &pubkey_one;
@@ -4188,28 +4188,28 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 0) == 0);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     CHECK(ecount == 1);
     CHECK(secp256k1_ec_pubkey_combine(ctx, NULL, pubkeys, 1) == 0);
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     CHECK(ecount == 2);
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, NULL, 1) == 0);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     CHECK(ecount == 3);
     pubkeys[0] = &pubkey_negone;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 1) == 1);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
     len = 33;
     CHECK(secp256k1_ec_pubkey_serialize(ctx, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
     CHECK(secp256k1_ec_pubkey_serialize(ctx, ctmp2, &len, &pubkey_negone, SECP256K1_EC_COMPRESSED) == 1);
-    CHECK(memcmp(ctmp, ctmp2, 33) == 0);
+    CHECK(secp256k1_memcmp_var(ctmp, ctmp2, 33) == 0);
     /* Result is infinity. */
     pubkeys[0] = &pubkey_one;
     pubkeys[1] = &pubkey_negone;
@@ -4217,7 +4217,7 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 2) == 0);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     CHECK(ecount == 3);
     /* Passes through infinity but comes out one. */
     pubkeys[2] = &pubkey_one;
@@ -4225,19 +4225,19 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 3) == 1);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
     len = 33;
     CHECK(secp256k1_ec_pubkey_serialize(ctx, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
     CHECK(secp256k1_ec_pubkey_serialize(ctx, ctmp2, &len, &pubkey_one, SECP256K1_EC_COMPRESSED) == 1);
-    CHECK(memcmp(ctmp, ctmp2, 33) == 0);
+    CHECK(secp256k1_memcmp_var(ctmp, ctmp2, 33) == 0);
     /* Adds to two. */
     pubkeys[1] = &pubkey_one;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 2) == 1);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
+    CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
     secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
 }
@@ -4251,21 +4251,21 @@ void run_eckey_negate_test(void) {
 
     /* Verify negation changes the key and changes it back */
     CHECK(secp256k1_ec_seckey_negate(ctx, seckey) == 1);
-    CHECK(memcmp(seckey, seckey_tmp, 32) != 0);
+    CHECK(secp256k1_memcmp_var(seckey, seckey_tmp, 32) != 0);
     CHECK(secp256k1_ec_seckey_negate(ctx, seckey) == 1);
-    CHECK(memcmp(seckey, seckey_tmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(seckey, seckey_tmp, 32) == 0);
 
     /* Check that privkey alias gives same result */
     CHECK(secp256k1_ec_seckey_negate(ctx, seckey) == 1);
     CHECK(secp256k1_ec_privkey_negate(ctx, seckey_tmp) == 1);
-    CHECK(memcmp(seckey, seckey_tmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(seckey, seckey_tmp, 32) == 0);
 
     /* Negating all 0s fails */
     memset(seckey, 0, 32);
     memset(seckey_tmp, 0, 32);
     CHECK(secp256k1_ec_seckey_negate(ctx, seckey) == 0);
     /* Check that seckey is not modified */
-    CHECK(memcmp(seckey, seckey_tmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(seckey, seckey_tmp, 32) == 0);
 
     /* Negating an overflowing seckey fails and the seckey is zeroed. In this
      * test, the seckey has 16 random bytes to ensure that ec_seckey_negate
@@ -4274,7 +4274,7 @@ void run_eckey_negate_test(void) {
     memset(seckey, 0xFF, 16);
     memset(seckey_tmp, 0, 32);
     CHECK(secp256k1_ec_seckey_negate(ctx, seckey) == 0);
-    CHECK(memcmp(seckey, seckey_tmp, 32) == 0);
+    CHECK(secp256k1_memcmp_var(seckey, seckey_tmp, 32) == 0);
 }
 
 void random_sign(secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *key, const secp256k1_scalar *msg, int *recid) {
@@ -4363,7 +4363,7 @@ static int nonce_function_test_retry(unsigned char *nonce32, const unsigned char
 
 int is_empty_signature(const secp256k1_ecdsa_signature *sig) {
     static const unsigned char res[sizeof(secp256k1_ecdsa_signature)] = {0};
-    return memcmp(sig, res, sizeof(secp256k1_ecdsa_signature)) == 0;
+    return secp256k1_memcmp_var(sig, res, sizeof(secp256k1_ecdsa_signature)) == 0;
 }
 
 void test_ecdsa_end_to_end(void) {
@@ -4403,14 +4403,14 @@ void test_ecdsa_end_to_end(void) {
     /* Verify negation changes the key and changes it back */
     memcpy(&pubkey_tmp, &pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_negate(ctx, &pubkey_tmp) == 1);
-    CHECK(memcmp(&pubkey_tmp, &pubkey, sizeof(pubkey)) != 0);
+    CHECK(secp256k1_memcmp_var(&pubkey_tmp, &pubkey, sizeof(pubkey)) != 0);
     CHECK(secp256k1_ec_pubkey_negate(ctx, &pubkey_tmp) == 1);
-    CHECK(memcmp(&pubkey_tmp, &pubkey, sizeof(pubkey)) == 0);
+    CHECK(secp256k1_memcmp_var(&pubkey_tmp, &pubkey, sizeof(pubkey)) == 0);
 
     /* Verify private key import and export. */
     CHECK(ec_privkey_export_der(ctx, seckey, &seckeylen, privkey, secp256k1_rand_bits(1) == 1));
     CHECK(ec_privkey_import_der(ctx, privkey2, seckey, seckeylen) == 1);
-    CHECK(memcmp(privkey, privkey2, 32) == 0);
+    CHECK(secp256k1_memcmp_var(privkey, privkey2, 32) == 0);
 
     /* Optionally tweak the keys using addition. */
     if (secp256k1_rand_int(3) == 0) {
@@ -4431,9 +4431,9 @@ void test_ecdsa_end_to_end(void) {
         if (ret1 == 0) {
             return;
         }
-        CHECK(memcmp(privkey, privkey_tmp, 32) == 0);
+        CHECK(secp256k1_memcmp_var(privkey, privkey_tmp, 32) == 0);
         CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey2, privkey) == 1);
-        CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
+        CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     }
 
     /* Optionally tweak the keys using multiplication. */
@@ -4455,9 +4455,9 @@ void test_ecdsa_end_to_end(void) {
         if (ret1 == 0) {
             return;
         }
-        CHECK(memcmp(privkey, privkey_tmp, 32) == 0);
+        CHECK(secp256k1_memcmp_var(privkey, privkey_tmp, 32) == 0);
         CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey2, privkey) == 1);
-        CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
+        CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     }
 
     /* Sign. */
@@ -4469,13 +4469,13 @@ void test_ecdsa_end_to_end(void) {
     extra[31] = 0;
     extra[0] = 1;
     CHECK(secp256k1_ecdsa_sign(ctx, &signature[3], message, privkey, NULL, extra) == 1);
-    CHECK(memcmp(&signature[0], &signature[4], sizeof(signature[0])) == 0);
-    CHECK(memcmp(&signature[0], &signature[1], sizeof(signature[0])) != 0);
-    CHECK(memcmp(&signature[0], &signature[2], sizeof(signature[0])) != 0);
-    CHECK(memcmp(&signature[0], &signature[3], sizeof(signature[0])) != 0);
-    CHECK(memcmp(&signature[1], &signature[2], sizeof(signature[0])) != 0);
-    CHECK(memcmp(&signature[1], &signature[3], sizeof(signature[0])) != 0);
-    CHECK(memcmp(&signature[2], &signature[3], sizeof(signature[0])) != 0);
+    CHECK(secp256k1_memcmp_var(&signature[0], &signature[4], sizeof(signature[0])) == 0);
+    CHECK(secp256k1_memcmp_var(&signature[0], &signature[1], sizeof(signature[0])) != 0);
+    CHECK(secp256k1_memcmp_var(&signature[0], &signature[2], sizeof(signature[0])) != 0);
+    CHECK(secp256k1_memcmp_var(&signature[0], &signature[3], sizeof(signature[0])) != 0);
+    CHECK(secp256k1_memcmp_var(&signature[1], &signature[2], sizeof(signature[0])) != 0);
+    CHECK(secp256k1_memcmp_var(&signature[1], &signature[3], sizeof(signature[0])) != 0);
+    CHECK(secp256k1_memcmp_var(&signature[2], &signature[3], sizeof(signature[0])) != 0);
     /* Verify. */
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 1);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[1], message, &pubkey) == 1);
@@ -4496,7 +4496,7 @@ void test_ecdsa_end_to_end(void) {
     secp256k1_ecdsa_signature_save(&signature[5], &r, &s);
     CHECK(!secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 1);
-    CHECK(memcmp(&signature[5], &signature[0], 64) == 0);
+    CHECK(secp256k1_memcmp_var(&signature[5], &signature[0], 64) == 0);
 
     /* Serialize/parse DER and verify again */
     CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
@@ -4543,7 +4543,7 @@ void test_random_pubkeys(void) {
         /* If the pubkey can be parsed, it should round-trip... */
         CHECK(secp256k1_eckey_pubkey_serialize(&elem, out, &size, len == 33));
         CHECK(size == len);
-        CHECK(memcmp(&in[1], &out[1], len-1) == 0);
+        CHECK(secp256k1_memcmp_var(&in[1], &out[1], len-1) == 0);
         /* ... except for the type of hybrid inputs. */
         if ((in[0] != 6) && (in[0] != 7)) {
             CHECK(in[0] == out[0]);
@@ -4566,7 +4566,7 @@ void test_random_pubkeys(void) {
         if (res) {
             ge_equals_ge(&elem,&elem2);
             CHECK(secp256k1_eckey_pubkey_serialize(&elem, out, &size, 0));
-            CHECK(memcmp(&in[1], &out[1], 64) == 0);
+            CHECK(secp256k1_memcmp_var(&in[1], &out[1], 64) == 0);
         }
     }
 }
@@ -4622,21 +4622,21 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
     parsed_der = secp256k1_ecdsa_signature_parse_der(ctx, &sig_der, sig, siglen);
     if (parsed_der) {
         ret |= (!secp256k1_ecdsa_signature_serialize_compact(ctx, compact_der, &sig_der)) << 0;
-        valid_der = (memcmp(compact_der, zeroes, 32) != 0) && (memcmp(compact_der + 32, zeroes, 32) != 0);
+        valid_der = (secp256k1_memcmp_var(compact_der, zeroes, 32) != 0) && (secp256k1_memcmp_var(compact_der + 32, zeroes, 32) != 0);
     }
     if (valid_der) {
         ret |= (!secp256k1_ecdsa_signature_serialize_der(ctx, roundtrip_der, &len_der, &sig_der)) << 1;
-        roundtrips_der = (len_der == siglen) && memcmp(roundtrip_der, sig, siglen) == 0;
+        roundtrips_der = (len_der == siglen) && secp256k1_memcmp_var(roundtrip_der, sig, siglen) == 0;
     }
 
     parsed_der_lax = ecdsa_signature_parse_der_lax(ctx, &sig_der_lax, sig, siglen);
     if (parsed_der_lax) {
         ret |= (!secp256k1_ecdsa_signature_serialize_compact(ctx, compact_der_lax, &sig_der_lax)) << 10;
-        valid_der_lax = (memcmp(compact_der_lax, zeroes, 32) != 0) && (memcmp(compact_der_lax + 32, zeroes, 32) != 0);
+        valid_der_lax = (secp256k1_memcmp_var(compact_der_lax, zeroes, 32) != 0) && (secp256k1_memcmp_var(compact_der_lax + 32, zeroes, 32) != 0);
     }
     if (valid_der_lax) {
         ret |= (!secp256k1_ecdsa_signature_serialize_der(ctx, roundtrip_der_lax, &len_der_lax, &sig_der_lax)) << 11;
-        roundtrips_der_lax = (len_der_lax == siglen) && memcmp(roundtrip_der_lax, sig, siglen) == 0;
+        roundtrips_der_lax = (len_der_lax == siglen) && secp256k1_memcmp_var(roundtrip_der_lax, sig, siglen) == 0;
     }
 
     if (certainly_der) {
@@ -4652,7 +4652,7 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
     if (valid_der) {
         ret |= (!roundtrips_der_lax) << 12;
         ret |= (len_der != len_der_lax) << 13;
-        ret |= ((len_der != len_der_lax) || (memcmp(roundtrip_der_lax, roundtrip_der, len_der) != 0)) << 14;
+        ret |= ((len_der != len_der_lax) || (secp256k1_memcmp_var(roundtrip_der_lax, roundtrip_der, len_der) != 0)) << 14;
     }
     ret |= (roundtrips_der != roundtrips_der_lax) << 15;
     if (parsed_der) {
@@ -4669,19 +4669,19 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
         if (valid_openssl) {
             unsigned char tmp[32] = {0};
             BN_bn2bin(r, tmp + 32 - BN_num_bytes(r));
-            valid_openssl = memcmp(tmp, max_scalar, 32) < 0;
+            valid_openssl = secp256k1_memcmp_var(tmp, max_scalar, 32) < 0;
         }
         if (valid_openssl) {
             unsigned char tmp[32] = {0};
             BN_bn2bin(s, tmp + 32 - BN_num_bytes(s));
-            valid_openssl = memcmp(tmp, max_scalar, 32) < 0;
+            valid_openssl = secp256k1_memcmp_var(tmp, max_scalar, 32) < 0;
         }
     }
     len_openssl = i2d_ECDSA_SIG(sig_openssl, NULL);
     if (len_openssl <= 2048) {
         unsigned char *ptr = roundtrip_openssl;
         CHECK(i2d_ECDSA_SIG(sig_openssl, &ptr) == len_openssl);
-        roundtrips_openssl = valid_openssl && ((size_t)len_openssl == siglen) && (memcmp(roundtrip_openssl, sig, siglen) == 0);
+        roundtrips_openssl = valid_openssl && ((size_t)len_openssl == siglen) && (secp256k1_memcmp_var(roundtrip_openssl, sig, siglen) == 0);
     } else {
         len_openssl = 0;
     }
@@ -4693,7 +4693,7 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
     ret |= (roundtrips_der != roundtrips_openssl) << 7;
     if (roundtrips_openssl) {
         ret |= (len_der != (size_t)len_openssl) << 8;
-        ret |= ((len_der != (size_t)len_openssl) || (memcmp(roundtrip_der, roundtrip_openssl, len_der) != 0)) << 9;
+        ret |= ((len_der != (size_t)len_openssl) || (secp256k1_memcmp_var(roundtrip_der, roundtrip_openssl, len_der) != 0)) << 9;
     }
 #endif
     return ret;
@@ -5209,11 +5209,11 @@ void test_ecdsa_edge_cases(void) {
         CHECK(!is_empty_signature(&sig));
         CHECK(secp256k1_ecdsa_sign(ctx, &sig2, msg, key, nonce_function_rfc6979, extra) == 1);
         CHECK(!is_empty_signature(&sig2));
-        CHECK(memcmp(&sig, &sig2, sizeof(sig)) == 0);
+        CHECK(secp256k1_memcmp_var(&sig, &sig2, sizeof(sig)) == 0);
         /* The default nonce function is deterministic. */
         CHECK(secp256k1_ecdsa_sign(ctx, &sig2, msg, key, NULL, extra) == 1);
         CHECK(!is_empty_signature(&sig2));
-        CHECK(memcmp(&sig, &sig2, sizeof(sig)) == 0);
+        CHECK(secp256k1_memcmp_var(&sig, &sig2, sizeof(sig)) == 0);
         /* The default nonce function changes output with different messages. */
         for(i = 0; i < 256; i++) {
             int j;
@@ -5260,12 +5260,12 @@ void test_ecdsa_edge_cases(void) {
         VG_CHECK(nonce3,32);
         CHECK(nonce_function_rfc6979(nonce4, zeros, zeros, zeros, (void *)zeros, 0) == 1);
         VG_CHECK(nonce4,32);
-        CHECK(memcmp(nonce, nonce2, 32) != 0);
-        CHECK(memcmp(nonce, nonce3, 32) != 0);
-        CHECK(memcmp(nonce, nonce4, 32) != 0);
-        CHECK(memcmp(nonce2, nonce3, 32) != 0);
-        CHECK(memcmp(nonce2, nonce4, 32) != 0);
-        CHECK(memcmp(nonce3, nonce4, 32) != 0);
+        CHECK(secp256k1_memcmp_var(nonce, nonce2, 32) != 0);
+        CHECK(secp256k1_memcmp_var(nonce, nonce3, 32) != 0);
+        CHECK(secp256k1_memcmp_var(nonce, nonce4, 32) != 0);
+        CHECK(secp256k1_memcmp_var(nonce2, nonce3, 32) != 0);
+        CHECK(secp256k1_memcmp_var(nonce2, nonce4, 32) != 0);
+        CHECK(secp256k1_memcmp_var(nonce3, nonce4, 32) != 0);
     }
 
 
@@ -5368,12 +5368,12 @@ void run_memczero_test(void) {
     /* memczero(..., ..., 0) is a noop. */
     memcpy(buf2, buf1, sizeof(buf1));
     memczero(buf1, sizeof(buf1), 0);
-    CHECK(memcmp(buf1, buf2, sizeof(buf1)) == 0);
+    CHECK(secp256k1_memcmp_var(buf1, buf2, sizeof(buf1)) == 0);
 
     /* memczero(..., ..., 1) zeros the buffer. */
     memset(buf2, 0, sizeof(buf2));
     memczero(buf1, sizeof(buf1) , 1);
-    CHECK(memcmp(buf1, buf2, sizeof(buf1)) == 0);
+    CHECK(secp256k1_memcmp_var(buf1, buf2, sizeof(buf1)) == 0);
 }
 
 void int_cmov_test(void) {
@@ -5412,23 +5412,23 @@ void fe_cmov_test(void) {
     secp256k1_fe a = zero;
 
     secp256k1_fe_cmov(&r, &a, 0);
-    CHECK(memcmp(&r, &max, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &max, sizeof(r)) == 0);
 
     r = zero; a = max;
     secp256k1_fe_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &max, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &max, sizeof(r)) == 0);
 
     a = zero;
     secp256k1_fe_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &zero, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &zero, sizeof(r)) == 0);
 
     a = one;
     secp256k1_fe_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &one, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &one, sizeof(r)) == 0);
 
     r = one; a = zero;
     secp256k1_fe_cmov(&r, &a, 0);
-    CHECK(memcmp(&r, &one, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &one, sizeof(r)) == 0);
 }
 
 void fe_storage_cmov_test(void) {
@@ -5442,23 +5442,23 @@ void fe_storage_cmov_test(void) {
     secp256k1_fe_storage a = zero;
 
     secp256k1_fe_storage_cmov(&r, &a, 0);
-    CHECK(memcmp(&r, &max, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &max, sizeof(r)) == 0);
 
     r = zero; a = max;
     secp256k1_fe_storage_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &max, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &max, sizeof(r)) == 0);
 
     a = zero;
     secp256k1_fe_storage_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &zero, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &zero, sizeof(r)) == 0);
 
     a = one;
     secp256k1_fe_storage_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &one, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &one, sizeof(r)) == 0);
 
     r = one; a = zero;
     secp256k1_fe_storage_cmov(&r, &a, 0);
-    CHECK(memcmp(&r, &one, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &one, sizeof(r)) == 0);
 }
 
 void scalar_cmov_test(void) {
@@ -5472,23 +5472,23 @@ void scalar_cmov_test(void) {
     secp256k1_scalar a = zero;
 
     secp256k1_scalar_cmov(&r, &a, 0);
-    CHECK(memcmp(&r, &max, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &max, sizeof(r)) == 0);
 
     r = zero; a = max;
     secp256k1_scalar_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &max, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &max, sizeof(r)) == 0);
 
     a = zero;
     secp256k1_scalar_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &zero, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &zero, sizeof(r)) == 0);
 
     a = one;
     secp256k1_scalar_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &one, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &one, sizeof(r)) == 0);
 
     r = one; a = zero;
     secp256k1_scalar_cmov(&r, &a, 0);
-    CHECK(memcmp(&r, &one, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &one, sizeof(r)) == 0);
 }
 
 void ge_storage_cmov_test(void) {
@@ -5504,23 +5504,23 @@ void ge_storage_cmov_test(void) {
     secp256k1_ge_storage a = zero;
 
     secp256k1_ge_storage_cmov(&r, &a, 0);
-    CHECK(memcmp(&r, &max, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &max, sizeof(r)) == 0);
 
     r = zero; a = max;
     secp256k1_ge_storage_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &max, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &max, sizeof(r)) == 0);
 
     a = zero;
     secp256k1_ge_storage_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &zero, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &zero, sizeof(r)) == 0);
 
     a = one;
     secp256k1_ge_storage_cmov(&r, &a, 1);
-    CHECK(memcmp(&r, &one, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &one, sizeof(r)) == 0);
 
     r = one; a = zero;
     secp256k1_ge_storage_cmov(&r, &a, 0);
-    CHECK(memcmp(&r, &one, sizeof(r)) == 0);
+    CHECK(secp256k1_memcmp_var(&r, &one, sizeof(r)) == 0);
 }
 
 void run_cmov_tests(void) {

--- a/src/util.h
+++ b/src/util.h
@@ -216,6 +216,21 @@ static SECP256K1_INLINE void memczero(void *s, size_t len, int flag) {
     }
 }
 
+/** Semantics like memcmp. Variable-time.
+   We use this to avoid possible compiler bugs with memcmp, e.g., a bug in certain versions of GCC 9 and 10. */
+int secp256k1_memcmp_var(const void *s1, const void *s2, size_t n) {
+    const unsigned char *p1 = s1, *p2 = s2;
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        int diff = p1[i] - p2[i];
+        if (diff != 0) {
+            return diff;
+        }
+    }
+    return 0;
+}
+
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time.  Both *r and *a must be initialized and non-negative.*/
 static SECP256K1_INLINE void secp256k1_int_cmov(int *r, const int *a, int flag) {
     unsigned int mask0, mask1, r_masked, a_masked;


### PR DESCRIPTION
Fixes #823.

Fwiw, I considered to make this a constant-time function but didn't do it in the end. Most constant-time `memcmp` replacements are actually only inequality checks but we need a real `memcmp` which outputs which one of the arguments is larger.

If you look at crypto libraries, there are a few candidates but I found this overkill for our use case 
https://github.com/jedisct1/libsodium/blob/a8fa837aacd310bc08fa72705a738fafc2513125/src/libsodium/sodium/utils.c#L239
https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libc/string/timingsafe_memcmp.c?rev=1.1&content-type=text/x-cvsweb-markup

If we need a constant-time function in the future, it'll probably be only for equality/inequality, and then we can add the standard "OR of byte-wise XOR" implementation. 
