### PR TITLE
Rename testrand functions to have test in name

### DIFF
--- a/src/modules/extrakeys/tests_impl.h
+++ b/src/modules/extrakeys/tests_impl.h
@@ -35,9 +35,9 @@ void test_xonly_pubkey(void) {
     secp256k1_context *sign = api_test_context(SECP256K1_CONTEXT_SIGN, &ecount);
     secp256k1_context *verify = api_test_context(SECP256K1_CONTEXT_VERIFY, &ecount);
 
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(sk);
     memset(ones32, 0xFF, 32);
-    secp256k1_rand256(xy_sk);
+    secp256k1_testrand256(xy_sk);
     CHECK(secp256k1_ec_pubkey_create(sign, &pk, sk) == 1);
     CHECK(secp256k1_xonly_pubkey_from_pubkey(none, &xonly_pk, &pk_parity, &pk) == 1);
 
@@ -120,7 +120,7 @@ void test_xonly_pubkey(void) {
      * the curve) then xonly_pubkey_parse should fail as well. */
     for (i = 0; i < count; i++) {
         unsigned char rand33[33];
-        secp256k1_rand256(&rand33[1]);
+        secp256k1_testrand256(&rand33[1]);
         rand33[0] = SECP256K1_TAG_PUBKEY_EVEN;
         if (!secp256k1_ec_pubkey_parse(ctx, &pk, rand33, 33)) {
             memset(&xonly_pk, 1, sizeof(xonly_pk));
@@ -154,8 +154,8 @@ void test_xonly_pubkey_tweak(void) {
     secp256k1_context *verify = api_test_context(SECP256K1_CONTEXT_VERIFY, &ecount);
 
     memset(overflows, 0xff, sizeof(overflows));
-    secp256k1_rand256(tweak);
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(tweak);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_ec_pubkey_create(ctx, &internal_pk, sk) == 1);
     CHECK(secp256k1_xonly_pubkey_from_pubkey(none, &internal_xonly_pk, &pk_parity, &internal_pk) == 1);
 
@@ -198,7 +198,7 @@ void test_xonly_pubkey_tweak(void) {
 
     /* Invalid pk with a valid tweak */
     memset(&internal_xonly_pk, 0, sizeof(internal_xonly_pk));
-    secp256k1_rand256(tweak);
+    secp256k1_testrand256(tweak);
     ecount = 0;
     CHECK(secp256k1_xonly_pubkey_tweak_add(verify, &output_pk, &internal_xonly_pk, tweak) == 0);
     CHECK(ecount == 1);
@@ -228,8 +228,8 @@ void test_xonly_pubkey_tweak_check(void) {
     secp256k1_context *verify = api_test_context(SECP256K1_CONTEXT_VERIFY, &ecount);
 
     memset(overflows, 0xff, sizeof(overflows));
-    secp256k1_rand256(tweak);
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(tweak);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_ec_pubkey_create(ctx, &internal_pk, sk) == 1);
     CHECK(secp256k1_xonly_pubkey_from_pubkey(none, &internal_xonly_pk, &pk_parity, &internal_pk) == 1);
 
@@ -287,7 +287,7 @@ void test_xonly_pubkey_tweak_recursive(void) {
     unsigned char tweak[N_PUBKEYS - 1][32];
     int i;
 
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_ec_pubkey_create(ctx, &pk[0], sk) == 1);
     /* Add tweaks */
     for (i = 0; i < N_PUBKEYS - 1; i++) {
@@ -327,7 +327,7 @@ void test_keypair(void) {
 
     /* Test keypair_create */
     ecount = 0;
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_keypair_create(none, &keypair, sk) == 0);
     CHECK(memcmp(zeros96, &keypair, sizeof(keypair)) == 0);
     CHECK(ecount == 1);
@@ -349,7 +349,7 @@ void test_keypair(void) {
 
     /* Test keypair_pub */
     ecount = 0;
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk) == 1);
     CHECK(secp256k1_keypair_pub(none, &pk, &keypair) == 1);
     CHECK(secp256k1_keypair_pub(none, NULL, &keypair) == 0);
@@ -371,7 +371,7 @@ void test_keypair(void) {
 
     /** Test keypair_xonly_pub **/
     ecount = 0;
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk) == 1);
     CHECK(secp256k1_keypair_xonly_pub(none, &xonly_pk, &pk_parity, &keypair) == 1);
     CHECK(secp256k1_keypair_xonly_pub(none, NULL, &pk_parity, &keypair) == 0);
@@ -414,8 +414,8 @@ void test_keypair_add(void) {
     secp256k1_context *verify = api_test_context(SECP256K1_CONTEXT_VERIFY, &ecount);
 
     CHECK(sizeof(zeros96) == sizeof(keypair));
-    secp256k1_rand256(sk);
-    secp256k1_rand256(tweak);
+    secp256k1_testrand256(sk);
+    secp256k1_testrand256(tweak);
     memset(overflows, 0xFF, 32);
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk) == 1);
 
@@ -444,7 +444,7 @@ void test_keypair_add(void) {
     for (i = 0; i < count; i++) {
         secp256k1_scalar scalar_tweak;
         secp256k1_keypair keypair_tmp;
-        secp256k1_rand256(sk);
+        secp256k1_testrand256(sk);
         CHECK(secp256k1_keypair_create(ctx, &keypair, sk) == 1);
         memcpy(&keypair_tmp, &keypair, sizeof(keypair));
         /* Because sk may be negated before adding, we need to try with tweak =
@@ -460,7 +460,7 @@ void test_keypair_add(void) {
 
     /* Invalid keypair with a valid tweak */
     memset(&keypair, 0, sizeof(keypair));
-    secp256k1_rand256(tweak);
+    secp256k1_testrand256(tweak);
     ecount = 0;
     CHECK(secp256k1_keypair_xonly_tweak_add(verify, &keypair, tweak) == 0);
     CHECK(ecount == 1);
@@ -486,7 +486,7 @@ void test_keypair_add(void) {
         unsigned char pk32[32];
         int pk_parity;
 
-        secp256k1_rand256(tweak);
+        secp256k1_testrand256(tweak);
         CHECK(secp256k1_keypair_xonly_pub(ctx, &internal_pk, NULL, &keypair) == 1);
         CHECK(secp256k1_keypair_xonly_tweak_add(ctx, &keypair, tweak) == 1);
         CHECK(secp256k1_keypair_xonly_pub(ctx, &output_pk, &pk_parity, &keypair) == 1);

--- a/src/modules/recovery/tests_impl.h
+++ b/src/modules/recovery/tests_impl.h
@@ -25,7 +25,7 @@ static int recovery_test_nonce_function(unsigned char *nonce32, const unsigned c
     }
     /* On the next run, return a valid nonce, but flip a coin as to whether or not to fail signing. */
     memset(nonce32, 1, 32);
-    return secp256k1_rand_bits(1);
+    return secp256k1_testrand_bits(1);
 }
 
 void test_ecdsa_recovery_api(void) {
@@ -196,7 +196,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(memcmp(&pubkey, &recpubkey, sizeof(pubkey)) == 0);
     /* Serialize/destroy/parse signature and verify again. */
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
-    sig[secp256k1_rand_bits(6)] += 1 + secp256k1_rand_int(255);
+    sig[secp256k1_testrand_bits(6)] += 1 + secp256k1_testrand_int(255);
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 0);

--- a/src/modules/schnorrsig/tests_exhaustive_impl.h
+++ b/src/modules/schnorrsig/tests_exhaustive_impl.h
@@ -100,7 +100,7 @@ static void test_exhaustive_schnorrsig_verify(const secp256k1_context *ctx, cons
             while (e_count_done < EXHAUSTIVE_TEST_ORDER) {
                 secp256k1_scalar e;
                 unsigned char msg32[32];
-                secp256k1_rand256(msg32);
+                secp256k1_testrand256(msg32);
                 secp256k1_schnorrsig_challenge(&e, sig64, msg32, pk32);
                 /* Only do work if we hit a challenge we haven't tried before. */
                 if (!e_done[e]) {
@@ -116,7 +116,7 @@ static void test_exhaustive_schnorrsig_verify(const secp256k1_context *ctx, cons
                             expect_valid = actual_k != -1 && s != EXHAUSTIVE_TEST_ORDER &&
                                            (s_s == (actual_k + actual_d * e) % EXHAUSTIVE_TEST_ORDER);
                         } else {
-                            secp256k1_rand256(sig64 + 32);
+                            secp256k1_testrand256(sig64 + 32);
                             expect_valid = 0;
                         }
                         valid = secp256k1_schnorrsig_verify(ctx, sig64, msg32, &pubkeys[d - 1]);
@@ -153,7 +153,7 @@ static void test_exhaustive_schnorrsig_sign(const secp256k1_context *ctx, unsign
             /* Generate random messages until all challenges have been tried. */
             while (e_count_done < EXHAUSTIVE_TEST_ORDER) {
                 secp256k1_scalar e;
-                secp256k1_rand256(msg32);
+                secp256k1_testrand256(msg32);
                 secp256k1_schnorrsig_challenge(&e, xonly_pubkey_bytes[k - 1], msg32, xonly_pubkey_bytes[d - 1]);
                 /* Only do work if we hit a challenge we haven't tried before. */
                 if (!e_done[e]) {

--- a/src/modules/schnorrsig/tests_impl.h
+++ b/src/modules/schnorrsig/tests_impl.h
@@ -15,7 +15,7 @@
 void nonce_function_bip340_bitflip(unsigned char **args, size_t n_flip, size_t n_bytes) {
     unsigned char nonces[2][32];
     CHECK(nonce_function_bip340(nonces[0], args[0], args[1], args[2], args[3], args[4]) == 1);
-    secp256k1_rand_flip(args[n_flip], n_bytes);
+    secp256k1_testrand_flip(args[n_flip], n_bytes);
     CHECK(nonce_function_bip340(nonces[1], args[0], args[1], args[2], args[3], args[4]) == 1);
     CHECK(memcmp(nonces[0], nonces[1], 32) != 0);
 }
@@ -59,10 +59,10 @@ void run_nonce_function_bip340_tests(void) {
     secp256k1_nonce_function_bip340_sha256_tagged_aux(&sha_optimized);
     test_sha256_eq(&sha, &sha_optimized);
 
-    secp256k1_rand256(msg);
-    secp256k1_rand256(key);
-    secp256k1_rand256(pk);
-    secp256k1_rand256(aux_rand);
+    secp256k1_testrand256(msg);
+    secp256k1_testrand256(key);
+    secp256k1_testrand256(pk);
+    secp256k1_testrand256(aux_rand);
 
     /* Check that a bitflip in an argument results in different nonces. */
     args[0] = msg;
@@ -124,10 +124,10 @@ void test_schnorrsig_api(void) {
     secp256k1_context_set_illegal_callback(vrfy, counting_illegal_callback_fn, &ecount);
     secp256k1_context_set_illegal_callback(both, counting_illegal_callback_fn, &ecount);
 
-    secp256k1_rand256(sk1);
-    secp256k1_rand256(sk2);
-    secp256k1_rand256(sk3);
-    secp256k1_rand256(msg);
+    secp256k1_testrand256(sk1);
+    secp256k1_testrand256(sk2);
+    secp256k1_testrand256(sk3);
+    secp256k1_testrand256(msg);
     CHECK(secp256k1_keypair_create(ctx, &keypairs[0], sk1) == 1);
     CHECK(secp256k1_keypair_create(ctx, &keypairs[1], sk2) == 1);
     CHECK(secp256k1_keypair_create(ctx, &keypairs[2], sk3) == 1);
@@ -675,7 +675,7 @@ void test_schnorrsig_sign(void) {
     unsigned char sig[64];
     unsigned char zeros64[64] = { 0 };
 
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk));
     CHECK(secp256k1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, NULL) == 1);
 
@@ -703,12 +703,12 @@ void test_schnorrsig_sign_verify(void) {
     secp256k1_xonly_pubkey pk;
     secp256k1_scalar s;
 
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk));
     CHECK(secp256k1_keypair_xonly_pub(ctx, &pk, NULL, &keypair));
 
     for (i = 0; i < N_SIGS; i++) {
-        secp256k1_rand256(msg[i]);
+        secp256k1_testrand256(msg[i]);
         CHECK(secp256k1_schnorrsig_sign(ctx, sig[i], msg[i], &keypair, NULL, NULL));
         CHECK(secp256k1_schnorrsig_verify(ctx, sig[i], msg[i], &pk));
     }
@@ -716,19 +716,19 @@ void test_schnorrsig_sign_verify(void) {
     {
         /* Flip a few bits in the signature and in the message and check that
          * verify and verify_batch (TODO) fail */
-        size_t sig_idx = secp256k1_rand_int(N_SIGS);
-        size_t byte_idx = secp256k1_rand_int(32);
-        unsigned char xorbyte = secp256k1_rand_int(254)+1;
+        size_t sig_idx = secp256k1_testrand_int(N_SIGS);
+        size_t byte_idx = secp256k1_testrand_int(32);
+        unsigned char xorbyte = secp256k1_testrand_int(254)+1;
         sig[sig_idx][byte_idx] ^= xorbyte;
         CHECK(!secp256k1_schnorrsig_verify(ctx, sig[sig_idx], msg[sig_idx], &pk));
         sig[sig_idx][byte_idx] ^= xorbyte;
 
-        byte_idx = secp256k1_rand_int(32);
+        byte_idx = secp256k1_testrand_int(32);
         sig[sig_idx][32+byte_idx] ^= xorbyte;
         CHECK(!secp256k1_schnorrsig_verify(ctx, sig[sig_idx], msg[sig_idx], &pk));
         sig[sig_idx][32+byte_idx] ^= xorbyte;
 
-        byte_idx = secp256k1_rand_int(32);
+        byte_idx = secp256k1_testrand_int(32);
         msg[sig_idx][byte_idx] ^= xorbyte;
         CHECK(!secp256k1_schnorrsig_verify(ctx, sig[sig_idx], msg[sig_idx], &pk));
         msg[sig_idx][byte_idx] ^= xorbyte;
@@ -766,7 +766,7 @@ void test_schnorrsig_taproot(void) {
     unsigned char sig[64];
 
     /* Create output key */
-    secp256k1_rand256(sk);
+    secp256k1_testrand256(sk);
     CHECK(secp256k1_keypair_create(ctx, &keypair, sk) == 1);
     CHECK(secp256k1_keypair_xonly_pub(ctx, &internal_pk, NULL, &keypair) == 1);
     /* In actual taproot the tweak would be hash of internal_pk */
@@ -776,7 +776,7 @@ void test_schnorrsig_taproot(void) {
     CHECK(secp256k1_xonly_pubkey_serialize(ctx, output_pk_bytes, &output_pk) == 1);
 
     /* Key spend */
-    secp256k1_rand256(msg);
+    secp256k1_testrand256(msg);
     CHECK(secp256k1_schnorrsig_sign(ctx, sig, msg, &keypair, NULL, NULL) == 1);
     /* Verify key spend */
     CHECK(secp256k1_xonly_pubkey_parse(ctx, &output_pk, output_pk_bytes) == 1);

--- a/src/testrand.h
+++ b/src/testrand.h
@@ -14,34 +14,34 @@
 /* A non-cryptographic RNG used only for test infrastructure. */
 
 /** Seed the pseudorandom number generator for testing. */
-SECP256K1_INLINE static void secp256k1_rand_seed(const unsigned char *seed16);
+SECP256K1_INLINE static void secp256k1_testrand_seed(const unsigned char *seed16);
 
 /** Generate a pseudorandom number in the range [0..2**32-1]. */
-static uint32_t secp256k1_rand32(void);
+static uint32_t secp256k1_testrand32(void);
 
 /** Generate a pseudorandom number in the range [0..2**bits-1]. Bits must be 1 or
  *  more. */
-static uint32_t secp256k1_rand_bits(int bits);
+static uint32_t secp256k1_testrand_bits(int bits);
 
 /** Generate a pseudorandom number in the range [0..range-1]. */
-static uint32_t secp256k1_rand_int(uint32_t range);
+static uint32_t secp256k1_testrand_int(uint32_t range);
 
 /** Generate a pseudorandom 32-byte array. */
-static void secp256k1_rand256(unsigned char *b32);
+static void secp256k1_testrand256(unsigned char *b32);
 
 /** Generate a pseudorandom 32-byte array with long sequences of zero and one bits. */
-static void secp256k1_rand256_test(unsigned char *b32);
+static void secp256k1_testrand256_test(unsigned char *b32);
 
 /** Generate pseudorandom bytes with long sequences of zero and one bits. */
-static void secp256k1_rand_bytes_test(unsigned char *bytes, size_t len);
+static void secp256k1_testrand_bytes_test(unsigned char *bytes, size_t len);
 
 /** Flip a single random bit in a byte array */
-static void secp256k1_rand_flip(unsigned char *b, size_t len);
+static void secp256k1_testrand_flip(unsigned char *b, size_t len);
 
 /** Initialize the test RNG using (hex encoded) array up to 16 bytes, or randomly if hexseed is NULL. */
-static void secp256k1_rand_init(const char* hexseed);
+static void secp256k1_testrand_init(const char* hexseed);
 
 /** Print final test information. */
-static void secp256k1_rand_finish(void);
+static void secp256k1_testrand_finish(void);
 
 #endif /* SECP256K1_TESTRAND_H */

--- a/src/testrand_impl.h
+++ b/src/testrand_impl.h
@@ -20,11 +20,11 @@ static int secp256k1_test_rng_precomputed_used = 8;
 static uint64_t secp256k1_test_rng_integer;
 static int secp256k1_test_rng_integer_bits_left = 0;
 
-SECP256K1_INLINE static void secp256k1_rand_seed(const unsigned char *seed16) {
+SECP256K1_INLINE static void secp256k1_testrand_seed(const unsigned char *seed16) {
     secp256k1_rfc6979_hmac_sha256_initialize(&secp256k1_test_rng, seed16, 16);
 }
 
-SECP256K1_INLINE static uint32_t secp256k1_rand32(void) {
+SECP256K1_INLINE static uint32_t secp256k1_testrand32(void) {
     if (secp256k1_test_rng_precomputed_used == 8) {
         secp256k1_rfc6979_hmac_sha256_generate(&secp256k1_test_rng, (unsigned char*)(&secp256k1_test_rng_precomputed[0]), sizeof(secp256k1_test_rng_precomputed));
         secp256k1_test_rng_precomputed_used = 0;
@@ -32,10 +32,10 @@ SECP256K1_INLINE static uint32_t secp256k1_rand32(void) {
     return secp256k1_test_rng_precomputed[secp256k1_test_rng_precomputed_used++];
 }
 
-static uint32_t secp256k1_rand_bits(int bits) {
+static uint32_t secp256k1_testrand_bits(int bits) {
     uint32_t ret;
     if (secp256k1_test_rng_integer_bits_left < bits) {
-        secp256k1_test_rng_integer |= (((uint64_t)secp256k1_rand32()) << secp256k1_test_rng_integer_bits_left);
+        secp256k1_test_rng_integer |= (((uint64_t)secp256k1_testrand32()) << secp256k1_test_rng_integer_bits_left);
         secp256k1_test_rng_integer_bits_left += 32;
     }
     ret = secp256k1_test_rng_integer;
@@ -45,7 +45,7 @@ static uint32_t secp256k1_rand_bits(int bits) {
     return ret;
 }
 
-static uint32_t secp256k1_rand_int(uint32_t range) {
+static uint32_t secp256k1_testrand_int(uint32_t range) {
     /* We want a uniform integer between 0 and range-1, inclusive.
      * B is the smallest number such that range <= 2**B.
      * two mechanisms implemented here:
@@ -77,25 +77,25 @@ static uint32_t secp256k1_rand_int(uint32_t range) {
         mult = 1;
     }
     while(1) {
-        uint32_t x = secp256k1_rand_bits(bits);
+        uint32_t x = secp256k1_testrand_bits(bits);
         if (x < trange) {
             return (mult == 1) ? x : (x % range);
         }
     }
 }
 
-static void secp256k1_rand256(unsigned char *b32) {
+static void secp256k1_testrand256(unsigned char *b32) {
     secp256k1_rfc6979_hmac_sha256_generate(&secp256k1_test_rng, b32, 32);
 }
 
-static void secp256k1_rand_bytes_test(unsigned char *bytes, size_t len) {
+static void secp256k1_testrand_bytes_test(unsigned char *bytes, size_t len) {
     size_t bits = 0;
     memset(bytes, 0, len);
     while (bits < len * 8) {
         int now;
         uint32_t val;
-        now = 1 + (secp256k1_rand_bits(6) * secp256k1_rand_bits(5) + 16) / 31;
-        val = secp256k1_rand_bits(1);
+        now = 1 + (secp256k1_testrand_bits(6) * secp256k1_testrand_bits(5) + 16) / 31;
+        val = secp256k1_testrand_bits(1);
         while (now > 0 && bits < len * 8) {
             bytes[bits / 8] |= val << (bits % 8);
             now--;
@@ -104,15 +104,15 @@ static void secp256k1_rand_bytes_test(unsigned char *bytes, size_t len) {
     }
 }
 
-static void secp256k1_rand256_test(unsigned char *b32) {
-    secp256k1_rand_bytes_test(b32, 32);
+static void secp256k1_testrand256_test(unsigned char *b32) {
+    secp256k1_testrand_bytes_test(b32, 32);
 }
 
-static void secp256k1_rand_flip(unsigned char *b, size_t len) {
-    b[secp256k1_rand_int(len)] ^= (1 << secp256k1_rand_int(8));
+static void secp256k1_testrand_flip(unsigned char *b, size_t len) {
+    b[secp256k1_testrand_int(len)] ^= (1 << secp256k1_testrand_int(8));
 }
 
-static void secp256k1_rand_init(const char* hexseed) {
+static void secp256k1_testrand_init(const char* hexseed) {
     unsigned char seed16[16] = {0};
     if (hexseed && strlen(hexseed) != 0) {
         int pos = 0;
@@ -146,12 +146,12 @@ static void secp256k1_rand_init(const char* hexseed) {
     }
 
     printf("random seed = %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", seed16[0], seed16[1], seed16[2], seed16[3], seed16[4], seed16[5], seed16[6], seed16[7], seed16[8], seed16[9], seed16[10], seed16[11], seed16[12], seed16[13], seed16[14], seed16[15]);
-    secp256k1_rand_seed(seed16);
+    secp256k1_testrand_seed(seed16);
 }
 
-static void secp256k1_rand_finish(void) {
+static void secp256k1_testrand_finish(void) {
     unsigned char run32[32];
-    secp256k1_rand256(run32);
+    secp256k1_testrand256(run32);
     printf("random run = %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", run32[0], run32[1], run32[2], run32[3], run32[4], run32[5], run32[6], run32[7], run32[8], run32[9], run32[10], run32[11], run32[12], run32[13], run32[14], run32[15]);
 }
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -54,7 +54,7 @@ static void uncounting_illegal_callback_fn(const char* str, void* data) {
 void random_field_element_test(secp256k1_fe *fe) {
     do {
         unsigned char b32[32];
-        secp256k1_rand256_test(b32);
+        secp256k1_testrand256_test(b32);
         if (secp256k1_fe_set_b32(fe, b32)) {
             break;
         }
@@ -63,7 +63,7 @@ void random_field_element_test(secp256k1_fe *fe) {
 
 void random_field_element_magnitude(secp256k1_fe *fe) {
     secp256k1_fe zero;
-    int n = secp256k1_rand_int(9);
+    int n = secp256k1_testrand_int(9);
     secp256k1_fe_normalize(fe);
     if (n == 0) {
         return;
@@ -81,7 +81,7 @@ void random_group_element_test(secp256k1_ge *ge) {
     secp256k1_fe fe;
     do {
         random_field_element_test(&fe);
-        if (secp256k1_ge_set_xo_var(ge, &fe, secp256k1_rand_bits(1))) {
+        if (secp256k1_ge_set_xo_var(ge, &fe, secp256k1_testrand_bits(1))) {
             secp256k1_fe_normalize(&ge->y);
             break;
         }
@@ -108,7 +108,7 @@ void random_scalar_order_test(secp256k1_scalar *num) {
     do {
         unsigned char b32[32];
         int overflow = 0;
-        secp256k1_rand256_test(b32);
+        secp256k1_testrand256_test(b32);
         secp256k1_scalar_set_b32(num, b32, &overflow);
         if (overflow || secp256k1_scalar_is_zero(num)) {
             continue;
@@ -121,7 +121,7 @@ void random_scalar_order(secp256k1_scalar *num) {
     do {
         unsigned char b32[32];
         int overflow = 0;
-        secp256k1_rand256(b32);
+        secp256k1_testrand256(b32);
         secp256k1_scalar_set_b32(num, b32, &overflow);
         if (overflow || secp256k1_scalar_is_zero(num)) {
             continue;
@@ -444,7 +444,7 @@ void run_sha256_tests(void) {
         secp256k1_sha256_finalize(&hasher, out);
         CHECK(memcmp(out, outputs[i], 32) == 0);
         if (strlen(inputs[i]) > 0) {
-            int split = secp256k1_rand_int(strlen(inputs[i]));
+            int split = secp256k1_testrand_int(strlen(inputs[i]));
             secp256k1_sha256_initialize(&hasher);
             secp256k1_sha256_write(&hasher, (const unsigned char*)(inputs[i]), split);
             secp256k1_sha256_write(&hasher, (const unsigned char*)(inputs[i] + split), strlen(inputs[i]) - split);
@@ -488,7 +488,7 @@ void run_hmac_sha256_tests(void) {
         secp256k1_hmac_sha256_finalize(&hasher, out);
         CHECK(memcmp(out, outputs[i], 32) == 0);
         if (strlen(inputs[i]) > 0) {
-            int split = secp256k1_rand_int(strlen(inputs[i]));
+            int split = secp256k1_testrand_int(strlen(inputs[i]));
             secp256k1_hmac_sha256_initialize(&hasher, (const unsigned char*)(keys[i]), strlen(keys[i]));
             secp256k1_hmac_sha256_write(&hasher, (const unsigned char*)(inputs[i]), split);
             secp256k1_hmac_sha256_write(&hasher, (const unsigned char*)(inputs[i] + split), strlen(inputs[i]) - split);
@@ -558,7 +558,7 @@ void test_rand_bits(int rand32, int bits) {
     /* Multiply the output of all rand calls with the odd number m, which
        should not change the uniformity of its distribution. */
     for (i = 0; i < rounds[usebits]; i++) {
-        uint32_t r = (rand32 ? secp256k1_rand32() : secp256k1_rand_bits(bits));
+        uint32_t r = (rand32 ? secp256k1_testrand32() : secp256k1_testrand_bits(bits));
         CHECK((((uint64_t)r) >> bits) == 0);
         for (m = 0; m < sizeof(mults) / sizeof(mults[0]); m++) {
             uint32_t rm = r * mults[m];
@@ -583,7 +583,7 @@ void test_rand_int(uint32_t range, uint32_t subrange) {
     uint64_t x = 0;
     CHECK((range % subrange) == 0);
     for (i = 0; i < rounds; i++) {
-        uint32_t r = secp256k1_rand_int(range);
+        uint32_t r = secp256k1_testrand_int(range);
         CHECK(r < range);
         r = r % subrange;
         x |= (((uint64_t)1) << r);
@@ -615,7 +615,7 @@ void run_rand_int(void) {
 
 #ifndef USE_NUM_NONE
 void random_num_negate(secp256k1_num *num) {
-    if (secp256k1_rand_bits(1)) {
+    if (secp256k1_testrand_bits(1)) {
         secp256k1_num_negate(num);
     }
 }
@@ -659,11 +659,11 @@ void test_num_add_sub(void) {
     secp256k1_num n2;
     secp256k1_num n1p2, n2p1, n1m2, n2m1;
     random_num_order_test(&n1); /* n1 = R1 */
-    if (secp256k1_rand_bits(1)) {
+    if (secp256k1_testrand_bits(1)) {
         random_num_negate(&n1);
     }
     random_num_order_test(&n2); /* n2 = R2 */
-    if (secp256k1_rand_bits(1)) {
+    if (secp256k1_testrand_bits(1)) {
         random_num_negate(&n2);
     }
     secp256k1_num_add(&n1p2, &n1, &n2); /* n1p2 = R1 + R2 */
@@ -854,7 +854,7 @@ void scalar_test(void) {
         while (i < 256) {
             secp256k1_scalar t;
             int j;
-            int now = secp256k1_rand_int(15) + 1;
+            int now = secp256k1_testrand_int(15) + 1;
             if (now + i > 256) {
                 now = 256 - i;
             }
@@ -931,7 +931,7 @@ void scalar_test(void) {
         secp256k1_num rnum;
         secp256k1_num rnum2;
         unsigned char cone[1] = {0x01};
-        unsigned int shift = 256 + secp256k1_rand_int(257);
+        unsigned int shift = 256 + secp256k1_testrand_int(257);
         secp256k1_scalar_mul_shift_var(&r, &s1, &s2, shift);
         secp256k1_num_mul(&rnum, &s1num, &s2num);
         secp256k1_num_shift(&rnum, shift - 1);
@@ -949,7 +949,7 @@ void scalar_test(void) {
         random_scalar_order_test(&r);
         for (i = 0; i < 100; ++i) {
             int low;
-            int shift = 1 + secp256k1_rand_int(15);
+            int shift = 1 + secp256k1_testrand_int(15);
             int expected = r.d[0] % (1 << shift);
             low = secp256k1_scalar_shr_int(&r, shift);
             CHECK(expected == low);
@@ -997,7 +997,7 @@ void scalar_test(void) {
         secp256k1_scalar b;
         int i;
         /* Test add_bit. */
-        int bit = secp256k1_rand_bits(8);
+        int bit = secp256k1_testrand_bits(8);
         secp256k1_scalar_set_int(&b, 1);
         CHECK(secp256k1_scalar_is_one(&b));
         for (i = 0; i < bit; i++) {
@@ -1768,7 +1768,7 @@ void run_scalar_tests(void) {
 void random_fe(secp256k1_fe *x) {
     unsigned char bin[32];
     do {
-        secp256k1_rand256(bin);
+        secp256k1_testrand256(bin);
         if (secp256k1_fe_set_b32(x, bin)) {
             return;
         }
@@ -1778,7 +1778,7 @@ void random_fe(secp256k1_fe *x) {
 void random_fe_test(secp256k1_fe *x) {
     unsigned char bin[32];
     do {
-        secp256k1_rand256_test(bin);
+        secp256k1_testrand256_test(bin);
         if (secp256k1_fe_set_b32(x, bin)) {
             return;
         }
@@ -1971,7 +1971,7 @@ void run_field_inv_all_var(void) {
     secp256k1_fe_inv_all_var(xi, x, 0);
     for (i = 0; i < count; i++) {
         size_t j;
-        size_t len = secp256k1_rand_int(15) + 1;
+        size_t len = secp256k1_testrand_int(15) + 1;
         for (j = 0; j < len; j++) {
             random_fe_non_zero(&x[j]);
         }
@@ -2263,7 +2263,7 @@ void test_ge(void) {
             gej_shuffled[i] = gej[i];
         }
         for (i = 0; i < 4 * runs + 1; i++) {
-            int swap = i + secp256k1_rand_int(4 * runs + 1 - i);
+            int swap = i + secp256k1_testrand_int(4 * runs + 1 - i);
             if (swap != i) {
                 secp256k1_gej t = gej_shuffled[i];
                 gej_shuffled[i] = gej_shuffled[swap];
@@ -3059,7 +3059,7 @@ void test_secp256k1_pippenger_bucket_window_inv(void) {
  * for a given scratch space.
  */
 void test_ecmult_multi_pippenger_max_points(void) {
-    size_t scratch_size = secp256k1_rand_int(256);
+    size_t scratch_size = secp256k1_testrand_int(256);
     size_t max_size = secp256k1_pippenger_scratch_size(secp256k1_pippenger_bucket_window_inv(PIPPENGER_MAX_BUCKET_WINDOW-1)+512, 12);
     secp256k1_scratch *scratch;
     size_t n_points_supported;
@@ -3519,7 +3519,7 @@ void test_ecmult_gen_blind(void) {
     secp256k1_ge pge;
     random_scalar_order_test(&key);
     secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &pgej, &key);
-    secp256k1_rand256(seed32);
+    secp256k1_testrand256(seed32);
     b = ctx->ecmult_gen_ctx.blind;
     i = ctx->ecmult_gen_ctx.initial;
     secp256k1_ecmult_gen_blind(&ctx->ecmult_gen_ctx, seed32);
@@ -4294,7 +4294,7 @@ void test_ecdsa_sign_verify(void) {
     random_scalar_order_test(&key);
     secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &pubj, &key);
     secp256k1_ge_set_gej(&pub, &pubj);
-    getrec = secp256k1_rand_bits(1);
+    getrec = secp256k1_testrand_bits(1);
     random_sign(&sigr, &sigs, &key, &msg, getrec?&recid:NULL);
     if (getrec) {
         CHECK(recid >= 0 && recid < 4);
@@ -4394,7 +4394,7 @@ void test_ecdsa_end_to_end(void) {
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Verify exporting and importing public key. */
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, pubkeyc, &pubkeyclen, &pubkey, secp256k1_rand_bits(1) == 1 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
+    CHECK(secp256k1_ec_pubkey_serialize(ctx, pubkeyc, &pubkeyclen, &pubkey, secp256k1_testrand_bits(1) == 1 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
     memset(&pubkey, 0, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 1);
 
@@ -4406,19 +4406,19 @@ void test_ecdsa_end_to_end(void) {
     CHECK(memcmp(&pubkey_tmp, &pubkey, sizeof(pubkey)) == 0);
 
     /* Verify private key import and export. */
-    CHECK(ec_privkey_export_der(ctx, seckey, &seckeylen, privkey, secp256k1_rand_bits(1) == 1));
+    CHECK(ec_privkey_export_der(ctx, seckey, &seckeylen, privkey, secp256k1_testrand_bits(1) == 1));
     CHECK(ec_privkey_import_der(ctx, privkey2, seckey, seckeylen) == 1);
     CHECK(memcmp(privkey, privkey2, 32) == 0);
 
     /* Optionally tweak the keys using addition. */
-    if (secp256k1_rand_int(3) == 0) {
+    if (secp256k1_testrand_int(3) == 0) {
         int ret1;
         int ret2;
         int ret3;
         unsigned char rnd[32];
         unsigned char privkey_tmp[32];
         secp256k1_pubkey pubkey2;
-        secp256k1_rand256_test(rnd);
+        secp256k1_testrand256_test(rnd);
         memcpy(privkey_tmp, privkey, 32);
         ret1 = secp256k1_ec_seckey_tweak_add(ctx, privkey, rnd);
         ret2 = secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, rnd);
@@ -4435,14 +4435,14 @@ void test_ecdsa_end_to_end(void) {
     }
 
     /* Optionally tweak the keys using multiplication. */
-    if (secp256k1_rand_int(3) == 0) {
+    if (secp256k1_testrand_int(3) == 0) {
         int ret1;
         int ret2;
         int ret3;
         unsigned char rnd[32];
         unsigned char privkey_tmp[32];
         secp256k1_pubkey pubkey2;
-        secp256k1_rand256_test(rnd);
+        secp256k1_testrand256_test(rnd);
         memcpy(privkey_tmp, privkey, 32);
         ret1 = secp256k1_ec_seckey_tweak_mul(ctx, privkey, rnd);
         ret2 = secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, rnd);
@@ -4504,7 +4504,7 @@ void test_ecdsa_end_to_end(void) {
     /* Serialize/destroy/parse DER and verify again. */
     siglen = 74;
     CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
-    sig[secp256k1_rand_int(siglen)] += 1 + secp256k1_rand_int(255);
+    sig[secp256k1_testrand_int(siglen)] += 1 + secp256k1_testrand_int(255);
     CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 0 ||
           secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 0);
 }
@@ -4514,23 +4514,23 @@ void test_random_pubkeys(void) {
     secp256k1_ge elem2;
     unsigned char in[65];
     /* Generate some randomly sized pubkeys. */
-    size_t len = secp256k1_rand_bits(2) == 0 ? 65 : 33;
-    if (secp256k1_rand_bits(2) == 0) {
-        len = secp256k1_rand_bits(6);
+    size_t len = secp256k1_testrand_bits(2) == 0 ? 65 : 33;
+    if (secp256k1_testrand_bits(2) == 0) {
+        len = secp256k1_testrand_bits(6);
     }
     if (len == 65) {
-      in[0] = secp256k1_rand_bits(1) ? 4 : (secp256k1_rand_bits(1) ? 6 : 7);
+      in[0] = secp256k1_testrand_bits(1) ? 4 : (secp256k1_testrand_bits(1) ? 6 : 7);
     } else {
-      in[0] = secp256k1_rand_bits(1) ? 2 : 3;
+      in[0] = secp256k1_testrand_bits(1) ? 2 : 3;
     }
-    if (secp256k1_rand_bits(3) == 0) {
-        in[0] = secp256k1_rand_bits(8);
+    if (secp256k1_testrand_bits(3) == 0) {
+        in[0] = secp256k1_testrand_bits(8);
     }
     if (len > 1) {
-        secp256k1_rand256(&in[1]);
+        secp256k1_testrand256(&in[1]);
     }
     if (len > 33) {
-        secp256k1_rand256(&in[33]);
+        secp256k1_testrand256(&in[33]);
     }
     if (secp256k1_eckey_pubkey_parse(&elem, in, len)) {
         unsigned char out[65];
@@ -4552,7 +4552,7 @@ void test_random_pubkeys(void) {
         CHECK(secp256k1_eckey_pubkey_parse(&elem2, in, size));
         ge_equals_ge(&elem,&elem2);
         /* Check that the X9.62 hybrid type is checked. */
-        in[0] = secp256k1_rand_bits(1) ? 6 : 7;
+        in[0] = secp256k1_testrand_bits(1) ? 6 : 7;
         res = secp256k1_eckey_pubkey_parse(&elem2, in, size);
         if (firstb == 2 || firstb == 3) {
             if (in[0] == firstb + 4) {
@@ -4711,27 +4711,27 @@ static void assign_big_endian(unsigned char *ptr, size_t ptrlen, uint32_t val) {
 
 static void damage_array(unsigned char *sig, size_t *len) {
     int pos;
-    int action = secp256k1_rand_bits(3);
+    int action = secp256k1_testrand_bits(3);
     if (action < 1 && *len > 3) {
         /* Delete a byte. */
-        pos = secp256k1_rand_int(*len);
+        pos = secp256k1_testrand_int(*len);
         memmove(sig + pos, sig + pos + 1, *len - pos - 1);
         (*len)--;
         return;
     } else if (action < 2 && *len < 2048) {
         /* Insert a byte. */
-        pos = secp256k1_rand_int(1 + *len);
+        pos = secp256k1_testrand_int(1 + *len);
         memmove(sig + pos + 1, sig + pos, *len - pos);
-        sig[pos] = secp256k1_rand_bits(8);
+        sig[pos] = secp256k1_testrand_bits(8);
         (*len)++;
         return;
     } else if (action < 4) {
         /* Modify a byte. */
-        sig[secp256k1_rand_int(*len)] += 1 + secp256k1_rand_int(255);
+        sig[secp256k1_testrand_int(*len)] += 1 + secp256k1_testrand_int(255);
         return;
     } else { /* action < 8 */
         /* Modify a bit. */
-        sig[secp256k1_rand_int(*len)] ^= 1 << secp256k1_rand_bits(3);
+        sig[secp256k1_testrand_int(*len)] ^= 1 << secp256k1_testrand_bits(3);
         return;
     }
 }
@@ -4744,23 +4744,23 @@ static void random_ber_signature(unsigned char *sig, size_t *len, int* certainly
     int n;
 
     *len = 0;
-    der = secp256k1_rand_bits(2) == 0;
+    der = secp256k1_testrand_bits(2) == 0;
     *certainly_der = der;
     *certainly_not_der = 0;
-    indet = der ? 0 : secp256k1_rand_int(10) == 0;
+    indet = der ? 0 : secp256k1_testrand_int(10) == 0;
 
     for (n = 0; n < 2; n++) {
         /* We generate two classes of numbers: nlow==1 "low" ones (up to 32 bytes), nlow==0 "high" ones (32 bytes with 129 top bits set, or larger than 32 bytes) */
-        nlow[n] = der ? 1 : (secp256k1_rand_bits(3) != 0);
+        nlow[n] = der ? 1 : (secp256k1_testrand_bits(3) != 0);
         /* The length of the number in bytes (the first byte of which will always be nonzero) */
-        nlen[n] = nlow[n] ? secp256k1_rand_int(33) : 32 + secp256k1_rand_int(200) * secp256k1_rand_int(8) / 8;
+        nlen[n] = nlow[n] ? secp256k1_testrand_int(33) : 32 + secp256k1_testrand_int(200) * secp256k1_testrand_int(8) / 8;
         CHECK(nlen[n] <= 232);
         /* The top bit of the number. */
-        nhbit[n] = (nlow[n] == 0 && nlen[n] == 32) ? 1 : (nlen[n] == 0 ? 0 : secp256k1_rand_bits(1));
+        nhbit[n] = (nlow[n] == 0 && nlen[n] == 32) ? 1 : (nlen[n] == 0 ? 0 : secp256k1_testrand_bits(1));
         /* The top byte of the number (after the potential hardcoded 16 0xFF characters for "high" 32 bytes numbers) */
-        nhbyte[n] = nlen[n] == 0 ? 0 : (nhbit[n] ? 128 + secp256k1_rand_bits(7) : 1 + secp256k1_rand_int(127));
+        nhbyte[n] = nlen[n] == 0 ? 0 : (nhbit[n] ? 128 + secp256k1_testrand_bits(7) : 1 + secp256k1_testrand_int(127));
         /* The number of zero bytes in front of the number (which is 0 or 1 in case of DER, otherwise we extend up to 300 bytes) */
-        nzlen[n] = der ? ((nlen[n] == 0 || nhbit[n]) ? 1 : 0) : (nlow[n] ? secp256k1_rand_int(3) : secp256k1_rand_int(300 - nlen[n]) * secp256k1_rand_int(8) / 8);
+        nzlen[n] = der ? ((nlen[n] == 0 || nhbit[n]) ? 1 : 0) : (nlow[n] ? secp256k1_testrand_int(3) : secp256k1_testrand_int(300 - nlen[n]) * secp256k1_testrand_int(8) / 8);
         if (nzlen[n] > ((nlen[n] == 0 || nhbit[n]) ? 1 : 0)) {
             *certainly_not_der = 1;
         }
@@ -4769,7 +4769,7 @@ static void random_ber_signature(unsigned char *sig, size_t *len, int* certainly
         nlenlen[n] = nlen[n] + nzlen[n] < 128 ? 0 : (nlen[n] + nzlen[n] < 256 ? 1 : 2);
         if (!der) {
             /* nlenlen[n] max 127 bytes */
-            int add = secp256k1_rand_int(127 - nlenlen[n]) * secp256k1_rand_int(16) * secp256k1_rand_int(16) / 256;
+            int add = secp256k1_testrand_int(127 - nlenlen[n]) * secp256k1_testrand_int(16) * secp256k1_testrand_int(16) / 256;
             nlenlen[n] += add;
             if (add != 0) {
                 *certainly_not_der = 1;
@@ -4783,7 +4783,7 @@ static void random_ber_signature(unsigned char *sig, size_t *len, int* certainly
     CHECK(tlen <= 856);
 
     /* The length of the garbage inside the tuple. */
-    elen = (der || indet) ? 0 : secp256k1_rand_int(980 - tlen) * secp256k1_rand_int(8) / 8;
+    elen = (der || indet) ? 0 : secp256k1_testrand_int(980 - tlen) * secp256k1_testrand_int(8) / 8;
     if (elen != 0) {
         *certainly_not_der = 1;
     }
@@ -4791,7 +4791,7 @@ static void random_ber_signature(unsigned char *sig, size_t *len, int* certainly
     CHECK(tlen <= 980);
 
     /* The length of the garbage after the end of the tuple. */
-    glen = der ? 0 : secp256k1_rand_int(990 - tlen) * secp256k1_rand_int(8) / 8;
+    glen = der ? 0 : secp256k1_testrand_int(990 - tlen) * secp256k1_testrand_int(8) / 8;
     if (glen != 0) {
         *certainly_not_der = 1;
     }
@@ -4806,7 +4806,7 @@ static void random_ber_signature(unsigned char *sig, size_t *len, int* certainly
     } else {
         int tlenlen = tlen < 128 ? 0 : (tlen < 256 ? 1 : 2);
         if (!der) {
-            int add = secp256k1_rand_int(127 - tlenlen) * secp256k1_rand_int(16) * secp256k1_rand_int(16) / 256;
+            int add = secp256k1_testrand_int(127 - tlenlen) * secp256k1_testrand_int(16) * secp256k1_testrand_int(16) / 256;
             tlenlen += add;
             if (add != 0) {
                 *certainly_not_der = 1;
@@ -4857,13 +4857,13 @@ static void random_ber_signature(unsigned char *sig, size_t *len, int* certainly
             nlen[n]--;
         }
         /* Generate remaining random bytes of number */
-        secp256k1_rand_bytes_test(sig + *len, nlen[n]);
+        secp256k1_testrand_bytes_test(sig + *len, nlen[n]);
         *len += nlen[n];
         nlen[n] = 0;
     }
 
     /* Generate random garbage inside tuple. */
-    secp256k1_rand_bytes_test(sig + *len, elen);
+    secp256k1_testrand_bytes_test(sig + *len, elen);
     *len += elen;
 
     /* Generate end-of-contents bytes. */
@@ -4875,7 +4875,7 @@ static void random_ber_signature(unsigned char *sig, size_t *len, int* certainly
     CHECK(tlen + glen <= 1121);
 
     /* Generate random garbage outside tuple. */
-    secp256k1_rand_bytes_test(sig + *len, glen);
+    secp256k1_testrand_bytes_test(sig + *len, glen);
     *len += glen;
     tlen += glen;
     CHECK(tlen <= 1121);
@@ -5292,7 +5292,7 @@ EC_KEY *get_openssl_key(const unsigned char *key32) {
     unsigned char privkey[300];
     size_t privkeylen;
     const unsigned char* pbegin = privkey;
-    int compr = secp256k1_rand_bits(1);
+    int compr = secp256k1_testrand_bits(1);
     EC_KEY *ec_key = EC_KEY_new_by_curve_name(NID_secp256k1);
     CHECK(ec_privkey_export_der(ctx, privkey, &privkeylen, key32, compr));
     CHECK(d2i_ECPrivateKey(&ec_key, &pbegin, privkeylen));
@@ -5313,7 +5313,7 @@ void test_ecdsa_openssl(void) {
     unsigned char message[32];
     unsigned char signature[80];
     unsigned char key32[32];
-    secp256k1_rand256_test(message);
+    secp256k1_testrand256_test(message);
     secp256k1_scalar_set_b32(&msg, message, NULL);
     random_scalar_order_test(&key);
     secp256k1_scalar_get_b32(key32, &key);
@@ -5545,17 +5545,17 @@ int main(int argc, char **argv) {
     printf("test count = %i\n", count);
 
     /* find random seed */
-    secp256k1_rand_init(argc > 2 ? argv[2] : NULL);
+    secp256k1_testrand_init(argc > 2 ? argv[2] : NULL);
 
     /* initialize */
     run_context_tests(0);
     run_context_tests(1);
     run_scratch_tests();
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
-    if (secp256k1_rand_bits(1)) {
+    if (secp256k1_testrand_bits(1)) {
         unsigned char rand32[32];
-        secp256k1_rand256(rand32);
-        CHECK(secp256k1_context_randomize(ctx, secp256k1_rand_bits(1) ? rand32 : NULL));
+        secp256k1_testrand256(rand32);
+        CHECK(secp256k1_context_randomize(ctx, secp256k1_testrand_bits(1) ? rand32 : NULL));
     }
 
     run_rand_bits();
@@ -5643,7 +5643,7 @@ int main(int argc, char **argv) {
 
     run_cmov_tests();
 
-    secp256k1_rand_finish();
+    secp256k1_testrand_finish();
 
     /* shutdown */
     secp256k1_context_destroy(ctx);

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -58,7 +58,7 @@ void ge_equals_gej(const secp256k1_ge *a, const secp256k1_gej *b) {
 void random_fe(secp256k1_fe *x) {
     unsigned char bin[32];
     do {
-        secp256k1_rand256(bin);
+        secp256k1_testrand256(bin);
         if (secp256k1_fe_set_b32(x, bin)) {
             return;
         }
@@ -378,7 +378,7 @@ int main(int argc, char** argv) {
     printf("test count = %i\n", count);
 
     /* find random seed */
-    secp256k1_rand_init(argc > 2 ? argv[2] : NULL);
+    secp256k1_testrand_init(argc > 2 ? argv[2] : NULL);
 
     /* set up split processing */
     if (argc > 4) {
@@ -394,7 +394,7 @@ int main(int argc, char** argv) {
     while (count--) {
         /* Build context */
         ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
-        secp256k1_rand256(rand32);
+        secp256k1_testrand256(rand32);
         CHECK(secp256k1_context_randomize(ctx, rand32));
 
         /* Generate the entire group */
@@ -451,7 +451,7 @@ int main(int argc, char** argv) {
         secp256k1_context_destroy(ctx);
     }
 
-    secp256k1_rand_finish();
+    secp256k1_testrand_finish();
 
     printf("no problems found\n");
     return 0;


### PR DESCRIPTION
Suggested here: https://github.com/bitcoin-core/secp256k1/pull/808#discussion_r488871913
