### PR TITLE
Workaround for GCC bug 95189 using -fno-builtin-memcmp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,16 +55,28 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
 dnl Workaround for GCC bug 95189
 AC_MSG_CHECKING([if ${CC} has a broken memcmp builtin])
 if test x"$GCC" = x"yes"; then
-  gcc_version=`${CC} -dumpfullversion`
-  case $gcc_version in
-  9.*|10.*)
-    AC_MSG_RESULT([maybe, using -fno-builtin-memcmp])
+  AC_TRY_RUN([
+    int main() {
+      char a[] = "\0abc";
+      return __builtin_memcmp(a, "\0\0\0\0", 4);
+    }
+  ], [
+    AC_MSG_RESULT([yes, using -fno-builtin-memcmp])
     CFLAGS="$CFLAGS -fno-builtin-memcmp"
-    ;;
-  *)
+  ],[
     AC_MSG_RESULT([probably not])
-    ;;
-  esac
+  ],[
+    gcc_version=`${CC} -dumpfullversion`
+    case $gcc_version in
+    9.*|10.*)
+      AC_MSG_RESULT([maybe, using -fno-builtin-memcmp])
+      CFLAGS="$CFLAGS -fno-builtin-memcmp"
+      ;;
+    *)
+      AC_MSG_RESULT([probably not])
+      ;;
+    esac
+  ])
 fi
 
 AC_ARG_ENABLE(benchmark,

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,21 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
     ])
 
 
+dnl Workaround for GCC bug 95189
+AC_MSG_CHECKING([if ${CC} has a broken memcmp builtin])
+if test x"$GCC" = x"yes"; then
+  gcc_version=`${CC} -dumpfullversion`
+  case $gcc_version in
+  9.*|10.*)
+    AC_MSG_RESULT([maybe, using -fno-builtin-memcmp])
+    CFLAGS="$CFLAGS -fno-builtin-memcmp"
+    ;;
+  *)
+    AC_MSG_RESULT([probably not])
+    ;;
+  esac
+fi
+
 AC_ARG_ENABLE(benchmark,
     AS_HELP_STRING([--enable-benchmark],[compile benchmark (default is yes)]),
     [use_benchmark=$enableval],


### PR DESCRIPTION
For native builds, this builds and runs a test for the bug itself.

When cross-compiling, it assumes any 9.x or 10.x GCC is affected.

The second commit (native test) may be more than this project needs.