### PR TITLE
Add simple static checker based on clang-query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ libtool
 *~
 *.log
 *.trs
+compile_commands.commands.json
+compile_commands.json
 src/libsecp256k1-config.h
 src/libsecp256k1-config.h.in
 src/ecmult_static_context.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ osx_image: xcode10.1
 addons:
   apt:
     packages:
+      - clang-tools-10
       - libgmp-dev
       - valgrind
       - libtool-bin
+      - bear
 compiler:
   - clang
   - gcc
@@ -43,10 +45,12 @@ matrix:
       addons:
         apt:
           packages:
+            - clang-tools-10
             - gcc-multilib
             - libgmp-dev:i386
             - valgrind
             - libtool-bin
+            - bear
             - libc6-dbg:i386
     - compiler: clang
       env: HOST=i686-linux-gnu
@@ -54,9 +58,11 @@ matrix:
       addons:
         apt:
           packages:
+            - clang-tools-10
             - gcc-multilib
             - valgrind
             - libtool-bin
+            - bear
             - libc6-dbg:i386
     - compiler: gcc
       env: HOST=i686-linux-gnu
@@ -64,6 +70,7 @@ matrix:
       addons:
         apt:
           packages:
+            - clang-tools-10
             - gcc-multilib
             - valgrind
             - libtool-bin
@@ -74,6 +81,7 @@ matrix:
       addons:
         apt:
           packages:
+            - clang-tools-10
             - gcc-multilib
             - libgmp-dev:i386
             - valgrind
@@ -104,5 +112,7 @@ after_script:
     - cat ./exhaustive_tests.log
     - cat ./valgrind_ctime_test.log
     - cat ./bench.log
+    - cat ./clang-query.log
+    - cat ./compile_commands.json
     - $CC --version
     - valgrind --version

--- a/clang-query.sh
+++ b/clang-query.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -u
+
+matcher=$(cat <<'EOF'
+set print-matcher true
+enable output detailed-ast
+
+### Expressions of any floating point type (unless in a system header)
+match expr(allOf(unless(isExpansionInSystemHeader()), hasType(realFloatingPointType())))
+
+### Calls to memcmp (secp256k1_memcmp_var should be used instead)
+match callExpr(callee(functionDecl(hasName("memcmp"))))
+
+### Reserved identifiers (unless in a system header) with external linkage or at file scope.
+# Any function is in file scope. Any variable with static storage (unless static local variable) is in file scope.
+# Allowed exceptions: __builtin_expect
+# We need the "::" due to LLVM bug 47879.
+match namedDecl(allOf(unless(isExpansionInSystemHeader()), anyOf(hasExternalFormalLinkage(), functionDecl(), varDecl(allOf(hasStaticStorageDuration(), unless(isStaticLocal())))), allOf(matchesName("^::(_|((mem|is|to|str|wcs)[a-z]))"), unless(hasAnyName("__builtin_expect")))))
+
+### Reserved type names (unless in a system header)
+# Allowed exceptions: uint128_t, int128_t, __int128_t, __uint128_t (the latter two are "implicit", i.e., added by the compiler)
+match typedefDecl(allOf(unless(isExpansionInSystemHeader()), matchesName("(^::u?int)|(_t$)"), unless(hasAnyName("int128_t", "uint128_t", "__int128_t", "__uint128_t"))))
+
+quit
+EOF
+)
+
+# Poor man's JSON parser.
+# This is not great but it works with the output of all common tools and it does not need extra dependencies.
+files=$(grep 'file' compile_commands.json | uniq | cut -d '"' -f 4)
+echo "Running clang-query on files:"
+echo "$files"
+
+output=$(echo "$matcher" | ${CLANG_QUERY:-clang-query} "$@" $files)
+status=$?
+echo "$output"
+echo
+exit $status

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,15 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
     ])
 
 saved_CFLAGS="$CFLAGS"
+CFLAGS="-Wreserved-id-macro $CFLAGS"
+AC_MSG_CHECKING([if ${CC} supports -Wreserved-id-macro])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
+[ AC_MSG_RESULT([yes]) ],
+[ AC_MSG_RESULT([no])
+CFLAGS="$saved_CFLAGS"
+])
+
+saved_CFLAGS="$CFLAGS"
 CFLAGS="-fvisibility=hidden $CFLAGS"
 AC_MSG_CHECKING([if ${CC} supports -fvisibility=hidden])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],


### PR DESCRIPTION
This add a simple static checker based on clang-query, which is a
tool that could be described as a "clever grep" for abstract syntax
trees (ASTs).

As an initial proof of usefulness, this commit adds these checks:
  - No uses of floating point types.
  - No use of certain reserved identifiers (e.g., "mem(...)", #829).
  - No use of memcmp (#823).

The checks are easily extensible.

The main purpose is to run the checker on CI, and this commit adds
the checker to the Travis CI script.

This currently requires clang-query version at least 10. (However,
it's not required not compile with clang version 10, or with clang
at all. Just the compiler flags must be compatible with clang.)
Clang-query simply uses the clang compiler as a backend for
generating the AST.

In order to determine the compile in which the code is supposed to be
compiled (e.g., compiler flags such as -D defines and include paths),
it reads a compilation database in JSON format. There are multiple ways
to generate this database. The easiest way to obtain such a database is
to use a tool that intercepts the make process and build the database.

On Travis CI, we currently use "bear" for this purpose. It's a natural
choice because there is an Ubuntu package for it. If you want to run
this locally, bear is a good choice but other tools such as compiledb
(Python) are available.