### PR TITLE
Make autotools check for all the used openssl functions

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -36,16 +36,39 @@ if test x"$has_libcrypto" = x"yes" && test x"$has_openssl_ec" = x; then
   CPPFLAGS_TEMP="$CPPFLAGS"
   CPPFLAGS="$CRYPTO_CPPFLAGS $CPPFLAGS"
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    #include <openssl/bn.h>
     #include <openssl/ec.h>
     #include <openssl/ecdsa.h>
     #include <openssl/obj_mac.h>]],[[
-    EC_KEY *eckey = EC_KEY_new_by_curve_name(NID_secp256k1);
-    ECDSA_sign(0, NULL, 0, NULL, NULL, eckey);
+    # if OPENSSL_VERSION_NUMBER < 0x10100000L
+    void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps) {(void)sig->r; (void)sig->s;}
+    # endif
+
+    unsigned int zero = 0;
+    const unsigned char *zero_ptr = (unsigned char*)&zero;
+    EC_KEY_free(EC_KEY_new_by_curve_name(NID_secp256k1));
+    EC_KEY *eckey = EC_KEY_new();
+    EC_GROUP *group = EC_GROUP_new_by_curve_name(NID_secp256k1);
+    EC_KEY_set_group(eckey, group);
+    ECDSA_sign(0, NULL, 0, NULL, &zero, eckey);
     ECDSA_verify(0, NULL, 0, NULL, 0, eckey);
+    o2i_ECPublicKey(&eckey, &zero_ptr, 0);
+    d2i_ECPrivateKey(&eckey, &zero_ptr, 0);
+    EC_KEY_check_key(eckey);
     EC_KEY_free(eckey);
+    EC_GROUP_free(group);
     ECDSA_SIG *sig_openssl;
     sig_openssl = ECDSA_SIG_new();
+    d2i_ECDSA_SIG(&sig_openssl, &zero_ptr, 0);
+    i2d_ECDSA_SIG(sig_openssl, NULL);
+    ECDSA_SIG_get0(sig_openssl, NULL, NULL);
     ECDSA_SIG_free(sig_openssl);
+    const BIGNUM *bignum = BN_value_one();
+    BN_is_negative(bignum);
+    BN_num_bits(bignum);
+    if (sizeof(zero) >= BN_num_bytes(bignum)) {
+        BN_bn2bin(bignum, (unsigned char*)&zero);
+    }
   ]])],[has_openssl_ec=yes],[has_openssl_ec=no])
   AC_MSG_RESULT([$has_openssl_ec])
   CPPFLAGS="$CPPFLAGS_TEMP"

--- a/configure.ac
+++ b/configure.ac
@@ -395,8 +395,8 @@ esac
 
 if test x"$use_tests" = x"yes"; then
   SECP_OPENSSL_CHECK
-  if test x"$has_openssl_ec" = x"yes"; then
-    if test x"$enable_openssl_tests" != x"no"; then
+  if test x"$enable_openssl_tests" != x"no" && test x"$has_openssl_ec" = x"yes"; then
+      enable_openssl_tests=yes
       AC_DEFINE(ENABLE_OPENSSL_TESTS, 1, [Define this symbol if OpenSSL EC functions are available])
       SECP_TEST_INCLUDES="$SSL_CFLAGS $CRYPTO_CFLAGS $CRYPTO_CPPFLAGS"
       SECP_TEST_LIBS="$CRYPTO_LIBS"
@@ -406,16 +406,17 @@ if test x"$use_tests" = x"yes"; then
         SECP_TEST_LIBS="$SECP_TEST_LIBS -lgdi32"
         ;;
       esac
-    fi
   else
     if test x"$enable_openssl_tests" = x"yes"; then
       AC_MSG_ERROR([OpenSSL tests requested but OpenSSL with EC support is not available])
     fi
+    enable_openssl_tests=no
   fi
 else
   if test x"$enable_openssl_tests" = x"yes"; then
     AC_MSG_ERROR([OpenSSL tests requested but tests are not enabled])
   fi
+  enable_openssl_tests=no
 fi
 
 if test x"$set_bignum" = x"gmp"; then
@@ -503,6 +504,8 @@ echo "Build Options:"
 echo "  with ecmult precomp     = $set_precomp"
 echo "  with external callbacks = $use_external_default_callbacks"
 echo "  with benchmarks         = $use_benchmark"
+echo "  with tests              = $use_tests"
+echo "  with openssl tests      = $enable_openssl_tests"
 echo "  with coverage           = $enable_coverage"
 echo "  module ecdh             = $enable_module_ecdh"
 echo "  module recovery         = $enable_module_recovery"


### PR DESCRIPTION
I added all the openssl functions that we call in `tests.c` and in `bench_verify.c` to the m4 check, that way if any of them are missing it won't enable openssl.
I also modified it a little to prevent a segmentation fault when running that program (not that it really matters for autotools)

This should fix #836