### PR TITLE
Avoids a potentially shortening size_t to int cast in strauss_wnaf_

### DIFF
--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -443,7 +443,7 @@ struct secp256k1_strauss_state {
     struct secp256k1_strauss_point_state* ps;
 };
 
-static void secp256k1_ecmult_strauss_wnaf(const secp256k1_ecmult_context *ctx, const struct secp256k1_strauss_state *state, secp256k1_gej *r, int num, const secp256k1_gej *a, const secp256k1_scalar *na, const secp256k1_scalar *ng) {
+static void secp256k1_ecmult_strauss_wnaf(const secp256k1_ecmult_context *ctx, const struct secp256k1_strauss_state *state, secp256k1_gej *r, size_t num, const secp256k1_gej *a, const secp256k1_scalar *na, const secp256k1_scalar *ng) {
     secp256k1_ge tmpa;
     secp256k1_fe Z;
     /* Splitted G factors. */
@@ -454,8 +454,8 @@ static void secp256k1_ecmult_strauss_wnaf(const secp256k1_ecmult_context *ctx, c
     int bits_ng_128 = 0;
     int i;
     int bits = 0;
-    int np;
-    int no = 0;
+    size_t np;
+    size_t no = 0;
 
     for (np = 0; np < num; ++np) {
         if (secp256k1_scalar_is_zero(&na[np]) || secp256k1_gej_is_infinity(&a[np])) {


### PR DESCRIPTION
Fixes #834.