### PR TITLE
make test count iteration configurable by environment variable

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -5632,6 +5632,10 @@ int main(int argc, char **argv) {
             count = strtol(env, NULL, 0);
         }
     }
+    if (count <= 0) {
+        fputs("An iteration count of 0 or less is not allowed.\n", stderr);
+        return EXIT_FAILURE;
+    }
     printf("test count = %i\n", count);
 
     /* find random seed */

--- a/src/tests.c
+++ b/src/tests.c
@@ -5626,6 +5626,11 @@ int main(int argc, char **argv) {
     /* find iteration count */
     if (argc > 1) {
         count = strtol(argv[1], NULL, 0);
+    } else {
+        const char* env = getenv("SECP256K1_TEST_ITERS");
+        if (env) {
+            count = strtol(env, NULL, 0);
+        }
     }
     printf("test count = %i\n", count);
 


### PR DESCRIPTION
You can set the test iteration count by command-line parameter but it is very hard to control the iteration count used by `make check` and even harder to control the count when this is run through Bitcoin Core's build system. Using an environment var solves both problems.