### PR TITLE
Autoconf improvements

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -87,3 +87,11 @@ if test x"$has_gmp" != x"yes"; then
   LIBS="$LIBS_TEMP"
 fi
 ])
+
+AC_DEFUN([SECP_VALGRIND_CHECK],[
+if test x"$has_valgrind" != x"yes"; then
+  CPPFLAGS_TEMP="$CPPFLAGS"
+  CPPFLAGS="$VALGRIND_CPPFLAGS $CPPFLAGS"
+  AC_CHECK_HEADER([valgrind/memcheck.h], [has_valgrind=yes; AC_DEFINE(HAVE_VALGRIND,1,[Define this symbol if valgrind is installed])])
+fi
+])

--- a/configure.ac
+++ b/configure.ac
@@ -40,9 +40,9 @@ case $host_os in
          dnl These Homebrew packages may be keg-only, meaning that they won't be found
          dnl in expected paths because they may conflict with system files. Ask
          dnl Homebrew where each one is located, then adjust paths accordingly.
-
          openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
          gmp_prefix=`$BREW --prefix gmp 2>/dev/null`
+         valgrind_prefix=`$BREW --prefix valgrind 2>/dev/null`
          if test x$openssl_prefix != x; then
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
@@ -51,6 +51,9 @@ case $host_os in
          if test x$gmp_prefix != x; then
            GMP_CPPFLAGS="-I$gmp_prefix/include"
            GMP_LIBS="-L$gmp_prefix/lib"
+         fi
+         if test x$valgrind_prefix != x; then
+           VALGRIND_CPPFLAGS="-I$valgrind_prefix/include"
          fi
        else
          AC_PATH_PROG([PORT],port,)
@@ -180,12 +183,15 @@ AC_ARG_WITH([valgrind], [AS_HELP_STRING([--with-valgrind=yes|no|auto],
 if test x"$req_valgrind" = x"no"; then
   enable_valgrind=no
 else
-  AC_CHECK_HEADER([valgrind/memcheck.h], [enable_valgrind=yes], [
+  SECP_VALGRIND_CHECK
+  if test x"$has_valgrind" != x"yes"; then
     if test x"$req_valgrind" = x"yes"; then
       AC_MSG_ERROR([Valgrind support explicitly requested but valgrind/memcheck.h header not available])
     fi
     enable_valgrind=no
-  ], [])
+  else
+    enable_valgrind=yes
+  fi
 fi
 AM_CONDITIONAL([VALGRIND_ENABLED],[test "$enable_valgrind" = "yes"])
 
@@ -422,6 +428,10 @@ fi
 if test x"$set_bignum" = x"gmp"; then
   SECP_LIBS="$SECP_LIBS $GMP_LIBS"
   SECP_INCLUDES="$SECP_INCLUDES $GMP_CPPFLAGS"
+fi
+
+if test x"$enable_valgrind" = x"yes"; then
+  SECP_INCLUDES="$SECP_INCLUDES $VALGRIND_CPPFLAGS"
 fi
 
 if test x"$set_precomp" = x"yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 : ${CFLAGS="-g"}
 LT_INIT
 
-dnl make the compilation flags quiet unless V=1 is used
+# Make the compilation flags quiet unless V=1 is used.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 PKG_PROG_PKG_CONFIG
@@ -37,9 +37,9 @@ case $host_os in
      if  test x$cross_compiling != xyes; then
        AC_PATH_PROG([BREW],brew,)
        if test x$BREW != x; then
-         dnl These Homebrew packages may be keg-only, meaning that they won't be found
-         dnl in expected paths because they may conflict with system files. Ask
-         dnl Homebrew where each one is located, then adjust paths accordingly.
+         # These Homebrew packages may be keg-only, meaning that they won't be found
+         # in expected paths because they may conflict with system files. Ask
+         # Homebrew where each one is located, then adjust paths accordingly.
          openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
          gmp_prefix=`$BREW --prefix gmp 2>/dev/null`
          valgrind_prefix=`$BREW --prefix valgrind 2>/dev/null`
@@ -57,8 +57,8 @@ case $host_os in
          fi
        else
          AC_PATH_PROG([PORT],port,)
-         dnl if homebrew isn't installed and macports is, add the macports default paths
-         dnl as a last resort.
+         # If homebrew isn't installed and macports is, add the macports default paths
+         # as a last resort.
          if test x$PORT != x; then
            CPPFLAGS="$CPPFLAGS -isystem /opt/local/include"
            LDFLAGS="$LDFLAGS -L/opt/local/lib"
@@ -88,6 +88,10 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
     [ AC_MSG_RESULT([no])
       CFLAGS="$saved_CFLAGS"
     ])
+
+###
+### Define config arguments
+###
 
 AC_ARG_ENABLE(benchmark,
     AS_HELP_STRING([--enable-benchmark],[compile benchmark [default=yes]]),
@@ -149,8 +153,8 @@ AC_ARG_ENABLE(external_default_callbacks,
     [use_external_default_callbacks=$enableval],
     [use_external_default_callbacks=no])
 
-dnl Test-only override of the (autodetected by the C code) "widemul" setting.
-dnl Legal values are int64 (for [u]int64_t), int128 (for [unsigned] __int128), and auto (the default).
+# Test-only override of the (autodetected by the C code) "widemul" setting.
+# Legal values are int64 (for [u]int64_t), int128 (for [unsigned] __int128), and auto (the default).
 AC_ARG_WITH([test-override-wide-multiply], [] ,[set_widemul=$withval], [set_widemul=auto])
 
 AC_ARG_WITH([bignum], [AS_HELP_STRING([--with-bignum=gmp|no|auto],
@@ -180,6 +184,10 @@ AC_ARG_WITH([valgrind], [AS_HELP_STRING([--with-valgrind=yes|no|auto],
 )],
 [req_valgrind=$withval], [req_valgrind=auto])
 
+###
+### Handle config options (except for modules)
+###
+
 if test x"$req_valgrind" = x"no"; then
   enable_valgrind=no
 else
@@ -201,61 +209,6 @@ if test x"$enable_coverage" = x"yes"; then
     LDFLAGS="--coverage $LDFLAGS"
 else
     CFLAGS="-O2 $CFLAGS"
-fi
-
-if test x"$use_ecmult_static_precomputation" != x"no"; then
-  # Temporarily switch to an environment for the native compiler
-  save_cross_compiling=$cross_compiling
-  cross_compiling=no
-  SAVE_CC="$CC"
-  CC="$CC_FOR_BUILD"
-  SAVE_CFLAGS="$CFLAGS"
-  CFLAGS="$CFLAGS_FOR_BUILD"
-  SAVE_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$CPPFLAGS_FOR_BUILD"
-  SAVE_LDFLAGS="$LDFLAGS"
-  LDFLAGS="$LDFLAGS_FOR_BUILD"
-
-  warn_CFLAGS_FOR_BUILD="-Wall -Wextra -Wno-unused-function"
-  saved_CFLAGS="$CFLAGS"
-  CFLAGS="$warn_CFLAGS_FOR_BUILD $CFLAGS"
-  AC_MSG_CHECKING([if native ${CC_FOR_BUILD} supports ${warn_CFLAGS_FOR_BUILD}])
-  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
-      [ AC_MSG_RESULT([yes]) ],
-      [ AC_MSG_RESULT([no])
-        CFLAGS="$saved_CFLAGS"
-      ])
-
-  AC_MSG_CHECKING([for working native compiler: ${CC_FOR_BUILD}])
-  AC_RUN_IFELSE(
-    [AC_LANG_PROGRAM([], [])],
-    [working_native_cc=yes],
-    [working_native_cc=no],[:])
-
-  CFLAGS_FOR_BUILD="$CFLAGS"
-
-  # Restore the environment
-  cross_compiling=$save_cross_compiling
-  CC="$SAVE_CC"
-  CFLAGS="$SAVE_CFLAGS"
-  CPPFLAGS="$SAVE_CPPFLAGS"
-  LDFLAGS="$SAVE_LDFLAGS"
-
-  if test x"$working_native_cc" = x"no"; then
-    AC_MSG_RESULT([no])
-    set_precomp=no
-    m4_define([please_set_for_build], [Please set CC_FOR_BUILD, CFLAGS_FOR_BUILD, CPPFLAGS_FOR_BUILD, and/or LDFLAGS_FOR_BUILD.])
-    if test x"$use_ecmult_static_precomputation" = x"yes";  then
-      AC_MSG_ERROR([native compiler ${CC_FOR_BUILD} does not produce working binaries. please_set_for_build])
-    else
-      AC_MSG_WARN([Disabling statically generated ecmult table because the native compiler ${CC_FOR_BUILD} does not produce working binaries. please_set_for_build])
-    fi
-  else
-    AC_MSG_RESULT([yes])
-    set_precomp=yes
-  fi
-else
-  set_precomp=no
 fi
 
 if test x"$req_asm" = x"auto"; then
@@ -311,7 +264,7 @@ else
   esac
 fi
 
-# select assembly optimization
+# Select assembly optimization
 use_external_asm=no
 
 case $set_asm in
@@ -328,7 +281,12 @@ no)
   ;;
 esac
 
-# select wide multiplication implementation
+if test x"$use_external_asm" = x"yes"; then
+  AC_DEFINE(USE_EXTERNAL_ASM, 1, [Define this symbol if an external (non-inline) assembly implementation is used])
+fi
+
+
+# Select wide multiplication implementation
 case $set_widemul in
 int128)
   AC_DEFINE(USE_FORCE_WIDEMUL_INT128, 1, [Define this symbol to force the use of the (unsigned) __int128 based wide multiplication implementation])
@@ -343,7 +301,7 @@ auto)
   ;;
 esac
 
-# select bignum implementation
+# Select bignum implementation
 case $set_bignum in
 gmp)
   AC_DEFINE(HAVE_LIBGMP, 1, [Define this symbol if libgmp is installed])
@@ -361,7 +319,7 @@ no)
   ;;
 esac
 
-#set ecmult window size
+# Set ecmult window size
 if test x"$req_ecmult_window" = x"auto"; then
   set_ecmult_window=15
 else
@@ -383,7 +341,7 @@ case $set_ecmult_window in
   ;;
 esac
 
-#set ecmult gen precision
+# Set ecmult gen precision
 if test x"$req_ecmult_gen_precision" = x"auto"; then
   set_ecmult_gen_precision=4
 else
@@ -434,9 +392,69 @@ if test x"$enable_valgrind" = x"yes"; then
   SECP_INCLUDES="$SECP_INCLUDES $VALGRIND_CPPFLAGS"
 fi
 
+# Handle static precomputation (after everything which modifies CFLAGS and friends)
+if test x"$use_ecmult_static_precomputation" != x"no"; then
+  # Temporarily switch to an environment for the native compiler
+  save_cross_compiling=$cross_compiling
+  cross_compiling=no
+  SAVE_CC="$CC"
+  CC="$CC_FOR_BUILD"
+  SAVE_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS_FOR_BUILD"
+  SAVE_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS_FOR_BUILD"
+  SAVE_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS_FOR_BUILD"
+
+  warn_CFLAGS_FOR_BUILD="-Wall -Wextra -Wno-unused-function"
+  saved_CFLAGS="$CFLAGS"
+  CFLAGS="$warn_CFLAGS_FOR_BUILD $CFLAGS"
+  AC_MSG_CHECKING([if native ${CC_FOR_BUILD} supports ${warn_CFLAGS_FOR_BUILD}])
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
+      [ AC_MSG_RESULT([yes]) ],
+      [ AC_MSG_RESULT([no])
+        CFLAGS="$saved_CFLAGS"
+      ])
+
+  AC_MSG_CHECKING([for working native compiler: ${CC_FOR_BUILD}])
+  AC_RUN_IFELSE(
+    [AC_LANG_PROGRAM([], [])],
+    [working_native_cc=yes],
+    [working_native_cc=no],[:])
+
+  CFLAGS_FOR_BUILD="$CFLAGS"
+
+  # Restore the environment
+  cross_compiling=$save_cross_compiling
+  CC="$SAVE_CC"
+  CFLAGS="$SAVE_CFLAGS"
+  CPPFLAGS="$SAVE_CPPFLAGS"
+  LDFLAGS="$SAVE_LDFLAGS"
+
+  if test x"$working_native_cc" = x"no"; then
+    AC_MSG_RESULT([no])
+    set_precomp=no
+    m4_define([please_set_for_build], [Please set CC_FOR_BUILD, CFLAGS_FOR_BUILD, CPPFLAGS_FOR_BUILD, and/or LDFLAGS_FOR_BUILD.])
+    if test x"$use_ecmult_static_precomputation" = x"yes";  then
+      AC_MSG_ERROR([native compiler ${CC_FOR_BUILD} does not produce working binaries. please_set_for_build])
+    else
+      AC_MSG_WARN([Disabling statically generated ecmult table because the native compiler ${CC_FOR_BUILD} does not produce working binaries. please_set_for_build])
+    fi
+  else
+    AC_MSG_RESULT([yes])
+    set_precomp=yes
+  fi
+else
+  set_precomp=no
+fi
+
 if test x"$set_precomp" = x"yes"; then
   AC_DEFINE(USE_ECMULT_STATIC_PRECOMPUTATION, 1, [Define this symbol to use a statically generated ecmult table])
 fi
+
+###
+### Handle module options
+###
 
 if test x"$enable_module_ecdh" = x"yes"; then
   AC_DEFINE(ENABLE_MODULE_ECDH, 1, [Define this symbol to enable the ECDH module])
@@ -457,13 +475,13 @@ if test x"$enable_module_extrakeys" = x"yes"; then
   AC_DEFINE(ENABLE_MODULE_EXTRAKEYS, 1, [Define this symbol to enable the extrakeys module])
 fi
 
-if test x"$use_external_asm" = x"yes"; then
-  AC_DEFINE(USE_EXTERNAL_ASM, 1, [Define this symbol if an external (non-inline) assembly implementation is used])
-fi
-
 if test x"$use_external_default_callbacks" = x"yes"; then
   AC_DEFINE(USE_EXTERNAL_DEFAULT_CALLBACKS, 1, [Define this symbol if an external implementation of the default callbacks is used])
 fi
+
+###
+### Check for --enable-experimental if necessary
+###
 
 if test x"$enable_experimental" = x"yes"; then
   AC_MSG_NOTICE([******])
@@ -484,6 +502,10 @@ else
   fi
 fi
 
+###
+### Generate output
+###
+
 AC_CONFIG_HEADERS([src/libsecp256k1-config.h])
 AC_CONFIG_FILES([Makefile libsecp256k1.pc])
 AC_SUBST(SECP_INCLUDES)
@@ -502,7 +524,7 @@ AM_CONDITIONAL([ENABLE_MODULE_SCHNORRSIG], [test x"$enable_module_schnorrsig" = 
 AM_CONDITIONAL([USE_EXTERNAL_ASM], [test x"$use_external_asm" = x"yes"])
 AM_CONDITIONAL([USE_ASM_ARM], [test x"$set_asm" = x"arm"])
 
-dnl make sure nothing new is exported so that we don't break the cache
+# Make sure nothing new is exported so that we don't break the cache.
 PKGCONFIG_PATH_TEMP="$PKG_CONFIG_PATH"
 unset PKG_CONFIG_PATH
 PKG_CONFIG_PATH="$PKGCONFIG_PATH_TEMP"
@@ -526,7 +548,7 @@ echo "  asm                     = $set_asm"
 echo "  bignum                  = $set_bignum"
 echo "  ecmult window size      = $set_ecmult_window"
 echo "  ecmult gen prec. bits   = $set_ecmult_gen_precision"
-dnl Hide test-only options unless they're used.
+# Hide test-only options unless they're used.
 if test x"$set_widemul" != xauto; then
 echo "  wide multiplication     = $set_widemul"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,6 @@ PKG_PROG_PKG_CONFIG
 AC_PATH_TOOL(AR, ar)
 AC_PATH_TOOL(RANLIB, ranlib)
 AC_PATH_TOOL(STRIP, strip)
-AX_PROG_CC_FOR_BUILD
 
 AM_PROG_CC_C_O
 
@@ -394,56 +393,75 @@ fi
 
 # Handle static precomputation (after everything which modifies CFLAGS and friends)
 if test x"$use_ecmult_static_precomputation" != x"no"; then
-  # Temporarily switch to an environment for the native compiler
-  save_cross_compiling=$cross_compiling
-  cross_compiling=no
-  SAVE_CC="$CC"
-  CC="$CC_FOR_BUILD"
-  SAVE_CFLAGS="$CFLAGS"
-  CFLAGS="$CFLAGS_FOR_BUILD"
-  SAVE_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$CPPFLAGS_FOR_BUILD"
-  SAVE_LDFLAGS="$LDFLAGS"
-  LDFLAGS="$LDFLAGS_FOR_BUILD"
-
-  warn_CFLAGS_FOR_BUILD="-Wall -Wextra -Wno-unused-function"
-  saved_CFLAGS="$CFLAGS"
-  CFLAGS="$warn_CFLAGS_FOR_BUILD $CFLAGS"
-  AC_MSG_CHECKING([if native ${CC_FOR_BUILD} supports ${warn_CFLAGS_FOR_BUILD}])
-  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
-      [ AC_MSG_RESULT([yes]) ],
-      [ AC_MSG_RESULT([no])
-        CFLAGS="$saved_CFLAGS"
-      ])
-
-  AC_MSG_CHECKING([for working native compiler: ${CC_FOR_BUILD}])
-  AC_RUN_IFELSE(
-    [AC_LANG_PROGRAM([], [])],
-    [working_native_cc=yes],
-    [working_native_cc=no],[:])
-
-  CFLAGS_FOR_BUILD="$CFLAGS"
-
-  # Restore the environment
-  cross_compiling=$save_cross_compiling
-  CC="$SAVE_CC"
-  CFLAGS="$SAVE_CFLAGS"
-  CPPFLAGS="$SAVE_CPPFLAGS"
-  LDFLAGS="$SAVE_LDFLAGS"
-
-  if test x"$working_native_cc" = x"no"; then
-    AC_MSG_RESULT([no])
-    set_precomp=no
-    m4_define([please_set_for_build], [Please set CC_FOR_BUILD, CFLAGS_FOR_BUILD, CPPFLAGS_FOR_BUILD, and/or LDFLAGS_FOR_BUILD.])
-    if test x"$use_ecmult_static_precomputation" = x"yes";  then
-      AC_MSG_ERROR([native compiler ${CC_FOR_BUILD} does not produce working binaries. please_set_for_build])
-    else
-      AC_MSG_WARN([Disabling statically generated ecmult table because the native compiler ${CC_FOR_BUILD} does not produce working binaries. please_set_for_build])
-    fi
-  else
-    AC_MSG_RESULT([yes])
+  if test x"$cross_compiling" = x"no"; then
     set_precomp=yes
+    if test x"${CC_FOR_BUILD+x}${CFLAGS_FOR_BUILD+x}${CPPFLAGS_FOR_BUILD+x}${LDFLAGS_FOR_BUILD+x}" != x; then
+      AC_MSG_WARN([CC_FOR_BUILD, CFLAGS_FOR_BUILD, CPPFLAGS_FOR_BUILD, and/or LDFLAGS_FOR_BUILD is set but ignored because we are not cross-compiling.])
+    fi
+    # If we're not cross-compiling, simply use the same compiler for building the static precompation code.
+    CC_FOR_BUILD="$CC"
+    CFLAGS_FOR_BUILD="$CFLAGS"
+    CPPFLAGS_FOR_BUILD="$CPPFLAGS"
+    LDFLAGS_FOR_BUILD="$LDFLAGS"
+  else
+    AX_PROG_CC_FOR_BUILD
+
+    # Temporarily switch to an environment for the native compiler
+    save_cross_compiling=$cross_compiling
+    cross_compiling=no
+    SAVE_CC="$CC"
+    CC="$CC_FOR_BUILD"
+    SAVE_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS_FOR_BUILD"
+    SAVE_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS_FOR_BUILD"
+    SAVE_LDFLAGS="$LDFLAGS"
+    LDFLAGS="$LDFLAGS_FOR_BUILD"
+
+    warn_CFLAGS_FOR_BUILD="-Wall -Wextra -Wno-unused-function"
+    saved_CFLAGS="$CFLAGS"
+    CFLAGS="$warn_CFLAGS_FOR_BUILD $CFLAGS"
+    AC_MSG_CHECKING([if native ${CC_FOR_BUILD} supports ${warn_CFLAGS_FOR_BUILD}])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
+        [ AC_MSG_RESULT([yes]) ],
+        [ AC_MSG_RESULT([no])
+          CFLAGS="$saved_CFLAGS"
+        ])
+
+    AC_MSG_CHECKING([for working native compiler: ${CC_FOR_BUILD}])
+    AC_RUN_IFELSE(
+      [AC_LANG_PROGRAM([], [])],
+      [working_native_cc=yes],
+      [working_native_cc=no],[:])
+
+    CFLAGS_FOR_BUILD="$CFLAGS"
+
+    # Restore the environment
+    cross_compiling=$save_cross_compiling
+    CC="$SAVE_CC"
+    CFLAGS="$SAVE_CFLAGS"
+    CPPFLAGS="$SAVE_CPPFLAGS"
+    LDFLAGS="$SAVE_LDFLAGS"
+
+    if test x"$working_native_cc" = x"no"; then
+      AC_MSG_RESULT([no])
+      set_precomp=no
+      m4_define([please_set_for_build], [Please set CC_FOR_BUILD, CFLAGS_FOR_BUILD, CPPFLAGS_FOR_BUILD, and/or LDFLAGS_FOR_BUILD.])
+      if test x"$use_ecmult_static_precomputation" = x"yes";  then
+        AC_MSG_ERROR([native compiler ${CC_FOR_BUILD} does not produce working binaries. please_set_for_build])
+      else
+        AC_MSG_WARN([Disabling statically generated ecmult table because the native compiler ${CC_FOR_BUILD} does not produce working binaries. please_set_for_build])
+      fi
+    else
+      AC_MSG_RESULT([yes])
+      set_precomp=yes
+    fi
   fi
+
+  AC_SUBST(CC_FOR_BUILD)
+  AC_SUBST(CFLAGS_FOR_BUILD)
+  AC_SUBST(CPPFLAGS_FOR_BUILD)
+  AC_SUBST(LDFLAGS_FOR_BUILD)
 else
   set_precomp=no
 fi
@@ -559,3 +577,9 @@ echo "  CFLAGS                  = $CFLAGS"
 echo "  CPPFLAGS                = $CPPFLAGS"
 echo "  LDFLAGS                 = $LDFLAGS"
 echo
+if test x"$set_precomp" = x"yes"; then
+echo "  CC_FOR_BUILD            = $CC_FOR_BUILD"
+echo "  CFLAGS_FOR_BUILD        = $CFLAGS_FOR_BUILD"
+echo "  CPPFLAGS_FOR_BUILD      = $CPPFLAGS_FOR_BUILD"
+echo "  LDFLAGS_FOR_BUILD       = $LDFLAGS_FOR_BUILD"
+fi

--- a/src/gen_context.c
+++ b/src/gen_context.c
@@ -4,8 +4,8 @@
  * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
  ***********************************************************************/
 
-// Autotools creates libsecp256k1-config.h, of which ECMULT_GEN_PREC_BITS is needed.
-// ifndef guard so downstream users can define their own if they do not use autotools.
+/* Autotools creates libsecp256k1-config.h, of which ECMULT_GEN_PREC_BITS is needed.
+   ifndef guard so downstream users can define their own if they do not use autotools. */
 #if !defined(ECMULT_GEN_PREC_BITS)
 #include "libsecp256k1-config.h"
 #endif


### PR DESCRIPTION
See individual commit messages. These are improvements in preparation of the switch to Cirrus CI. (Maybe I'll just open a PR on top of this one.)

The first commit made the difference between successful build https://cirrus-ci.com/task/6740575057608704 and unsuccessful build https://cirrus-ci.com/task/4909571074424832.

I've tested the second commit without cross-compilation and with cross-compilation for android (https://github.com/bitcoin-core/secp256k1/issues/621#issuecomment-495703399)

When working on the autoconf stuff, I noticed two things that I just want to write down here:
 - At some point we should update [build-aux/m4/ax_prog_cc_for_build.m4](https://www.gnu.org/software/autoconf-archive/ax_prog_cc_for_build.html). This is outdated, and [there have been a lot of fixes](https://github.com/autoconf-archive/autoconf-archive/pull/207) But the latest version is [broken](https://lists.gnu.org/archive/html/autoconf-archive-maintainers/2020-06/msg00002.html), so now is probably not the time.
 - The latest autoconf 2.70 deprecates `AC_PROG_CC_C89`. It's not needed anymore because `AC_PROG_CC` cares about testing for version support. This makes autoconf 2.70 output a warning that we should probably just ignore. We don't want to force users onto 2.70...  
