### PR TITLE
Avoid casting (void**) values.

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -141,7 +141,7 @@ static SECP256K1_INLINE void *manual_alloc(void** prealloc_ptr, size_t alloc_siz
     VERIFY_CHECK(((unsigned char*)*prealloc_ptr - (unsigned char*)base) % ALIGNMENT == 0);
     VERIFY_CHECK((unsigned char*)*prealloc_ptr - (unsigned char*)base + aligned_alloc_size <= max_size);
     ret = *prealloc_ptr;
-    *((unsigned char**)prealloc_ptr) += aligned_alloc_size;
+    *prealloc_ptr = (unsigned char*)*prealloc_ptr + aligned_alloc_size;
     return ret;
 }
 


### PR DESCRIPTION
Replaced with an expression that only casts (void*) values.

While casting between `void *` and `foo *` generally allowed (upto alignment issues), the same cannot be said for casting between `void **` and `foo **` values, which is not okay in general.

While the C standard which says "A pointer to void shall have the same representation and alignment requirements as a pointer to a character type.” likely implies the cast is sound because `void *` and `char *` values have the same representation, perhaps it is better to rewrite the expression to not require a careful reading of the standard to be correct.