### PR TITLE
Remove unused secp256k1_fe_inv_all_var

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -114,11 +114,6 @@ static void secp256k1_fe_inv(secp256k1_fe *r, const secp256k1_fe *a);
 /** Potentially faster version of secp256k1_fe_inv, without constant-time guarantee. */
 static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256k1_fe *a);
 
-/** Calculate the (modular) inverses of a batch of field elements. Requires the inputs' magnitudes to be
- *  at most 8. The output magnitudes are 1 (but not guaranteed to be normalized). The inputs and
- *  outputs must not overlap in memory. */
-static void secp256k1_fe_inv_all_var(secp256k1_fe *r, const secp256k1_fe *a, size_t len);
-
 /** Convert a field element to the storage type. */
 static void secp256k1_fe_to_storage(secp256k1_fe_storage *r, const secp256k1_fe *a);
 

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -263,33 +263,6 @@ static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256k1_fe *a) {
 #endif
 }
 
-static void secp256k1_fe_inv_all_var(secp256k1_fe *r, const secp256k1_fe *a, size_t len) {
-    secp256k1_fe u;
-    size_t i;
-    if (len < 1) {
-        return;
-    }
-
-    VERIFY_CHECK((r + len <= a) || (a + len <= r));
-
-    r[0] = a[0];
-
-    i = 0;
-    while (++i < len) {
-        secp256k1_fe_mul(&r[i], &r[i - 1], &a[i]);
-    }
-
-    secp256k1_fe_inv_var(&u, &r[--i]);
-
-    while (i > 0) {
-        size_t j = i--;
-        secp256k1_fe_mul(&r[j], &r[i], &u);
-        secp256k1_fe_mul(&u, &u, &a[j]);
-    }
-
-    r[0] = u;
-}
-
 static int secp256k1_fe_is_quad_var(const secp256k1_fe *a) {
 #ifndef USE_NUM_NONE
     unsigned char b[32];

--- a/src/tests.c
+++ b/src/tests.c
@@ -1964,28 +1964,6 @@ void run_field_inv_var(void) {
     }
 }
 
-void run_field_inv_all_var(void) {
-    secp256k1_fe x[16], xi[16], xii[16];
-    int i;
-    /* Check it's safe to call for 0 elements */
-    secp256k1_fe_inv_all_var(xi, x, 0);
-    for (i = 0; i < count; i++) {
-        size_t j;
-        size_t len = secp256k1_testrand_int(15) + 1;
-        for (j = 0; j < len; j++) {
-            random_fe_non_zero(&x[j]);
-        }
-        secp256k1_fe_inv_all_var(xi, x, len);
-        for (j = 0; j < len; j++) {
-            CHECK(check_fe_inverse(&x[j], &xi[j]));
-        }
-        secp256k1_fe_inv_all_var(xii, xi, len);
-        for (j = 0; j < len; j++) {
-            CHECK(check_fe_equal(&x[j], &xii[j]));
-        }
-    }
-}
-
 void run_sqr(void) {
     secp256k1_fe x, s;
 
@@ -2111,7 +2089,6 @@ void test_ge(void) {
      */
     secp256k1_ge *ge = (secp256k1_ge *)checked_malloc(&ctx->error_callback, sizeof(secp256k1_ge) * (1 + 4 * runs));
     secp256k1_gej *gej = (secp256k1_gej *)checked_malloc(&ctx->error_callback, sizeof(secp256k1_gej) * (1 + 4 * runs));
-    secp256k1_fe *zinv = (secp256k1_fe *)checked_malloc(&ctx->error_callback, sizeof(secp256k1_fe) * (1 + 4 * runs));
     secp256k1_fe zf;
     secp256k1_fe zfi2, zfi3;
 
@@ -2143,23 +2120,6 @@ void test_ge(void) {
             random_field_element_magnitude(&gej[1 + j + 4 * i].y);
             random_field_element_magnitude(&gej[1 + j + 4 * i].z);
         }
-    }
-
-    /* Compute z inverses. */
-    {
-        secp256k1_fe *zs = checked_malloc(&ctx->error_callback, sizeof(secp256k1_fe) * (1 + 4 * runs));
-        for (i = 0; i < 4 * runs + 1; i++) {
-            if (i == 0) {
-                /* The point at infinity does not have a meaningful z inverse. Any should do. */
-                do {
-                    random_field_element_test(&zs[i]);
-                } while(secp256k1_fe_is_zero(&zs[i]));
-            } else {
-                zs[i] = gej[i].z;
-            }
-        }
-        secp256k1_fe_inv_all_var(zinv, zs, 4 * runs + 1);
-        free(zs);
     }
 
     /* Generate random zf, and zfi2 = 1/zf^2, zfi3 = 1/zf^3 */
@@ -2270,16 +2230,9 @@ void test_ge(void) {
         free(gej_shuffled);
     }
 
-    /* Test batch gej -> ge conversion with and without known z ratios. */
+    /* Test batch gej -> ge conversion without known z ratios. */
     {
-        secp256k1_fe *zr = (secp256k1_fe *)checked_malloc(&ctx->error_callback, (4 * runs + 1) * sizeof(secp256k1_fe));
         secp256k1_ge *ge_set_all = (secp256k1_ge *)checked_malloc(&ctx->error_callback, (4 * runs + 1) * sizeof(secp256k1_ge));
-        for (i = 0; i < 4 * runs + 1; i++) {
-            /* Compute gej[i + 1].z / gez[i].z (with gej[n].z taken to be 1). */
-            if (i < 4 * runs) {
-                secp256k1_fe_mul(&zr[i + 1], &zinv[i], &gej[i + 1].z);
-            }
-        }
         secp256k1_ge_set_all_gej_var(ge_set_all, gej, 4 * runs + 1);
         for (i = 0; i < 4 * runs + 1; i++) {
             secp256k1_fe s;
@@ -2288,7 +2241,6 @@ void test_ge(void) {
             ge_equals_gej(&ge_set_all[i], &gej[i]);
         }
         free(ge_set_all);
-        free(zr);
     }
 
     /* Test batch gej -> ge conversion with many infinities. */
@@ -2309,7 +2261,6 @@ void test_ge(void) {
 
     free(ge);
     free(gej);
-    free(zinv);
 }
 
 
@@ -5670,7 +5621,6 @@ int main(int argc, char **argv) {
     /* field tests */
     run_field_inv();
     run_field_inv_var();
-    run_field_inv_all_var();
     run_field_misc();
     run_field_convert();
     run_sqr();


### PR DESCRIPTION
This function is only used in tests, since its functionality was inlined into `secp256k1_ge_set_all_gej_var` in #553.

Closes #873.