### PR TITLE
fix uninitialized read in tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,15 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
     ])
 
 saved_CFLAGS="$CFLAGS"
+CFLAGS="-Wconditional-uninitialized $CFLAGS"
+AC_MSG_CHECKING([if ${CC} supports -Wconditional-uninitialized])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
+    [ AC_MSG_RESULT([yes]) ],
+    [ AC_MSG_RESULT([no])
+      CFLAGS="$saved_CFLAGS"
+    ])
+
+saved_CFLAGS="$CFLAGS"
 CFLAGS="-fvisibility=hidden $CFLAGS"
 AC_MSG_CHECKING([if ${CC} supports -fvisibility=hidden])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],

--- a/src/tests.c
+++ b/src/tests.c
@@ -4324,8 +4324,10 @@ void test_ecdsa_sign_verify(void) {
     secp256k1_scalar one;
     secp256k1_scalar msg, key;
     secp256k1_scalar sigr, sigs;
-    int recid;
     int getrec;
+    /* Initialize recid to suppress a false positive -Wconditional-uninitialized in clang.
+       VG_UNDEF ensures that valgrind will still treat the variable as uninitialized. */
+    int recid = -1; VG_UNDEF(&recid, sizeof(recid));
     random_scalar_order_test(&msg);
     random_scalar_order_test(&key);
     secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &pubj, &key);


### PR DESCRIPTION
I tried compiling secp256k1 with clang and `-Wconditional-uninitialized` and got the following warning:

```
$ make check
  CC       src/tests-tests.o
src/tests.c:4336:15: warning: variable 'recid' may be uninitialized when used here [-Wconditional-uninitialized]
        CHECK(recid >= 0 && recid < 4);
              ^~~~~
./src/util.h:54:18: note: expanded from macro 'CHECK'
    if (EXPECT(!(cond), 0)) { \
                 ^~~~
./src/util.h:41:39: note: expanded from macro 'EXPECT'
#define EXPECT(x,c) __builtin_expect((x),(c))
                                      ^
src/tests.c:4327:14: note: initialize the variable 'recid' to silence this warning
    int recid;
             ^
              = 0
1 warning generated.
  CCLD     tests
make  check-TESTS
```

This initializes `recid` and adds the  `-Wconditional-uninitialized` flag when building with clang.
