### PR TITLE
ctime_test: move context randomization test to the end

### DIFF
--- a/src/valgrind_ctime_test.c
+++ b/src/valgrind_ctime_test.c
@@ -5,6 +5,8 @@
  ***********************************************************************/
 
 #include <valgrind/memcheck.h>
+#include <stdio.h>
+
 #include "include/secp256k1.h"
 #include "assumptions.h"
 #include "util.h"
@@ -25,8 +27,42 @@
 #include "include/secp256k1_schnorrsig.h"
 #endif
 
+void run_tests(secp256k1_context *ctx, unsigned char *key);
+
 int main(void) {
     secp256k1_context* ctx;
+    unsigned char key[32];
+    int ret, i;
+
+    if (!RUNNING_ON_VALGRIND) {
+        fprintf(stderr, "This test can only usefully be run inside valgrind.\n");
+        fprintf(stderr, "Usage: libtool --mode=execute valgrind ./valgrind_ctime_test\n");
+        return 1;
+    }
+    ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN
+                                   | SECP256K1_CONTEXT_VERIFY
+                                   | SECP256K1_CONTEXT_DECLASSIFY);
+    /** In theory, testing with a single secret input should be sufficient:
+     *  If control flow depended on secrets the tool would generate an error.
+     */
+    for (i = 0; i < 32; i++) {
+        key[i] = i + 65;
+    }
+
+    run_tests(ctx, key);
+
+    /* Test context randomisation. Do this last because it leaves the context
+     * tainted. */
+    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    ret = secp256k1_context_randomize(ctx, key);
+    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    CHECK(ret);
+
+    secp256k1_context_destroy(ctx);
+    return 0;
+}
+
+void run_tests(secp256k1_context *ctx, unsigned char *key) {
     secp256k1_ecdsa_signature signature;
     secp256k1_pubkey pubkey;
     size_t siglen = 74;
@@ -34,7 +70,6 @@ int main(void) {
     int i;
     int ret;
     unsigned char msg[32];
-    unsigned char key[32];
     unsigned char sig[74];
     unsigned char spubkey[33];
 #ifdef ENABLE_MODULE_RECOVERY
@@ -45,25 +80,9 @@ int main(void) {
     secp256k1_keypair keypair;
 #endif
 
-    if (!RUNNING_ON_VALGRIND) {
-        fprintf(stderr, "This test can only usefully be run inside valgrind.\n");
-        fprintf(stderr, "Usage: libtool --mode=execute valgrind ./valgrind_ctime_test\n");
-        exit(1);
-    }
-
-    /** In theory, testing with a single secret input should be sufficient:
-     *  If control flow depended on secrets the tool would generate an error.
-     */
-    for (i = 0; i < 32; i++) {
-        key[i] = i + 65;
-    }
     for (i = 0; i < 32; i++) {
         msg[i] = i + 1;
     }
-
-    ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN
-                                   | SECP256K1_CONTEXT_VERIFY
-                                   | SECP256K1_CONTEXT_DECLASSIFY);
 
     /* Test keygen. */
     VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
@@ -122,12 +141,6 @@ int main(void) {
     VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
     CHECK(ret == 1);
 
-    /* Test context randomisation. Do this last because it leaves the context tainted. */
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
-    ret = secp256k1_context_randomize(ctx, key);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
-    CHECK(ret);
-
     /* Test keypair_create and keypair_xonly_tweak_add. */
 #ifdef ENABLE_MODULE_EXTRAKEYS
     VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
@@ -157,7 +170,4 @@ int main(void) {
     VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
     CHECK(ret == 1);
 #endif
-
-    secp256k1_context_destroy(ctx);
-    return 0;
 }


### PR DESCRIPTION
I noticed this while reviewing https://github.com/ElementsProject/secp256k1-zkp/pull/117 and  finding some seemingly unnecessary `VALGRIND_MAKE_MEM_DEFINED` that I couldn't remove until I saw the bug.