### PR TITLE
Automatically check that VERIFY_CHECKs are side effect free

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -9,6 +9,20 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 AC_MSG_RESULT([$has_64bit_asm])
 ])
 
+AC_DEFUN([SECP_CHECK_SIDE_EFFECT_FREE],[
+AC_MSG_CHECKING(whether compiler detects side effect free statements)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  extern int should_not_survive;
+  static int side_effect_free(void) {
+      int x=3;
+      return x*x == 15;
+  }
+]],[[
+  (void)(should_not_survive || side_effect_free());
+  ]])],[has_check_side_effect_free=yes],[has_check_side_effect_free=no])
+AC_MSG_RESULT([$has_check_side_effect_free])
+])
+
 dnl
 AC_DEFUN([SECP_OPENSSL_CHECK],[
   has_libcrypto=no

--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,13 @@ else
     CFLAGS="-O2 $CFLAGS"
 fi
 
+SECP_CHECK_SIDE_EFFECT_FREE
+if test x"$have_check_side_effect_free" = x"yes"; then
+  set_check_side_effect_free=yes
+else
+  set_check_side_effect_free=no
+fi
+
 if test x"$req_asm" = x"auto"; then
   SECP_64BIT_ASM_CHECK
   if test x"$has_64bit_asm" = x"yes"; then
@@ -292,6 +299,16 @@ if test x"$use_external_asm" = x"yes"; then
   AC_DEFINE(USE_EXTERNAL_ASM, 1, [Define this symbol if an external (non-inline) assembly implementation is used])
 fi
 
+case $set_check_side_effect_free in
+yes)
+  AC_DEFINE(CHECK_SIDE_EFFECT_FREE, 1, [Define this symbol to enable checks for side-effect free statements])
+  ;;
+no)
+  ;;
+*)
+  AC_MSG_ERROR([invalid selection for check_side_effect_free])
+  ;;
+esac
 
 # Select wide multiplication implementation
 case $set_widemul in

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -276,8 +276,10 @@ SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe *a) {
     const uint32_t *t = a->n;
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
-    secp256k1_fe_verify(a);
 #endif
+    /* No secp256k1_fe_verify is needed here, because if all limbs are 0,
+     * the representation is always valid. This also allows using this function
+     * inside VERIFY_CHECK conditions itself without side effects. */
     return (t[0] | t[1] | t[2] | t[3] | t[4] | t[5] | t[6] | t[7] | t[8] | t[9]) == 0;
 }
 

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -239,8 +239,10 @@ SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe *a) {
     const uint64_t *t = a->n;
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
-    secp256k1_fe_verify(a);
 #endif
+    /* No secp256k1_fe_verify is needed here, because if all limbs are 0,
+     * the representation is always valid. This also allows using this function
+     * inside VERIFY_CHECK conditions itself without side effects. */
     return (t[0] | t[1] | t[2] | t[3] | t[4]) == 0;
 }
 


### PR DESCRIPTION
At configure time, detect whether our compiler is able to optimize out references to variables that only control execution of a side-effect free statement. If so, use that trick at compile time to verify that all our VERIFY_CHECK statements are in fact (provably) side-effect free.

This trick is explained on stackoverflow.com/a/35294344, and was suggested on https://github.com/bitcoin-core/secp256k1/pull/902#issuecomment-797736831.