### PR TITLE
add ECMULT_GEN_PREC_BITS to basic_config.h

### DIFF
--- a/src/basic-config.h
+++ b/src/basic-config.h
@@ -19,6 +19,7 @@
 
 #define USE_WIDEMUL_64 1
 #define ECMULT_WINDOW_SIZE 15
+#define ECMULT_GEN_PREC_BITS 4
 
 #endif /* USE_BASIC_CONFIG */
 


### PR DESCRIPTION
set ECMULT_GEN_PREC_BITS to the "auto" value of 4 in basic_config.h, so libsecp can be used without autoconf