### PR TITLE
Test all ecmult functions with many j*2^i combinations

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -290,7 +290,7 @@ task:
       env:
         # The `--error-exitcode` is required to make the test fail if valgrind found errors, otherwise it'll return 0 (https://www.valgrind.org/docs/manual/manual-core.html)
         WRAPPER_CMD: "valgrind --error-exitcode=42"
-        SECP256K1_TEST_ITERS: 16
+        SECP256K1_TEST_ITERS: 2
     - name: "UBSan, ASan, LSan"
       env:
         CFLAGS: "-fsanitize=undefined,address -g"


### PR DESCRIPTION
Instead of just testing properties of the points xG for x=-36..36:
* also compute all xG where x=j*2^i for i=0..255 and odd j=1..255.
* test them against known exact results (SHA256 all of them, and compared against an independently created result)
* test all 4 ecmult functions (and for secp256k1_ecmult and secp256k1_ecmult_multi_var, both as G, and through the generic point input)

