### PR TITLE
secp256k1.h: clarify that by default arguments must be != NULL

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -7,7 +7,9 @@ extern "C" {
 
 #include <stddef.h>
 
-/* These rules specify the order of arguments in API calls:
+/* Unless explicitly stated all pointer arguments must not be NULL.
+ *
+ * The following rules specify the order of arguments in API calls:
  *
  * 1. Context pointers go first, followed by output arguments, combined
  *    output/input arguments, and finally input-only arguments.


### PR DESCRIPTION
The same file says that the illegal callback will only triger for violations
explicitly mentioned, which is not true without this commit because we often
don't mention that an argument is not allowed to be NULL.

This line is extracted from #783 in the hope that it gets merged faster because other PRs depend on it.