### PR TITLE
Recommend VPATH (out-of-tree) builds in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ valgrind_ctime_test
 *.so
 *.a
 !.gitignore
-
 Makefile
 configure
 build/**
@@ -34,6 +33,13 @@ libtool
 *~
 *.log
 *.trs
+
+coverage/
+coverage.html
+coverage.*.html
+*.gcda
+*.gcno
+
 src/libsecp256k1-config.h
 src/libsecp256k1-config.h.in
 src/ecmult_static_context.h

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ valgrind_ctime_test
 
 Makefile
 configure
+build/**
 .libs/
 Makefile.in
 aclocal.m4

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Build steps
 libsecp256k1 is built using autotools:
 
     $ ./autogen.sh
-    $ ./configure
+    $ mkdir -p build; cd build
+    $ ../configure
     $ make
     $ make check
     $ sudo make install  # optional
@@ -84,7 +85,7 @@ This library aims to have full coverage of the reachable lines and branches.
 
 To create a test coverage report, configure with `--enable-coverage` (use of GCC is necessary):
 
-    $ ./configure --enable-coverage
+    $ ../configure --enable-coverage
 
 Run the tests:
 
@@ -92,11 +93,11 @@ Run the tests:
 
 To create a report, `gcovr` is recommended, as it includes branch coverage reporting:
 
-    $ gcovr --exclude 'src/bench*' --print-summary
+    $ gcovr --root .. --exclude '../src/bench*' --print-summary
 
 To create a HTML report with coloured and annotated source code:
 
-    $ gcovr --exclude 'src/bench*' --html --html-details -o coverage.html
+    $ gcovr --root .. --exclude '../src/bench*' --html --html-details -o coverage.html
 
 Reporting a vulnerability
 ------------

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ To create a report, `gcovr` is recommended, as it includes branch coverage repor
 
 To create a HTML report with coloured and annotated source code:
 
-    $ gcovr --root .. --exclude '../src/bench*' --html --html-details -o coverage.html
+    $ mdkir -p coverage
+    $ gcovr --root .. --exclude '../src/bench*' --html --html-details -o coverage/coverage.html
 
 Reporting a vulnerability
 ------------

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -12,7 +12,8 @@ valgrind --version || true
 
 ./autogen.sh
 
-./configure \
+mkdir build; cd build
+../configure \
     --enable-experimental="$EXPERIMENTAL" \
     --with-test-override-wide-multiply="$WIDEMUL" --with-asm="$ASM" \
     --enable-ecmult-static-precomputation="$STATICPRECOMPUTATION" --with-ecmult-gen-precision="$ECMULTGENPRECISION" \


### PR DESCRIPTION
These VPATH builds are supported natively by autotools, so we can
just rely on them.

This also removes the leftover `obj` directory and provides an empty `build`
directory instead.