### PR TITLE
Verify that secp256k1_ge_set_gej_zinv does not operate on infinity.

### DIFF
--- a/src/ecmult_const.h
+++ b/src/ecmult_const.h
@@ -14,6 +14,7 @@
  * Multiply: R = q*A (in constant-time)
  * Here `bits` should be set to the maximum bitlength of the _absolute value_ of `q`, plus
  * one because we internally sometimes add 2 to the number during the WNAF conversion.
+ * A must not be infinity.
  */
 static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, const secp256k1_scalar *q, int bits);
 

--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -168,6 +168,7 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
      * that the Z coordinate was 1, use affine addition formulae, and correct
      * the Z coordinate of the result once at the end.
      */
+    VERIFY_CHECK(!a->infinity);
     secp256k1_gej_set_ge(r, a);
     secp256k1_ecmult_odd_multiples_table_globalz_windowa(pre_a, &Z, r);
     for (i = 0; i < ECMULT_TABLE_SIZE(WINDOW_A); i++) {

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -67,6 +67,7 @@ static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(0, 0, 0, 0, 
 static void secp256k1_ge_set_gej_zinv(secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zi) {
     secp256k1_fe zi2;
     secp256k1_fe zi3;
+    VERIFY_CHECK(!a->infinity);
     secp256k1_fe_sqr(&zi2, zi);
     secp256k1_fe_mul(&zi3, &zi2, zi);
     secp256k1_fe_mul(&r->x, &a->x, &zi2);


### PR DESCRIPTION
a->x and a->y should not be used if the infinity flag is set.