### PR TITLE
ci: Run PRs on merge result even for i686

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,6 +92,7 @@ task:
         CC: i686-linux-gnu-gcc
     - env:
         CC: clang --target=i686-pc-linux-gnu -isystem /usr/i686-linux-gnu/include
+  << : *MERGE_BASE
   test_script:
     - ./ci/cirrus.sh
   << : *CAT_LOGS


### PR DESCRIPTION
This line should have been added in c7f754fe4d5e032fd150c4b9b985855e9fcaa521.

This mistake caused some i686 builds to fail when the PR was not
rebased, see https://cirrus-ci.com/build/5156197872435200.