### PR TITLE
configure: replace AC_PATH_PROG to AC_CHECK_PROG

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,8 +42,8 @@ AM_PROG_AS
 case $host_os in
   *darwin*)
      if  test x$cross_compiling != xyes; then
-       AC_PATH_PROG([BREW],brew,)
-       if test x$BREW != x; then
+       AC_CHECK_PROG([BREW], brew, brew)
+       if test x$BREW = xbrew; then
          # These Homebrew packages may be keg-only, meaning that they won't be found
          # in expected paths because they may conflict with system files. Ask
          # Homebrew where each one is located, then adjust paths accordingly.
@@ -58,10 +58,10 @@ case $host_os in
            VALGRIND_CPPFLAGS="-I$valgrind_prefix/include"
          fi
        else
-         AC_PATH_PROG([PORT],port,)
+         AC_CHECK_PROG([PORT], port, port)
          # If homebrew isn't installed and macports is, add the macports default paths
          # as a last resort.
-         if test x$PORT != x; then
+         if test x$PORT = xport; then
            CPPFLAGS="$CPPFLAGS -isystem /opt/local/include"
            LDFLAGS="$LDFLAGS -L/opt/local/lib"
          fi


### PR DESCRIPTION
~When libsecp256k1 is built as an external package for some another program it might be important to respect parent's `--prefix`. AC_CHECK_PROG does this correctly while AC_PATH_PROG finds system-wide installed binaries instead.~ See correct description of the issue in the comment below.

A patch like this applied to Bitcoin Core repo directly fixes `make check` for Bitcoin Core 0.19 and older on macOS. openssl was removed from dependencies in v0.20 so `make check` no longer fails on newer versions but it makes sense to fix libsecp256k1 anyway probably.

Example `make check` failure for Bitcoin Core 0.19:
```
Undefined symbols for architecture x86_64:
  "_BN_is_negative", referenced from:
      _test_ecdsa_der_parse in tests-tests.o
  "_ECDSA_SIG_get0", referenced from:
      _test_ecdsa_der_parse in tests-tests.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Example configure logs for Bitcoin Core 0.19 with `--prefix`
(I also exposed `$enable_openssl_tests` like it's done in master to make it easier to compare)

Before:
```
...
checking for brew... no
...
=== configuring in src/secp256k1 (/path/to/bitcoin/src/secp256k1)
...
checking for brew... /usr/local/bin/brew
...
checking for libcrypto... yes
checking for main in -lcrypto... yes
checking for EC functions in libcrypto... yes
...
Build Options:
...
  with openssl tests  = auto
...
```

After:
```
...
checking for brew... no
...
=== configuring in src/secp256k1 (/path/to/bitcoin/src/secp256k1)
...
checking for brew... no
checking for port... no
...
checking for libcrypto... yes
checking for main in -lcrypto... yes
checking for EC functions in libcrypto... yes
...
Build Options:
...
  with openssl tests  = auto
...
```

Example configure logs for Bitcoin Core 0.21.99 (master) with `--prefix`

Before:
```
...
checking for brew... no
...
=== configuring in src/secp256k1 (/path/to/bitcoin/src/secp256k1)
...
checking for brew... /usr/local/bin/brew
...
checking for libcrypto... yes
checking for main in -lcrypto... yes
checking for EC functions in libcrypto... yes
...
Build Options:
...
  with openssl tests      = yes
...
```

After:
```
...
checking for brew... no
...
=== configuring in src/secp256k1 (/path/to/bitcoin/src/secp256k1)
...
checking for brew... no
checking for port... no
...
checking for libcrypto... no
checking for openssl/crypto.h... no
...
Build Options:
...
  with openssl tests      = no
...
```