### PR TITLE
ci: Fixes after Debian release

### DIFF
--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install --no-install-recommends --no-upgrade -y \
         make automake libtool pkg-config dpkg-dev valgrind qemu-user \
         gcc clang llvm libc6-dbg \
         g++ \
-        gcc-i686-linux-gnu libc6-dev-i386-cross libc6-dbg:i386 libubsan1:i386 libasan5:i386 \
+        gcc-i686-linux-gnu libc6-dev-i386-cross libc6-dbg:i386 libubsan1:i386 libasan6:i386 \
         gcc-s390x-linux-gnu libc6-dev-s390x-cross libc6-dbg:s390x \
         gcc-arm-linux-gnueabihf libc6-dev-armhf-cross libc6-dbg:armhf \
         gcc-aarch64-linux-gnu libc6-dev-arm64-cross libc6-dbg:arm64 \


### PR DESCRIPTION
Debian stable is now bullseye. This results in an update of compiler versions, which make some minor fixes necessary. See commit messages for details.

Tip: If you want to build the docker image locally, use `--pull` to force docker to pull the latest Debian image as a base, e.g., `docker build . -f ci/linux-debian.Dockerfile --pull`.