### PR TITLE
Add a `--enable-dev-mode` to enable everything

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,6 +166,18 @@ AC_ARG_ENABLE(external_default_callbacks,
     [use_external_default_callbacks=$enableval],
     [use_external_default_callbacks=no])
 
+AC_ARG_ENABLE(dev_mode,
+    AS_HELP_STRING([--enable-dev-mode],[enables all modules including experimental, for development use only [default=no]]),
+    [use_benchmark=$enableval
+     use_tests=$enableval
+     use_experimental=$enableval
+     use_exhaustive_tests=$enableval
+     enable_module_ecdh=$enableval
+     enable_module_recovery=$enableval
+     enable_module_extrakeys=$enableval
+     enable_module_schnorrsig=$enableval],
+    [])
+
 # Test-only override of the (autodetected by the C code) "widemul" setting.
 # Legal values are int64 (for [u]int64_t), int128 (for [unsigned] __int128), and auto (the default).
 AC_ARG_WITH([test-override-wide-multiply], [] ,[set_widemul=$withval], [set_widemul=auto])

--- a/configure.ac
+++ b/configure.ac
@@ -464,7 +464,7 @@ fi
 ### Check for --enable-experimental if necessary
 ###
 
-if test x"$enable_experimental" = x"yes"; then
+if test x"$use_experimental" = x"yes"; then
   AC_MSG_NOTICE([******])
   AC_MSG_NOTICE([WARNING: experimental build])
   AC_MSG_NOTICE([Experimental features do not have stable APIs or properties, and may not be safe for production use.])


### PR DESCRIPTION
When modifying the internals I usually want to run all the tests and make sure that I don't break any of the modules.
but I never remember exactly if `module` comes before or after the module name (i.e. `--enable-module-ecdh` vs `--enable-ecdh-module`) and it's a lot to enable all modules.

So I added a short simple flag `--enable-dev-mode` that enables everything.
(If we want to make it more configurable, we can set all default values before, then process `dev-mode`, and then process the rest of the flags without any `action-if-not-given`, so that further flags can override the default dev-mode, but because it's for development I think this is currently enough)

This also fixes the fact that we've assigned `use_experimental` but used `enable_experimental`.