### PR TITLE
tests: remove `secp256k1_fe_verify` from tests.c and modify `_fe_from_storage` to call `_fe_verify`

### DIFF
--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -1162,6 +1162,7 @@ static SECP256K1_INLINE void secp256k1_fe_from_storage(secp256k1_fe *r, const se
 #ifdef VERIFY
     r->magnitude = 1;
     r->normalized = 1;
+    secp256k1_fe_verify(r);
 #endif
 }
 

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -496,6 +496,7 @@ static SECP256K1_INLINE void secp256k1_fe_from_storage(secp256k1_fe *r, const se
 #ifdef VERIFY
     r->magnitude = 1;
     r->normalized = 1;
+    secp256k1_fe_verify(r);
 #endif
 }
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -3435,8 +3435,6 @@ void test_pre_g_table(const secp256k1_ge_storage * pre_g, size_t n) {
     CHECK(0 < n);
 
     secp256k1_ge_from_storage(&p, &pre_g[0]);
-    secp256k1_fe_verify(&p.x);
-    secp256k1_fe_verify(&p.y);
     CHECK(secp256k1_ge_is_valid_var(&p));
 
     secp256k1_gej_set_ge(&g2, &p);
@@ -3449,8 +3447,6 @@ void test_pre_g_table(const secp256k1_ge_storage * pre_g, size_t n) {
         CHECK(!secp256k1_fe_normalizes_to_zero_var(&dpx) || !secp256k1_fe_normalizes_to_zero_var(&dpy));
 
         secp256k1_ge_from_storage(&q, &pre_g[i]);
-        secp256k1_fe_verify(&q.x);
-        secp256k1_fe_verify(&q.y);
         CHECK(secp256k1_ge_is_valid_var(&q));
 
         secp256k1_fe_negate(&dqx, &q.x, 1); secp256k1_fe_add(&dqx, &gg.x); secp256k1_fe_normalize_weak(&dqx);


### PR DESCRIPTION
**Changes:** (Suggested in secp256k1 IRC channel)
- `secp256k1_fe_verify` is removed from tests since it throws an error if the build does not define `VERIFY`.
   (Ex: `./configure --enable-coverage` does not define `VERIFY`)
-  `secp256k1_fe_from_storage` calls `secp256k1_fe_verify` in the `VERIFY` build to check for invalid field element.

To test the changes build secp256k1 with `./configure --enable-coverage` and run
```
make
make check
```

You can find my `make check` output [here](https://pastebin.ubuntu.com/p/H7zd5WfX9q/).