### PR TITLE
.gitignore: add build-aux/ltmain.sh-e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ build-aux/config.sub
 build-aux/depcomp
 build-aux/install-sh
 build-aux/ltmain.sh
+build-aux/ltmain.sh-e
 build-aux/m4/libtool.m4
 build-aux/m4/lt~obsolete.m4
 build-aux/m4/ltoptions.m4


### PR DESCRIPTION
When running [autogen](https://github.com/ElementsProject/libwally-core/blob/master/tools/autogen.sh) in [LibWally](https://github.com/ElementsProject/libwally-core), which uses secp256k1-zkp as a submodule, this file is left on my system. It also happens when I swap out secp256k1-zkp for secp256k1.

It does not happen when I compile secp256k1 directly, so perhaps this is an issue on the LibWally side.

