### PR TITLE
bench.c: add `--help` option and ci: move env variables

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,9 +19,9 @@ env:
   RECOVERY: no
   SCHNORRSIG: no
   ### test options
-  TEST_ITERS:
+  SECP256K1_TEST_ITERS:
   BENCH: yes
-  BENCH_ITERS: 2
+  SECP256K1_BENCH_ITERS: 2
   CTIMETEST: yes
 
 cat_logs_snippet: &CAT_LOGS
@@ -171,7 +171,7 @@ task:
     memory: 1G
   env:
     WRAPPER_CMD: qemu-s390x
-    TEST_ITERS: 16
+    SECP256K1_TEST_ITERS: 16
     HOST: s390x-linux-gnu
     WITH_VALGRIND: no
     ECDH: yes
@@ -194,7 +194,7 @@ task:
     memory: 1G
   env:
     WRAPPER_CMD: qemu-arm
-    TEST_ITERS: 16
+    SECP256K1_TEST_ITERS: 16
     HOST: arm-linux-gnueabihf
     WITH_VALGRIND: no
     ECDH: yes
@@ -218,7 +218,7 @@ task:
     memory: 1G
   env:
     WRAPPER_CMD: qemu-aarch64
-    TEST_ITERS: 16
+    SECP256K1_TEST_ITERS: 16
     HOST: aarch64-linux-gnu
     WITH_VALGRIND: no
     ECDH: yes
@@ -239,7 +239,7 @@ task:
     memory: 1G
   env:
     WRAPPER_CMD: qemu-ppc64le
-    TEST_ITERS: 16
+    SECP256K1_TEST_ITERS: 16
     HOST: powerpc64le-linux-gnu
     WITH_VALGRIND: no
     ECDH: yes
@@ -260,7 +260,7 @@ task:
     memory: 1G
   env:
     WRAPPER_CMD: wine64-stable
-    TEST_ITERS: 16
+    SECP256K1_TEST_ITERS: 16
     HOST: x86_64-w64-mingw32
     WITH_VALGRIND: no
     ECDH: yes
@@ -290,7 +290,7 @@ task:
       env:
         # The `--error-exitcode` is required to make the test fail if valgrind found errors, otherwise it'll return 0 (https://www.valgrind.org/docs/manual/manual-core.html)
         WRAPPER_CMD: "valgrind --error-exitcode=42"
-        TEST_ITERS: 16
+        SECP256K1_TEST_ITERS: 16
     - name: "UBSan, ASan, LSan"
       env:
         CFLAGS: "-fsanitize=undefined,address"
@@ -298,7 +298,7 @@ task:
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
         ASAN_OPTIONS: "strict_string_checks=1:detect_stack_use_after_return=1:detect_leaks=1"
         LSAN_OPTIONS: "use_unaligned=1"
-        TEST_ITERS: 32
+        SECP256K1_TEST_ITERS: 32
   # Try to cover many configurations with just a tiny matrix.
   matrix:
     - env:

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -32,10 +32,6 @@ file .libs/* || true
 # This tells `make check` to wrap test invocations.
 export LOG_COMPILER="$WRAPPER_CMD"
 
-# This limits the iterations in the tests and benchmarks.
-export SECP256K1_TEST_ITERS="$TEST_ITERS"
-export SECP256K1_BENCH_ITERS="$BENCH_ITERS"
-
 make "$BUILD"
 
 if [ "$BENCH" = "yes" ]

--- a/src/bench.h
+++ b/src/bench.h
@@ -116,9 +116,35 @@ void run_benchmark(char *name, void (*benchmark)(void*, int), void (*setup)(void
 int have_flag(int argc, char** argv, char *flag) {
     char** argm = argv + argc;
     argv++;
-    while (argv != NULL && argv != argm) {
+    while (argv != argm) {
         if (strcmp(*argv, flag) == 0) {
             return 1;
+        }
+        argv++;
+    }
+    return 0;
+}
+
+/* takes an array containing the arguments that the user is allowed to enter on the command-line
+   returns:
+      - 1 if the user entered an invalid argument
+      - 0 if all the user entered arguments are valid */
+int have_invalid_args(int argc, char** argv, char** valid_args, size_t n) {
+    size_t i;
+    int found_valid;
+    char** argm = argv + argc;
+    argv++;
+
+    while (argv != argm) {
+        found_valid = 0;
+        for (i = 0; i < n; i++) {
+            if (strcmp(*argv, valid_args[i]) == 0) {
+                found_valid = 1; /* user entered a valid arg from the list */
+                break;
+            }
+        }
+        if (found_valid == 0) {
+            return 1; /* invalid arg found */
         }
         argv++;
     }

--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -292,7 +292,7 @@ int main(int argc, char **argv) {
            || have_flag(argc, argv, "--help")
            || have_flag(argc, argv, "help")) {
             help(argv);
-            return 1;
+            return 0;
         } else if(have_flag(argc, argv, "pippenger_wnaf")) {
             printf("Using pippenger_wnaf:\n");
             data.ecmult_multi = secp256k1_ecmult_pippenger_batch_single;


### PR DESCRIPTION
Fixes #1005

**Changes:**
- added `--help` option to `bench.c`
    - `help()` function prints the help to command-line
    - `have_invalid_args()` checks if the user has entered an invalid argument
- moved `secp256k1_bench_iters` and `secp256k1_test_iters` environment variables declaration to `.cirrus.yml`