### PR TITLE
ci: Enable -g if we set CFLAGS manually

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -293,8 +293,8 @@ task:
         TEST_ITERS: 16
     - name: "UBSan, ASan, LSan"
       env:
-        CFLAGS: "-fsanitize=undefined,address"
-        CFLAGS_FOR_BUILD: "-fsanitize=undefined,address"
+        CFLAGS: "-fsanitize=undefined,address -g"
+        CFLAGS_FOR_BUILD: "-fsanitize=undefined,address -g"
         UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
         ASAN_OPTIONS: "strict_string_checks=1:detect_stack_use_after_return=1:detect_leaks=1"
         LSAN_OPTIONS: "use_unaligned=1"
@@ -329,7 +329,7 @@ task:
     # ./configure correctly errors out when given CC=g++.
     # We hack around this by passing CC=g++ only to make.
     CC: gcc
-    MAKEFLAGS: -j2 CC=g++ CFLAGS=-fpermissive
+    MAKEFLAGS: -j2 CC=g++ CFLAGS=-fpermissive\ -g
     WERROR_CFLAGS:
     EXPERIMENTAL: yes
     ECDH: yes


### PR DESCRIPTION
This enables sanitizers to output line numbers in stack traces.