### PR TITLE
build: Windows DLL additions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,6 +74,7 @@ endif
 libsecp256k1_la_SOURCES = src/secp256k1.c
 libsecp256k1_la_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src $(SECP_INCLUDES)
 libsecp256k1_la_LIBADD = $(SECP_LIBS) $(COMMON_LIB)
+libsecp256k1_la_LDFLAGS = -no-undefined
 
 if VALGRIND_ENABLED
 libsecp256k1_la_CPPFLAGS += -DVALGRIND

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AH_TOP([#define LIBSECP256K1_CONFIG_H])
 AH_BOTTOM([#endif /*LIBSECP256K1_CONFIG_H*/])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 
-LT_INIT
+LT_INIT([win32-dll])
 
 # Make the compilation flags quiet unless V=1 is used.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])


### PR DESCRIPTION
This takes care of two of the outstanding issues in #923. One being initializing libtool with `win32-dll` and the other being the addition of `-no-undefined` to the libtool LDFLAGS. See each commit for more details.

Builders cross-compiling for Windows (including Core) will no-longer see:
```bash
libtool: warning: undefined symbols not allowed in x86_64-w64-mingw32 shared libraries; building static only
```

I'm planning on making some related changes downstream.