### PR TITLE
build: replace backtick command substitution with $()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ case $host_os in
          # in expected paths because they may conflict with system files. Ask
          # Homebrew where each one is located, then adjust paths accordingly.
          if $BREW list --versions valgrind >/dev/null; then
-           valgrind_prefix=`$BREW --prefix valgrind 2>/dev/null`
+           valgrind_prefix=$($BREW --prefix valgrind 2>/dev/null)
            VALGRIND_CPPFLAGS="-I$valgrind_prefix/include"
          fi
        else


### PR DESCRIPTION
This is only needed for the very oldest of non-POSIX-compatible shells.
Note that this code will also only be executed on macOS, where it'd be
very unlikely to run into such a shell anyways.

Followup to https://github.com/bitcoin-core/secp256k1/pull/1019#pullrequestreview-815300521. I had thought there were more usages of this
syntax, but seems like it's just the one.

See:
https://github.com/koalaman/shellcheck/wiki/SC2006

Co-authored-by: Hennadii Stepanov <32963518+hebasto@users.noreply.github.com>