### PR TITLE
build: Add a check that Valgrind actually supports a host platform

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -13,7 +13,13 @@ AC_DEFUN([SECP_VALGRIND_CHECK],[
 if test x"$has_valgrind" != x"yes"; then
   CPPFLAGS_TEMP="$CPPFLAGS"
   CPPFLAGS="$VALGRIND_CPPFLAGS $CPPFLAGS"
-  AC_CHECK_HEADER([valgrind/memcheck.h], [has_valgrind=yes; AC_DEFINE(HAVE_VALGRIND,1,[Define this symbol if valgrind is installed])])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    #include <valgrind/memcheck.h>
+  ]], [[
+    #if defined(NVALGRIND)
+    #  error "Valgrind does not support this platform."
+    #endif
+  ]])], [has_valgrind=yes; AC_DEFINE(HAVE_VALGRIND,1,[Define this symbol if valgrind is installed, and it supports the host platform])])
 fi
 ])
 


### PR DESCRIPTION
This PR adds a check that Valgrind actually supports a host platform.

On master (49f608de474a89e5c742830c8ff5ac8978b5796a):
```
$ ./autogen.sh &> /dev/null && ./configure -q --host=riscv64-linux-gnu 2>&1 | grep valgrind
  valgrind                = yes
```

With this PR:
```
$ ./autogen.sh &> /dev/null && ./configure -q --host=riscv64-linux-gnu 2>&1 | grep valgrind
  valgrind                = no
```

Closes #1023.
