### PR TITLE
Faster const-time modinv divsteps

### DIFF
--- a/doc/safegcd_implementation.md
+++ b/doc/safegcd_implementation.md
@@ -697,7 +697,7 @@ def divsteps_n_matrix(theta, f, g):
         # Conditionally subtract x, y, z from g, q, r.
         g, q, r = g - (x & c2), q - (y & c2), r - (z & c2)
         c3 = ~c1 & c2
-        # Conditionally completement theta, and then increment it by 1.
+        # Conditionally complement theta, and then increment it by 1.
         theta = (theta ^ c3) + 1
         # Conditionally add g, q, r to f, u, v.
         f, u, v = f + (g & c3), u + (q & c3), v + (r & c3)

--- a/src/modinv32_impl.h
+++ b/src/modinv32_impl.h
@@ -187,11 +187,11 @@ static int32_t secp256k1_modinv32_divsteps_30(int32_t theta, uint32_t f0, uint32
     for (i = 0; i < 30; ++i) {
         /* f must always be odd */
         VERIFY_CHECK((f & 1) == 1);
+        /* Minimum trailing zeros count for matrix elements decreases in each iteration */
+        VERIFY_CHECK(!((u | v | q | r) & (0xFFFFFFFFULL >> (i + 2))));
         /* Applying the matrix so far to the initial f,g gives current f,g. */
         VERIFY_CHECK((u >> (30 - i)) * f0 + (v >> (30 - i)) * g0 == f << i);
         VERIFY_CHECK((q >> (30 - i)) * f0 + (r >> (30 - i)) * g0 == g << i);
-        /* At the beginning of every loop, the matrix variables are even. */
-        VERIFY_CHECK(!((u | v | q | r) & 1));
         /* Compute conditional masks for (theta < 0) and for (g & 1). */
         c1 = theta >> 31;
         c2 = -(g & 1);
@@ -228,8 +228,9 @@ static int32_t secp256k1_modinv32_divsteps_30(int32_t theta, uint32_t f0, uint32
     VERIFY_CHECK(q * f0 + r * g0 == g << 30);
     /* The determinant of t must be a power of two. This guarantees that multiplication with t
      * does not change the gcd of f and g, apart from adding a power-of-2 factor to it (which
-     * will be divided out again). As each divstep's individual matrix has determinant 2, the
-     * aggregate of 30 of them will have determinant 2^30. */
+     * will be divided out again). As each divstep's individual matrix has determinant 2^-1,
+     * the aggregate of 30 of them will have determinant 2^-30. Multiplying with the initial
+     * 2^30*identity (which has determinant 2^60) means the result has determinant 2^30. */
     VERIFY_CHECK((int64_t)t->u * t->r - (int64_t)t->v * t->q == ((int64_t)1) << 30);
     return theta;
 }

--- a/src/modinv64_impl.h
+++ b/src/modinv64_impl.h
@@ -163,9 +163,13 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t theta, uint64_t f0, uint64
     int i;
 
     for (i = 3; i < 62; ++i) {
-        VERIFY_CHECK((f & 1) == 1); /* f must always be odd */
-        VERIFY_CHECK(((u >> (62 - i)) * f0 + (v >> (62 - i)) * g0) == f << i);
-        VERIFY_CHECK(((q >> (62 - i)) * f0 + (r >> (62 - i)) * g0) == g << i);
+        /* f must always be odd */
+        VERIFY_CHECK((f & 1) == 1);
+        /* Applying the matrix so far to the initial f,g gives current f,g. */
+        VERIFY_CHECK((u >> (62 - i)) * f0 + (v >> (62 - i)) * g0 == f << i);
+        VERIFY_CHECK((q >> (62 - i)) * f0 + (r >> (62 - i)) * g0 == g << i);
+        /* At the beginning of every loop, the matrix variables are even. */
+        VERIFY_CHECK(!((u | v | q | r) & 1));
         /* Compute conditional masks for (theta < 0) and for (g & 1). */
         c1 = theta >> 63;
         c2 = -(g & 1);
@@ -197,6 +201,9 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t theta, uint64_t f0, uint64
     t->v = v;
     t->q = q;
     t->r = r;
+    /* Applying the final matrix to the initial f,g gives final f,g. */
+    VERIFY_CHECK(u * f0 + v * g0 == f << 62);
+    VERIFY_CHECK(q * f0 + r * g0 == g << 62);
     /* The determinant of t must be a power of two. This guarantees that multiplication with t
      * does not change the gcd of f and g, apart from adding a power-of-2 factor to it (which
      * will be divided out again). As each divstep's individual matrix has determinant 2, the

--- a/src/modinv64_impl.h
+++ b/src/modinv64_impl.h
@@ -145,27 +145,20 @@ typedef struct {
     int64_t u, v, q, r;
 } secp256k1_modinv64_trans2x2;
 
-/* Compute the transition matrix and eta for 59 divsteps (where zeta=-(delta+1/2)).
+/* Compute the transition matrix and theta for 59 divsteps (where theta=delta-1/2)
  * Note that the transformation matrix is scaled by 2^62 and not 2^59.
  *
- * Input:  zeta: initial zeta
- *         f0:   bottom limb of initial f
- *         g0:   bottom limb of initial g
+ * Input:  theta: initial theta
+ *         f0:    bottom limb of initial f
+ *         g0:    bottom limb of initial g
  * Output: t: transition matrix
- * Return: final zeta
+ * Return: final theta
  *
  * Implements the divsteps_n_matrix function from the explanation.
  */
-static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_t g0, secp256k1_modinv64_trans2x2 *t) {
-    /* u,v,q,r are the elements of the transformation matrix being built up,
-     * starting with the identity matrix times 8 (because the caller expects
-     * a result scaled by 2^62). Semantically they are signed integers
-     * in range [-2^62,2^62], but here represented as unsigned mod 2^64. This
-     * permits left shifting (which is UB for negative numbers). The range
-     * being inside [-2^63,2^63) means that casting to signed works correctly.
-     */
+static int64_t secp256k1_modinv64_divsteps_59(int64_t theta, uint64_t f0, uint64_t g0, secp256k1_modinv64_trans2x2 *t) {
+    /* The transformation matrix being built up, scaled by 2^62. */
     int64_t u = (int64_t)1 << 62, v = 0, q = 0, r = (int64_t)1 << 62, y, z;
-    int64_t delta = ~zeta;
     uint64_t c1, c2, f = f0, g = g0, x;
     int i;
 
@@ -173,8 +166,8 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
         VERIFY_CHECK((f & 1) == 1); /* f must always be odd */
         VERIFY_CHECK(((u >> (62 - i)) * f0 + (v >> (62 - i)) * g0) == f << i);
         VERIFY_CHECK(((q >> (62 - i)) * f0 + (r >> (62 - i)) * g0) == g << i);
-        /* Compute conditional masks for (delta < 0) and for (g & 1). */
-        c1 = delta >> 63;
+        /* Compute conditional masks for (theta < 0) and for (g & 1). */
+        c1 = theta >> 63;
         c2 = -(g & 1);
         /* Compute x,y,z, conditionally complemented versions of f,u,v. */
         x = f ^ c1;
@@ -184,10 +177,10 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
         g -= x & c2;
         q -= y & c2;
         r -= z & c2;
-        /* In what follows, c2 is a condition mask for (delta >= 0) and (g & 1). */
+        /* In what follows, c2 is a condition mask for (theta >= 0) and (g & 1). */
         c2 &= ~c1;
-        /* Conditionally change delta into -delta or delta+1. */
-        delta = (delta ^ c2) + 1;
+        /* Conditionally change theta into -theta or theta+1. */
+        theta = (theta ^ c2) + 1;
         /* Conditionally add g,q,r to f,u,v. */
         f += g & c2;
         u += q & c2;
@@ -196,8 +189,8 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
         g >>= 1;
         q >>= 1;
         r >>= 1;
-        /* Bounds on delta that follow from the bounds on iteration count (max 10*59 divsteps). */
-        VERIFY_CHECK(delta >= -590 && delta <= 590);
+        /* Bounds on theta that follow from the bounds on iteration count (max 10*59 divsteps). */
+        VERIFY_CHECK(theta >= -590 && theta <= 590);
     }
     /* Return data in t and return value. */
     t->u = u;
@@ -211,7 +204,7 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
      * 8*identity (which has determinant 2^6) means the overall outputs has determinant
      * 2^65. */
     VERIFY_CHECK((int128_t)t->u * t->r - (int128_t)t->v * t->q == ((int128_t)1) << 65);
-    return ~delta;
+    return theta;
 }
 
 /* Compute the transition matrix and eta for 62 divsteps (variable time, eta=-delta).
@@ -225,7 +218,12 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
  * Implements the divsteps_n_matrix_var function from the explanation.
  */
 static int64_t secp256k1_modinv64_divsteps_62_var(int64_t eta, uint64_t f0, uint64_t g0, secp256k1_modinv64_trans2x2 *t) {
-    /* Transformation matrix; see comments in secp256k1_modinv64_divsteps_62. */
+    /* u,v,q,r are the elements of the transformation matrix being built up,
+     * starting with the identity matrix. Semantically they are signed integers
+     * in range [-2^62,2^62], but here represented as unsigned mod 2^64. This
+     * permits left shifting (which is UB for negative numbers). The range
+     * being inside [-2^63,2^63) means that casting to signed works correctly.
+     */
     uint64_t u = 1, v = 0, q = 0, r = 1;
     uint64_t f = f0, g = g0, m;
     uint32_t w;
@@ -460,19 +458,19 @@ static void secp256k1_modinv64_update_fg_62_var(int len, secp256k1_modinv64_sign
 
 /* Compute the inverse of x modulo modinfo->modulus, and replace x with it (constant time in x). */
 static void secp256k1_modinv64(secp256k1_modinv64_signed62 *x, const secp256k1_modinv64_modinfo *modinfo) {
-    /* Start with d=0, e=1, f=modulus, g=x, zeta=-1. */
+    /* Start with d=0, e=1, f=modulus, g=x, theta=0. */
     secp256k1_modinv64_signed62 d = {{0, 0, 0, 0, 0}};
     secp256k1_modinv64_signed62 e = {{1, 0, 0, 0, 0}};
     secp256k1_modinv64_signed62 f = modinfo->modulus;
     secp256k1_modinv64_signed62 g = *x;
     int i;
-    int64_t zeta = -1; /* zeta = -(delta+1/2); delta starts at 1/2. */
+    int64_t theta = 0; /* theta = delta-1/2; delta starts at 1/2. */
 
     /* Do 10 iterations of 59 divsteps each = 590 divsteps. This suffices for 256-bit inputs. */
     for (i = 0; i < 10; ++i) {
         /* Compute transition matrix and new zeta after 59 divsteps. */
         secp256k1_modinv64_trans2x2 t;
-        zeta = secp256k1_modinv64_divsteps_59(zeta, f.v[0], g.v[0], &t);
+        theta = secp256k1_modinv64_divsteps_59(theta, f.v[0], g.v[0], &t);
         /* Update d,e using that transition matrix. */
         secp256k1_modinv64_update_de_62(&d, &e, &t, modinfo);
         /* Update f,g using that transition matrix. */

--- a/src/modinv64_impl.h
+++ b/src/modinv64_impl.h
@@ -146,7 +146,9 @@ typedef struct {
 } secp256k1_modinv64_trans2x2;
 
 /* Compute the transition matrix and theta for 59 divsteps (where theta=delta-1/2)
- * Note that the transformation matrix is scaled by 2^62 and not 2^59.
+ * Although only 59 divsteps are performed, the resulting transformation matrix
+ * is scaled by 2^62 to allow reuse of _update_de_62 and _update_fg_62 between
+ * _modinv64 and _modinv64_var.
  *
  * Input:  theta: initial theta
  *         f0:    bottom limb of initial f
@@ -165,11 +167,11 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t theta, uint64_t f0, uint64
     for (i = 3; i < 62; ++i) {
         /* f must always be odd */
         VERIFY_CHECK((f & 1) == 1);
+        /* Minimum trailing zeros count for matrix elements decreases in each iteration */
+        VERIFY_CHECK(!((u | v | q | r) & (0xFFFFFFFFFFFFFFFFULL >> (i - 1))));
         /* Applying the matrix so far to the initial f,g gives current f,g. */
         VERIFY_CHECK((u >> (62 - i)) * f0 + (v >> (62 - i)) * g0 == f << i);
         VERIFY_CHECK((q >> (62 - i)) * f0 + (r >> (62 - i)) * g0 == g << i);
-        /* At the beginning of every loop, the matrix variables are even. */
-        VERIFY_CHECK(!((u | v | q | r) & 1));
         /* Compute conditional masks for (theta < 0) and for (g & 1). */
         c1 = theta >> 63;
         c2 = -(g & 1);
@@ -206,10 +208,9 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t theta, uint64_t f0, uint64
     VERIFY_CHECK(q * f0 + r * g0 == g << 62);
     /* The determinant of t must be a power of two. This guarantees that multiplication with t
      * does not change the gcd of f and g, apart from adding a power-of-2 factor to it (which
-     * will be divided out again). As each divstep's individual matrix has determinant 2, the
-     * aggregate of 59 of them will have determinant 2^59. Multiplying with the initial
-     * 8*identity (which has determinant 2^6) means the overall outputs has determinant
-     * 2^65. */
+     * will be divided out again). As each divstep's individual matrix has determinant 2^-1,
+     * the aggregate of 59 of them will have determinant 2^-59. Multiplying with the initial
+     * 2^62*identity (which has determinant 2^124) means the result has determinant 2^65. */
     VERIFY_CHECK((int128_t)t->u * t->r - (int128_t)t->v * t->q == ((int128_t)1) << 65);
     return theta;
 }

--- a/src/modinv64_impl.h
+++ b/src/modinv64_impl.h
@@ -164,45 +164,46 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
      * permits left shifting (which is UB for negative numbers). The range
      * being inside [-2^63,2^63) means that casting to signed works correctly.
      */
-    uint64_t u = 8, v = 0, q = 0, r = 8;
-    uint64_t c1, c2, f = f0, g = g0, x, y, z;
+    int64_t u = (int64_t)1 << 62, v = 0, q = 0, r = (int64_t)1 << 62, y, z;
+    int64_t delta = ~zeta;
+    uint64_t c1, c2, f = f0, g = g0, x;
     int i;
 
     for (i = 3; i < 62; ++i) {
         VERIFY_CHECK((f & 1) == 1); /* f must always be odd */
-        VERIFY_CHECK((u * f0 + v * g0) == f << i);
-        VERIFY_CHECK((q * f0 + r * g0) == g << i);
-        /* Compute conditional masks for (zeta < 0) and for (g & 1). */
-        c1 = zeta >> 63;
+        VERIFY_CHECK(((u >> (62 - i)) * f0 + (v >> (62 - i)) * g0) == f << i);
+        VERIFY_CHECK(((q >> (62 - i)) * f0 + (r >> (62 - i)) * g0) == g << i);
+        /* Compute conditional masks for (delta < 0) and for (g & 1). */
+        c1 = delta >> 63;
         c2 = -(g & 1);
-        /* Compute x,y,z, conditionally negated versions of f,u,v. */
-        x = (f ^ c1) - c1;
-        y = (u ^ c1) - c1;
-        z = (v ^ c1) - c1;
-        /* Conditionally add x,y,z to g,q,r. */
-        g += x & c2;
-        q += y & c2;
-        r += z & c2;
-        /* In what follows, c1 is a condition mask for (zeta < 0) and (g & 1). */
-        c1 &= c2;
-        /* Conditionally change zeta into -zeta-2 or zeta-1. */
-        zeta = (zeta ^ c1) - 1;
+        /* Compute x,y,z, conditionally complemented versions of f,u,v. */
+        x = f ^ c1;
+        y = u ^ c1;
+        z = v ^ c1;
+        /* Conditionally subtract x,y,z from g,q,r. */
+        g -= x & c2;
+        q -= y & c2;
+        r -= z & c2;
+        /* In what follows, c2 is a condition mask for (delta >= 0) and (g & 1). */
+        c2 &= ~c1;
+        /* Conditionally change delta into -delta or delta+1. */
+        delta = (delta ^ c2) + 1;
         /* Conditionally add g,q,r to f,u,v. */
-        f += g & c1;
-        u += q & c1;
-        v += r & c1;
+        f += g & c2;
+        u += q & c2;
+        v += r & c2;
         /* Shifts */
         g >>= 1;
-        u <<= 1;
-        v <<= 1;
-        /* Bounds on zeta that follow from the bounds on iteration count (max 10*59 divsteps). */
-        VERIFY_CHECK(zeta >= -591 && zeta <= 591);
+        q >>= 1;
+        r >>= 1;
+        /* Bounds on delta that follow from the bounds on iteration count (max 10*59 divsteps). */
+        VERIFY_CHECK(delta >= -590 && delta <= 590);
     }
     /* Return data in t and return value. */
-    t->u = (int64_t)u;
-    t->v = (int64_t)v;
-    t->q = (int64_t)q;
-    t->r = (int64_t)r;
+    t->u = u;
+    t->v = v;
+    t->q = q;
+    t->r = r;
     /* The determinant of t must be a power of two. This guarantees that multiplication with t
      * does not change the gcd of f and g, apart from adding a power-of-2 factor to it (which
      * will be divided out again). As each divstep's individual matrix has determinant 2, the
@@ -210,7 +211,7 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
      * 8*identity (which has determinant 2^6) means the overall outputs has determinant
      * 2^65. */
     VERIFY_CHECK((int128_t)t->u * t->r - (int128_t)t->v * t->q == ((int128_t)1) << 65);
-    return zeta;
+    return ~delta;
 }
 
 /* Compute the transition matrix and eta for 62 divsteps (variable time, eta=-delta).


### PR DESCRIPTION
Changes to _divsteps_59 (_30) that give maybe 4% speed improvement to const-time modinv on 64 bit. I see a larger gain on 32 bit but measured on 64 bit so might not be real.

Start the result matrix scaled by 2^62 (resp. 2^30) and shift q, r down instead of u, v up at each step (should make life easier for vectorization). Since we're always shifting away the LSB of g, q, r, we can avoid doing a full negation for x, y, z (after a few tweaks). Then it makes sense to switch zeta back to delta (I confined this change to the local method for the moment).