### PR TITLE
WIP Group verification

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -139,4 +139,11 @@ static void secp256k1_fe_half(secp256k1_fe *r);
  *  magnitude set to 'm' and is normalized if (and only if) 'm' is zero. */
 static void secp256k1_fe_get_bounds(secp256k1_fe *r, int m);
 
+#ifdef VERIFY
+
+/** Assert a context-specific limit m on the magnitude of a. m cannot be outside the intrinsic range of magnitudes supported by this field implementation. */
+static void secp256k1_fe_verify_magnitude(const secp256k1_fe *a, int m);
+
+#endif
+
 #endif /* SECP256K1_FIELD_H */

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -47,6 +47,12 @@ static void secp256k1_fe_verify(const secp256k1_fe *a) {
     }
     VERIFY_CHECK(r == 1);
 }
+
+static void secp256k1_fe_verify_magnitude(const secp256k1_fe *a, int m) {
+    VERIFY_CHECK(m >= 0);
+    VERIFY_CHECK(m <= 32);
+    VERIFY_CHECK(a->magnitude <= m);
+}
 #endif
 
 static void secp256k1_fe_get_bounds(secp256k1_fe *r, int m) {

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -56,6 +56,13 @@ static void secp256k1_fe_verify(const secp256k1_fe *a) {
     }
     VERIFY_CHECK(r == 1);
 }
+
+static void secp256k1_fe_verify_magnitude(const secp256k1_fe *a, int m) {
+    VERIFY_CHECK(m >= 0);
+    VERIFY_CHECK(m <= 2048);
+    VERIFY_CHECK(a->magnitude <= m);
+}
+
 #endif
 
 static void secp256k1_fe_get_bounds(secp256k1_fe *r, int m) {

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -66,11 +66,16 @@ static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(0, 0, 0, 0, 
 
 #ifdef VERIFY
 static void secp256k1_ge_verify(const secp256k1_ge *a) {
-    (void)a;
+    VERIFY_CHECK(a->infinity == 0 || a->infinity == 1);
+    secp256k1_fe_verify_magnitude(&a->x, 8);
+    secp256k1_fe_verify_magnitude(&a->y, 8);
 }
 
 static void secp256k1_gej_verify(const secp256k1_gej *a) {
-    (void)a;
+    VERIFY_CHECK(a->infinity == 0 || a->infinity == 1);
+    secp256k1_fe_verify_magnitude(&a->x, 8);
+    secp256k1_fe_verify_magnitude(&a->y, 8);
+    secp256k1_fe_verify_magnitude(&a->z, 8);
 }
 #endif
 

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -67,15 +67,15 @@ static const secp256k1_fe secp256k1_fe_const_b = SECP256K1_FE_CONST(0, 0, 0, 0, 
 #ifdef VERIFY
 static void secp256k1_ge_verify(const secp256k1_ge *a) {
     VERIFY_CHECK(a->infinity == 0 || a->infinity == 1);
-    secp256k1_fe_verify_magnitude(&a->x, 8);
-    secp256k1_fe_verify_magnitude(&a->y, 8);
+    secp256k1_fe_verify_magnitude(&a->x, 6);
+    secp256k1_fe_verify_magnitude(&a->y, 4);
 }
 
 static void secp256k1_gej_verify(const secp256k1_gej *a) {
     VERIFY_CHECK(a->infinity == 0 || a->infinity == 1);
-    secp256k1_fe_verify_magnitude(&a->x, 8);
-    secp256k1_fe_verify_magnitude(&a->y, 8);
-    secp256k1_fe_verify_magnitude(&a->z, 8);
+    secp256k1_fe_verify_magnitude(&a->x, 6);
+    secp256k1_fe_verify_magnitude(&a->y, 4);
+    secp256k1_fe_verify_magnitude(&a->z, 2);
 }
 #endif
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -59,9 +59,9 @@ void random_field_element_test(secp256k1_fe *fe) {
     } while(1);
 }
 
-void random_field_element_magnitude(secp256k1_fe *fe) {
+void random_field_element_magnitude(secp256k1_fe *fe, int m) {
     secp256k1_fe zero;
-    int n = secp256k1_testrand_int(9);
+    int n = secp256k1_testrand_int(m + 1);
     secp256k1_fe_normalize(fe);
     if (n == 0) {
         return;
@@ -73,6 +73,30 @@ void random_field_element_magnitude(secp256k1_fe *fe) {
 #ifdef VERIFY
     CHECK(fe->magnitude == n);
 #endif
+}
+
+void random_fe_magnitude(secp256k1_fe *fe) {
+    random_field_element_magnitude(fe, 8);
+}
+
+void random_ge_x_magnitude(secp256k1_ge *ge) {
+    random_field_element_magnitude(&ge->x, 6);
+}
+
+void random_ge_y_magnitude(secp256k1_ge *ge) {
+    random_field_element_magnitude(&ge->y, 4);
+}
+
+void random_gej_x_magnitude(secp256k1_gej *gej) {
+    random_field_element_magnitude(&gej->x, 6);
+}
+
+void random_gej_y_magnitude(secp256k1_gej *gej) {
+    random_field_element_magnitude(&gej->y, 4);
+}
+
+void random_gej_z_magnitude(secp256k1_gej *gej) {
+    random_field_element_magnitude(&gej->z, 2);
 }
 
 void random_group_element_test(secp256k1_ge *ge) {
@@ -2783,13 +2807,13 @@ void run_fe_mul(void) {
     for (i = 0; i < 100 * count; ++i) {
         secp256k1_fe a, b, c, d;
         random_fe(&a);
-        random_field_element_magnitude(&a);
+        random_fe_magnitude(&a);
         random_fe(&b);
-        random_field_element_magnitude(&b);
+        random_fe_magnitude(&b);
         random_fe_test(&c);
-        random_field_element_magnitude(&c);
+        random_fe_magnitude(&c);
         random_fe_test(&d);
-        random_field_element_magnitude(&d);
+        random_fe_magnitude(&d);
         test_fe_mul(&a, &a, 1);
         test_fe_mul(&c, &c, 1);
         test_fe_mul(&a, &b, 0);
@@ -3261,11 +3285,11 @@ void test_ge(void) {
         secp256k1_gej_set_ge(&gej[3 + 4 * i], &ge[3 + 4 * i]);
         random_group_element_jacobian_test(&gej[4 + 4 * i], &ge[4 + 4 * i]);
         for (j = 0; j < 4; j++) {
-            random_field_element_magnitude(&ge[1 + j + 4 * i].x);
-            random_field_element_magnitude(&ge[1 + j + 4 * i].y);
-            random_field_element_magnitude(&gej[1 + j + 4 * i].x);
-            random_field_element_magnitude(&gej[1 + j + 4 * i].y);
-            random_field_element_magnitude(&gej[1 + j + 4 * i].z);
+            random_ge_x_magnitude(&ge[1 + j + 4 * i]);
+            random_ge_y_magnitude(&ge[1 + j + 4 * i]);
+            random_gej_x_magnitude(&gej[1 + j + 4 * i]);
+            random_gej_y_magnitude(&gej[1 + j + 4 * i]);
+            random_gej_z_magnitude(&gej[1 + j + 4 * i]);
         }
     }
 
@@ -3273,7 +3297,7 @@ void test_ge(void) {
     do {
         random_field_element_test(&zf);
     } while(secp256k1_fe_is_zero(&zf));
-    random_field_element_magnitude(&zf);
+    random_fe_magnitude(&zf);
     secp256k1_fe_inv_var(&zfi3, &zf);
     secp256k1_fe_sqr(&zfi2, &zfi3);
     secp256k1_fe_mul(&zfi3, &zfi3, &zfi2);
@@ -3306,8 +3330,8 @@ void test_ge(void) {
                 secp256k1_ge ge2_zfi = ge[i2]; /* the second term with x and y rescaled for z = 1/zf */
                 secp256k1_fe_mul(&ge2_zfi.x, &ge2_zfi.x, &zfi2);
                 secp256k1_fe_mul(&ge2_zfi.y, &ge2_zfi.y, &zfi3);
-                random_field_element_magnitude(&ge2_zfi.x);
-                random_field_element_magnitude(&ge2_zfi.y);
+                random_ge_x_magnitude(&ge2_zfi);
+                random_ge_y_magnitude(&ge2_zfi);
                 secp256k1_gej_add_zinv_var(&resj, &gej[i1], &ge2_zfi, &zf);
                 ge_equals_gej(&ref, &resj);
             }


### PR DESCRIPTION
Sets up pre- and post- method verification of _ge and _gej group elements. At the moment, this is concerned mainly with imposing a tighter limit (than the default) on the magnitudes of field elements x, y (,z).

Having guarantees about the magnitudes in input group elements can let us avoid some of the normalization calls needed at the start of several group addition methods, and perhaps e.g. use an alternative double algorithm. There may be a trade-off between the effort needed to get outputs to meet lower limits vs the benefits that provides to other methods.
