### PR TITLE
ci: Optimize build matrix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -349,7 +349,7 @@ task:
   << : *CAT_LOGS
 
 task:
-  name: "C++ -fpermissive"
+  name: "C++ -fpermissive (entire project)"
   << : *LINUX_CONTAINER
   env:
     CC: g++
@@ -364,6 +364,14 @@ task:
   test_script:
     - ./ci/cirrus.sh
   << : *CAT_LOGS
+
+task:
+  name: "C++ (public headers)"
+  << : *LINUX_CONTAINER
+  test_script:
+    - g++ -Werror include/*.h
+    - clang -Werror -x c++-header include/*.h
+    - /opt/msvc/bin/x64/cl.exe -c -WX -TP include/*.h
 
 task:
   name: "sage prover"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -263,6 +263,42 @@ task:
     - ./ci/cirrus.sh
   << : *CAT_LOGS
 
+task:
+  << : *LINUX_CONTAINER
+  env:
+    WRAPPER_CMD: wine
+    WERROR_CFLAGS: -WX
+    WITH_VALGRIND: no
+    ECDH: yes
+    RECOVERY: yes
+    EXPERIMENTAL: yes
+    SCHNORRSIG: yes
+    CTIMETEST: no
+    # Set non-essential options that affect the CLI messages here.
+    # (They depend on the user's taste, so we don't want to set them automatically in configure.ac.)
+    CFLAGS: -nologo -diagnostics:caret
+    LDFLAGS: -XCClinker -nologo -XCClinker -diagnostics:caret
+  # Use a MinGW-w64 host to tell ./configure we're building for Windows.
+  # This will detect some MinGW-w64 tools but then make will need only
+  # the MSVC tools CC, AR and NM as specified below.
+  matrix:
+    - name: "x86_64 (MSVC): Windows (Debian stable, Wine)"
+      env: 
+        HOST: x86_64-w64-mingw32
+        CC: /opt/msvc/bin/x64/cl
+        AR: /opt/msvc/bin/x64/lib
+        NM: /opt/msvc/bin/x64/dumpbin -symbols -headers
+    - name: "i686 (MSVC): Windows (Debian stable, Wine)"
+      env: 
+        HOST: i686-w64-mingw32
+        CC: /opt/msvc/bin/x86/cl
+        AR: /opt/msvc/bin/x86/lib
+        NM: /opt/msvc/bin/x86/dumpbin -symbols -headers
+  << : *MERGE_BASE
+  test_script:
+    - ./ci/cirrus.sh
+  << : *CAT_LOGS
+
 # Sanitizers
 task:
   << : *LINUX_CONTAINER

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -312,10 +312,9 @@ task:
   name: "C++ -fpermissive"
   << : *LINUX_CONTAINER
   env:
-    # ./configure correctly errors out when given CC=g++.
-    # We hack around this by passing CC=g++ only to make.
-    CC: gcc
-    MAKEFLAGS: -j4 CC=g++ CFLAGS=-fpermissive\ -g
+    CC: g++
+    CFLAGS: -fpermissive -g
+    CPPFLAGS: -DSECP256K1_CPLUSPLUS_TEST_OVERRIDE
     WERROR_CFLAGS:
     EXPERIMENTAL: yes
     ECDH: yes

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -246,18 +246,22 @@ task:
   << : *CAT_LOGS
 
 task:
-  name: "x86_64 (mingw32-w64): Windows (Debian stable, Wine)"
   << : *LINUX_CONTAINER
   env:
-    WRAPPER_CMD: wine64-stable
-    SECP256K1_TEST_ITERS: 16
-    HOST: x86_64-w64-mingw32
+    WRAPPER_CMD: wine
     WITH_VALGRIND: no
     ECDH: yes
     RECOVERY: yes
     EXPERIMENTAL: yes
     SCHNORRSIG: yes
     CTIMETEST: no
+  matrix:
+    - name: "x86_64 (mingw32-w64): Windows (Debian stable, Wine)"
+      env: 
+        HOST: x86_64-w64-mingw32
+    - name: "i686 (mingw32-w64): Windows (Debian stable, Wine)"
+      env: 
+        HOST: i686-w64-mingw32
   << : *MERGE_BASE
   test_script:
     - ./ci/cirrus.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,6 @@ env:
   # -pedantic-errors is not equivalent to -Werror=pedantic and thus not implied by -Werror according to the GCC manual.
   WERROR_CFLAGS: -Werror -pedantic-errors
   MAKEFLAGS: -j4
-  BUILD: check
   ### secp256k1 config
   ECMULTWINDOW: auto
   ECMULTGENPRECISION: auto

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,18 +66,19 @@ task:
   name: "x86_64: Linux (Debian stable)"
   << : *LINUX_CONTAINER
   matrix: &ENV_MATRIX
-    - env: {WIDEMUL:  int64,  RECOVERY: yes}
-    - env: {WIDEMUL:  int64,                 ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes}
-    - env: {WIDEMUL: int128}
-    - env: {WIDEMUL: int128,  RECOVERY: yes,            EXPERIMENTAL: yes, SCHNORRSIG: yes}
-    - env: {WIDEMUL: int128,                 ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes}
-    - env: {WIDEMUL: int128,  ASM: x86_64}
-    - env: {                  RECOVERY: yes,            EXPERIMENTAL: yes, SCHNORRSIG: yes}
-    - env: {BUILD: distcheck, WITH_VALGRIND: no, CTIMETEST: no, BENCH: no}
-    - env: {CPPFLAGS: -DDETERMINISTIC}
-    - env: {CFLAGS: -O0, CTIMETEST: no}
-    - env: { ECMULTGENPRECISION: 2, ECMULTWINDOW: 2 }
-    - env: { ECMULTGENPRECISION: 8, ECMULTWINDOW: 4 }
+    # Enable all modules and test with all common configuration (WIDEMUL, ASM, some ECMULTWINDOW, some ECMULTGENPRECISION).
+    # Sneak in rare build options (CFLAGS: "-O0 -g", CTIMETEST: no, WITH_VALGRIND: no, BENCH: no, CPPFLAGS: -DDETERMINISTIC) at random positions.
+    - env: { WIDEMUL:  int64, RECOVERY: yes, ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes }
+    - env: { WIDEMUL:  int64, RECOVERY: yes, ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes, CFLAGS: "-O0 -g", CTIMETEST: no, WITH_VALGRIND: no }
+    - env: { WIDEMUL: int128, RECOVERY: yes, ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes }
+    - env: { WIDEMUL: int128, RECOVERY: yes, ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes, ASM: x86_64 }
+    - env: { WIDEMUL: int128, RECOVERY: yes, ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes, ASM: x86_64, ECMULTWINDOW: 4, ECMULTGENPRECISION: 2 }
+    - env: { WIDEMUL: int128, RECOVERY: yes, ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes,              ECMULTWINDOW: 8, ECMULTGENPRECISION: 8, CPPFLAGS: -DDETERMINISTIC }
+    - env: { WIDEMUL: int128, RECOVERY: yes, ECDH: yes, EXPERIMENTAL: yes, SCHNORRSIG: yes, CFLAGS: "-O0 -g", CTIMETEST: no, BENCH: no }
+    # No special settings, this is also useful to test autodetection
+    - env: { }
+    # Only non-experimental modules
+    - env: {                  RECOVERY: yes, ECDH: yes }
   matrix:
     - env:
         CC: gcc

--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -10,6 +10,7 @@ AC_MSG_RESULT([$has_64bit_asm])
 ])
 
 AC_DEFUN([SECP_VALGRIND_CHECK],[
+AC_MSG_CHECKING([for valgrind support])
 if test x"$has_valgrind" != x"yes"; then
   CPPFLAGS_TEMP="$CPPFLAGS"
   CPPFLAGS="$VALGRIND_CPPFLAGS $CPPFLAGS"
@@ -21,6 +22,7 @@ if test x"$has_valgrind" != x"yes"; then
     #endif
   ]])], [has_valgrind=yes; AC_DEFINE(HAVE_VALGRIND,1,[Define this symbol if valgrind is installed, and it supports the host platform])])
 fi
+AC_MSG_RESULT($has_valgrind)
 ])
 
 dnl SECP_TRY_APPEND_CFLAGS(flags, VAR)

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -5,6 +5,15 @@ set -x
 
 export LC_ALL=C
 
+# Start persistent wineserver if necessary.
+# This speeds up jobs with many invocations of wine (e.g., ./configure with MSVC) tremendously.
+case "$WRAPPER_CMD" in 
+    *wine*)
+        # This is apparently only reliable when we run a dummy command such as "hh.exe" afterwards.
+        wineserver -p && wine hh.exe
+        ;;
+esac
+
 env >> test_env.log
 
 $CC -v || true
@@ -63,6 +72,9 @@ then
     make clean-precomp
     make precomp
 fi
+
+# Shutdown wineserver again
+wineserver -k || true
 
 # Check that no repo files have been modified by the build.
 # (This fails for example if the precomp files need to be updated in the repo.)

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -9,6 +9,7 @@ env >> test_env.log
 
 $CC -v || true
 valgrind --version || true
+$WRAPPER_CMD --version || true
 
 ./autogen.sh
 

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -44,7 +44,7 @@ file .libs/* || true
 # This tells `make check` to wrap test invocations.
 export LOG_COMPILER="$WRAPPER_CMD"
 
-make "$BUILD"
+make check
 
 if [ "$BENCH" = "yes" ]
 then
@@ -65,6 +65,10 @@ if [ "$CTIMETEST" = "yes" ]
 then
     ./libtool --mode=execute valgrind --error-exitcode=42 ./valgrind_ctime_test > valgrind_ctime_test.log 2>&1
 fi
+
+# `distcheck` includes `check` but we don't want to run the `check` part again,
+# so we use a hack to make all tests immediately 77 (=SKIP).
+make distcheck LOG_COMPILER="sh -c 'exit 77'"
 
 # Rebuild precomputed files (if not cross-compiling).
 if [ -z "$HOST" ]

--- a/configure.ac
+++ b/configure.ac
@@ -35,9 +35,6 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 PKG_PROG_PKG_CONFIG
 
 AC_PROG_CC
-if test x"$ac_cv_prog_cc_c89" = x"no"; then
-  AC_MSG_ERROR([c89 compiler support required])
-fi
 AM_PROG_AS
 AM_PROG_AR
 

--- a/configure.ac
+++ b/configure.ac
@@ -86,23 +86,35 @@ esac
 #
 # TODO We should analogously not touch CPPFLAGS and LDFLAGS but currently there are no issues.
 AC_DEFUN([SECP_TRY_APPEND_DEFAULT_CFLAGS], [
-    # Try to append -Werror=unknown-warning-option to CFLAGS temporarily. Otherwise clang will
-    # not error out if it gets unknown warning flags and the checks here will always succeed
-    # no matter if clang knows the flag or not.
-    SECP_TRY_APPEND_DEFAULT_CFLAGS_saved_CFLAGS="$CFLAGS"
-    SECP_TRY_APPEND_CFLAGS([-Werror=unknown-warning-option], CFLAGS)
+    # GCC and compatible (incl. clang)
+    if test "x$GCC" = "xyes"; then
+      # Try to append -Werror=unknown-warning-option to CFLAGS temporarily. Otherwise clang will
+      # not error out if it gets unknown warning flags and the checks here will always succeed
+      # no matter if clang knows the flag or not.
+      SECP_TRY_APPEND_DEFAULT_CFLAGS_saved_CFLAGS="$CFLAGS"
+      SECP_TRY_APPEND_CFLAGS([-Werror=unknown-warning-option], CFLAGS)
 
-    SECP_TRY_APPEND_CFLAGS([-std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef], $1) # GCC >= 3.0, -Wlong-long is implied by -pedantic.
-    SECP_TRY_APPEND_CFLAGS([-Wno-overlength-strings], $1) # GCC >= 4.2, -Woverlength-strings is implied by -pedantic.
-    SECP_TRY_APPEND_CFLAGS([-Wall], $1) # GCC >= 2.95 and probably many other compilers
-    SECP_TRY_APPEND_CFLAGS([-Wno-unused-function], $1) # GCC >= 3.0, -Wunused-function is implied by -Wall.
-    SECP_TRY_APPEND_CFLAGS([-Wextra], $1) # GCC >= 3.4, this is the newer name of -W, which we don't use because older GCCs will warn about unused functions.
-    SECP_TRY_APPEND_CFLAGS([-Wcast-align], $1) # GCC >= 2.95
-    SECP_TRY_APPEND_CFLAGS([-Wcast-align=strict], $1) # GCC >= 8.0
-    SECP_TRY_APPEND_CFLAGS([-Wconditional-uninitialized], $1) # Clang >= 3.0 only
-    SECP_TRY_APPEND_CFLAGS([-fvisibility=hidden], $1) # GCC >= 4.0
+      SECP_TRY_APPEND_CFLAGS([-std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef], $1) # GCC >= 3.0, -Wlong-long is implied by -pedantic.
+      SECP_TRY_APPEND_CFLAGS([-Wno-overlength-strings], $1) # GCC >= 4.2, -Woverlength-strings is implied by -pedantic.
+      SECP_TRY_APPEND_CFLAGS([-Wall], $1) # GCC >= 2.95 and probably many other compilers
+      SECP_TRY_APPEND_CFLAGS([-Wno-unused-function], $1) # GCC >= 3.0, -Wunused-function is implied by -Wall.
+      SECP_TRY_APPEND_CFLAGS([-Wextra], $1) # GCC >= 3.4, this is the newer name of -W, which we don't use because older GCCs will warn about unused functions.
+      SECP_TRY_APPEND_CFLAGS([-Wcast-align], $1) # GCC >= 2.95
+      SECP_TRY_APPEND_CFLAGS([-Wcast-align=strict], $1) # GCC >= 8.0
+      SECP_TRY_APPEND_CFLAGS([-Wconditional-uninitialized], $1) # Clang >= 3.0 only
+      SECP_TRY_APPEND_CFLAGS([-fvisibility=hidden], $1) # GCC >= 4.0
 
-    CFLAGS="$SECP_TRY_APPEND_DEFAULT_CFLAGS_saved_CFLAGS"
+      CFLAGS="$SECP_TRY_APPEND_DEFAULT_CFLAGS_saved_CFLAGS"
+    fi
+
+    # MSVC
+    # Assume MSVC if we're building for Windows but not with GCC or compatible;
+    # libtool makes the same assumption internally.
+    # Note that "/opt" and "-opt" are equivalent for MSVC; we use "-opt" because "/opt" looks like a path.
+    if test x"$GCC" != x"yes" && test x"$build_windows" = x"yes"; then
+      SECP_TRY_APPEND_CFLAGS([-W2 -wd4146], $1) # Moderate warning level, disable warning C4146 "unary minus operator applied to unsigned type, result still unsigned"
+      SECP_TRY_APPEND_CFLAGS([-external:anglebrackets -external:W0], $1) # Suppress warnings from #include <...> files
+    fi
 ])
 SECP_TRY_APPEND_DEFAULT_CFLAGS(SECP_CFLAGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -32,13 +32,18 @@ AM_INIT_AUTOMAKE([1.11.2 foreign subdir-objects])
 # Make the compilation flags quiet unless V=1 is used.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-PKG_PROG_PKG_CONFIG
-
 AC_PROG_CC
 AM_PROG_AS
 AM_PROG_AR
 
+# Clear some cache variables as a workaround for a bug that appears due to a bad
+# interaction between AM_PROG_AR and LT_INIT when combining MSVC's archiver lib.exe.
+# https://debbugs.gnu.org/cgi/bugreport.cgi?bug=54421
+AS_UNSET(ac_cv_prog_AR)
+AS_UNSET(ac_cv_prog_ac_ct_AR)
 LT_INIT([win32-dll])
+
+PKG_PROG_PKG_CONFIG
 
 build_windows=no
 

--- a/src/bench.h
+++ b/src/bench.h
@@ -7,15 +7,31 @@
 #ifndef SECP256K1_BENCH_H
 #define SECP256K1_BENCH_H
 
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include "sys/time.h"
+
+#if (defined(_MSC_VER) && _MSC_VER >= 1900)
+#  include <time.h>
+#else
+#  include "sys/time.h"
+#endif
 
 static int64_t gettime_i64(void) {
+#if (defined(_MSC_VER) && _MSC_VER >= 1900)
+    /* C11 way to get wallclock time */
+    struct timespec tv;
+    if (!timespec_get(&tv, TIME_UTC)) {
+        fputs("timespec_get failed!", stderr);
+        exit(1);
+    }
+    return (int64_t)tv.tv_nsec / 1000 + (int64_t)tv.tv_sec * 1000000LL;
+#else
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (int64_t)tv.tv_usec + (int64_t)tv.tv_sec * 1000000LL;
+#endif
 }
 
 #define FP_EXP (6)

--- a/src/modules/schnorrsig/bench_impl.h
+++ b/src/modules/schnorrsig/bench_impl.h
@@ -91,10 +91,10 @@ void run_schnorrsig_bench(int iters, int argc, char** argv) {
         free((void *)data.msgs[i]);
         free((void *)data.sigs[i]);
     }
-    free(data.keypairs);
-    free(data.pk);
-    free(data.msgs);
-    free(data.sigs);
+    free((void *)data.keypairs);
+    free((void *)data.pk);
+    free((void *)data.msgs);
+    free((void *)data.sigs);
 
     secp256k1_context_destroy(data.ctx);
 }

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -4,6 +4,17 @@
  * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
  ***********************************************************************/
 
+/* This is a C project. It should not be compiled with a C++ compiler,
+ * and we error out if we detect one.
+ *
+ * We still want to be able to test the project with a C++ compiler
+ * because it is still good to know if this will lead to real trouble, so
+ * there is a possibility to override the check. But be warned that
+ * compiling with a C++ compiler is not supported. */
+#if defined(__cplusplus) && !defined(SECP256K1_CPLUSPLUS_TEST_OVERRIDE)
+#error Trying to compile a C project with a C++ compiler.
+#endif
+
 #define SECP256K1_BUILD
 
 #include "../include/secp256k1.h"


### PR DESCRIPTION
We should try to merge #995 before this PR to avoid conflicts.

This tries to get more coverage of "useful" configurations with fewer tasks. I think what I suggest here is good but on the other hand there's no real need to reduce the number of tasks right now, so please suggest additional configs if you think they're worth testing. Maybe we could add a `-UVERIFY` build? (Even nicer would be to run with and without VERIFY on the same seed and compare the results -- but that needs more work.)

This now always runs `make check` and then `make distcheck` but ensures that the latter skips the tests already run during `make check`.

I refrained from reducing the number of tasks on macOS further. Testing clang on macOS is useful because it's "Apple clang" and testing gcc is useful because it's gcc 9 (as opposed to gcc 10 on Linux).  Moreover, the changes in #1047 make macOS tasks quicker again. The annoying thing about these macOS tasks is not that they run too long, but just that there is more demand/scheduling pressure for macOS machines on Cirrus, so they often sit there for hours scheduled and waiting to be run. But there's nothing we can do about this.
