### PR TITLE
Use xoshiro256++ instead of RFC6979 for tests

### DIFF
--- a/src/modules/schnorrsig/tests_impl.h
+++ b/src/modules/schnorrsig/tests_impl.h
@@ -87,7 +87,7 @@ void run_nonce_function_bip340_tests(void) {
     CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, NULL, 0, NULL) == 0);
     CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, algo, algolen, NULL) == 1);
     /* Other algo is fine */
-    secp256k1_rfc6979_hmac_sha256_generate(&secp256k1_test_rng, algo, algolen);
+    secp256k1_testrand_bytes_test(algo, algolen);
     CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, algo, algolen, NULL) == 1);
 
     for (i = 0; i < count; i++) {

--- a/src/modules/schnorrsig/tests_impl.h
+++ b/src/modules/schnorrsig/tests_impl.h
@@ -795,18 +795,18 @@ void test_schnorrsig_sign_verify(void) {
         /* Flip a few bits in the signature and in the message and check that
          * verify and verify_batch (TODO) fail */
         size_t sig_idx = secp256k1_testrand_int(N_SIGS);
-        size_t byte_idx = secp256k1_testrand_int(32);
+        size_t byte_idx = secp256k1_testrand_bits(5);
         unsigned char xorbyte = secp256k1_testrand_int(254)+1;
         sig[sig_idx][byte_idx] ^= xorbyte;
         CHECK(!secp256k1_schnorrsig_verify(ctx, sig[sig_idx], msg[sig_idx], sizeof(msg[sig_idx]), &pk));
         sig[sig_idx][byte_idx] ^= xorbyte;
 
-        byte_idx = secp256k1_testrand_int(32);
+        byte_idx = secp256k1_testrand_bits(5);
         sig[sig_idx][32+byte_idx] ^= xorbyte;
         CHECK(!secp256k1_schnorrsig_verify(ctx, sig[sig_idx], msg[sig_idx], sizeof(msg[sig_idx]), &pk));
         sig[sig_idx][32+byte_idx] ^= xorbyte;
 
-        byte_idx = secp256k1_testrand_int(32);
+        byte_idx = secp256k1_testrand_bits(5);
         msg[sig_idx][byte_idx] ^= xorbyte;
         CHECK(!secp256k1_schnorrsig_verify(ctx, sig[sig_idx], msg[sig_idx], sizeof(msg[sig_idx]), &pk));
         msg[sig_idx][byte_idx] ^= xorbyte;

--- a/src/testrand.h
+++ b/src/testrand.h
@@ -17,11 +17,14 @@
 SECP256K1_INLINE static void secp256k1_testrand_seed(const unsigned char *seed16);
 
 /** Generate a pseudorandom number in the range [0..2**32-1]. */
-static uint32_t secp256k1_testrand32(void);
+SECP256K1_INLINE static uint32_t secp256k1_testrand32(void);
+
+/** Generate a pseudorandom number in the range [0..2**64-1]. */
+SECP256K1_INLINE static uint64_t secp256k1_testrand64(void);
 
 /** Generate a pseudorandom number in the range [0..2**bits-1]. Bits must be 1 or
  *  more. */
-static uint32_t secp256k1_testrand_bits(int bits);
+SECP256K1_INLINE static uint64_t secp256k1_testrand_bits(int bits);
 
 /** Generate a pseudorandom number in the range [0..range-1]. */
 static uint32_t secp256k1_testrand_int(uint32_t range);

--- a/src/testrand_impl.h
+++ b/src/testrand_impl.h
@@ -109,7 +109,7 @@ static void secp256k1_testrand256_test(unsigned char *b32) {
 }
 
 static void secp256k1_testrand_flip(unsigned char *b, size_t len) {
-    b[secp256k1_testrand_int(len)] ^= (1 << secp256k1_testrand_int(8));
+    b[secp256k1_testrand_int(len)] ^= (1 << secp256k1_testrand_bits(3));
 }
 
 static void secp256k1_testrand_init(const char* hexseed) {

--- a/src/testrand_impl.h
+++ b/src/testrand_impl.h
@@ -14,35 +14,62 @@
 #include "testrand.h"
 #include "hash.h"
 
-static secp256k1_rfc6979_hmac_sha256 secp256k1_test_rng;
-static uint32_t secp256k1_test_rng_precomputed[8];
-static int secp256k1_test_rng_precomputed_used = 8;
+static uint64_t secp256k1_test_state[4];
 static uint64_t secp256k1_test_rng_integer;
 static int secp256k1_test_rng_integer_bits_left = 0;
 
 SECP256K1_INLINE static void secp256k1_testrand_seed(const unsigned char *seed16) {
-    secp256k1_rfc6979_hmac_sha256_initialize(&secp256k1_test_rng, seed16, 16);
-}
+    static const unsigned char PREFIX[19] = "secp256k1 test init";
+    unsigned char out32[32];
+    secp256k1_sha256 hash;
+    int i;
 
-SECP256K1_INLINE static uint32_t secp256k1_testrand32(void) {
-    if (secp256k1_test_rng_precomputed_used == 8) {
-        secp256k1_rfc6979_hmac_sha256_generate(&secp256k1_test_rng, (unsigned char*)(&secp256k1_test_rng_precomputed[0]), sizeof(secp256k1_test_rng_precomputed));
-        secp256k1_test_rng_precomputed_used = 0;
+    /* Use SHA256(PREFIX || seed16) as initial state. */
+    secp256k1_sha256_initialize(&hash);
+    secp256k1_sha256_write(&hash, PREFIX, sizeof(PREFIX));
+    secp256k1_sha256_write(&hash, seed16, 16);
+    secp256k1_sha256_finalize(&hash, out32);
+    for (i = 0; i < 4; ++i) {
+        uint64_t s = 0;
+        int j;
+        for (j = 0; j < 8; ++j) s = (s << 8) | out32[8*i + j];
+        secp256k1_test_state[i] = s;
     }
-    return secp256k1_test_rng_precomputed[secp256k1_test_rng_precomputed_used++];
+    secp256k1_test_rng_integer_bits_left = 0;
 }
 
-static uint32_t secp256k1_testrand_bits(int bits) {
-    uint32_t ret;
+SECP256K1_INLINE static uint64_t rotl(const uint64_t x, int k) {
+    return (x << k) | (x >> (64 - k));
+}
+
+SECP256K1_INLINE static uint64_t secp256k1_testrand64(void) {
+    /* Test-only Xoshiro256++ RNG. See https://prng.di.unimi.it/ */
+    const uint64_t result = rotl(secp256k1_test_state[0] + secp256k1_test_state[3], 23) + secp256k1_test_state[0];
+    const uint64_t t = secp256k1_test_state[1] << 17;
+    secp256k1_test_state[2] ^= secp256k1_test_state[0];
+    secp256k1_test_state[3] ^= secp256k1_test_state[1];
+    secp256k1_test_state[1] ^= secp256k1_test_state[2];
+    secp256k1_test_state[0] ^= secp256k1_test_state[3];
+    secp256k1_test_state[2] ^= t;
+    secp256k1_test_state[3] = rotl(secp256k1_test_state[3], 45);
+    return result;
+}
+
+SECP256K1_INLINE static uint64_t secp256k1_testrand_bits(int bits) {
+    uint64_t ret;
     if (secp256k1_test_rng_integer_bits_left < bits) {
-        secp256k1_test_rng_integer |= (((uint64_t)secp256k1_testrand32()) << secp256k1_test_rng_integer_bits_left);
-        secp256k1_test_rng_integer_bits_left += 32;
+        secp256k1_test_rng_integer = secp256k1_testrand64();
+        secp256k1_test_rng_integer_bits_left = 64;
     }
     ret = secp256k1_test_rng_integer;
     secp256k1_test_rng_integer >>= bits;
     secp256k1_test_rng_integer_bits_left -= bits;
-    ret &= ((~((uint32_t)0)) >> (32 - bits));
+    ret &= ((~((uint64_t)0)) >> (64 - bits));
     return ret;
+}
+
+SECP256K1_INLINE static uint32_t secp256k1_testrand32(void) {
+    return secp256k1_testrand_bits(32);
 }
 
 static uint32_t secp256k1_testrand_int(uint32_t range) {
@@ -85,7 +112,19 @@ static uint32_t secp256k1_testrand_int(uint32_t range) {
 }
 
 static void secp256k1_testrand256(unsigned char *b32) {
-    secp256k1_rfc6979_hmac_sha256_generate(&secp256k1_test_rng, b32, 32);
+    int i;
+    for (i = 0; i < 4; ++i) {
+        uint64_t val = secp256k1_testrand64();
+        b32[0] = val;
+        b32[1] = val >> 8;
+        b32[2] = val >> 16;
+        b32[3] = val >> 24;
+        b32[4] = val >> 32;
+        b32[5] = val >> 40;
+        b32[6] = val >> 48;
+        b32[7] = val >> 56;
+        b32 += 8;
+    }
 }
 
 static void secp256k1_testrand_bytes_test(unsigned char *bytes, size_t len) {


### PR DESCRIPTION
Just some easy low-hanging fruit. It's complete overkill to use the RFC6979 RNG for our test randomness. Replace it with a modern non-cryptographic RNG with good properties. It's a few % speedup for me.

Given the internal naming of all these functions to be "testrand", I'm not concerned about the risk of someone using this for something that needs actual cryptographic randomness.