### PR TITLE
build: Replace use of deprecated autoconf macro AC_PROG_CC_C89

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,8 +38,7 @@ AC_PATH_TOOL(AR, ar)
 AC_PATH_TOOL(RANLIB, ranlib)
 AC_PATH_TOOL(STRIP, strip)
 
-AM_PROG_CC_C_O
-AC_PROG_CC_C89
+AC_PROG_CC
 if test x"$ac_cv_prog_cc_c89" = x"no"; then
   AC_MSG_ERROR([c89 compiler support required])
 fi


### PR DESCRIPTION
According to [autoconf 2.70](https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Obsolete-Macros.html) documentation, the `AC_PROG_CC_C89` is replaced by `AC_PROG_CC`, which defines the same variable `ac_cv_prog_cc_c89` under the same conditions.

Avoids the following message:
```
configure.ac:23: warning: The macro `AC_PROG_CC_C89' is obsolete.
```
I'm not sure when the behavior was introduced, but it goes back to at least [2.60](https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/C-Compiler.html#AC_005fPROG_005fCC).

