### PR TITLE
ci: Attempt to make macOS builds more reliable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,9 @@ task:
   ##   - rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
   ##
   brew_valgrind_pre_script:
-    - brew update
+    # Reinstall brew. We could do `brew update` instead but that often fails.
+    - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+    - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     - brew config
     - brew tap LouisBrunner/valgrind
     # Fetch valgrind source but don't build it yet.


### PR DESCRIPTION
The macOS CI tasks often error fail when doing `brew update` with
git fetch errors:
```
remote: fatal: packfile /data/repositories/b/nw/b6/07/5c/123272362/network.git/objects/pack/pack-2139bd07361b62a358e380a0e7d58ec35593d191.pack cannot be accessed
fatal: protocol error: bad pack header
Error: Fetching /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core failed!
```
Superficially this seems to be a problem on the GitHub server because
the message shows a "remote" error. But it seems we're the only one in
the world running into this specific issue when doing `brew update`, so
it's more likely that the something else is the culprit, and this error
message is just a symptom.

This commit replaces `brew update` with a complete reinstallation of
brew. This is essentially a shot in the dark but it's worth a try, and
I doubt it's significantly more expensive. If that won't work, we may
consider simply retrying `brew update` a few times.