### PR TITLE
 ci: Retry brew update a few times to avoid random failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,9 +135,7 @@ task:
   ##   - rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
   ##
   brew_valgrind_pre_script:
-    # Reinstall brew. We could do `brew update` instead but that often fails.
-    - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
-    - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    - brew update
     - brew config
     - brew tap LouisBrunner/valgrind
     # Fetch valgrind source but don't build it yet.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,8 @@ task:
   ##   - rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
   ##
   brew_valgrind_pre_script:
-    - brew update
+    # Retry a few times because this tends to fail randomly.
+    - for i in {1..5}; do brew update && break || sleep 15; done
     - brew config
     - brew tap LouisBrunner/valgrind
     # Fetch valgrind source but don't build it yet.


### PR DESCRIPTION
Apparently #1072 didn't work out. I should have done this here directly.

Core vendors a script for retrying (https://github.com/bitcoin/bitcoin/tree/master/ci/retry) but I think that's overkill for us.