### PR TITLE
configure: Use modern way to set AR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.*.html
 
 src/libsecp256k1-config.h
 src/libsecp256k1-config.h.in
+build-aux/ar-lib
 build-aux/config.guess
 build-aux/config.sub
 build-aux/depcomp

--- a/configure.ac
+++ b/configure.ac
@@ -25,24 +25,23 @@ AC_CANONICAL_HOST
 AH_TOP([#ifndef LIBSECP256K1_CONFIG_H])
 AH_TOP([#define LIBSECP256K1_CONFIG_H])
 AH_BOTTOM([#endif /*LIBSECP256K1_CONFIG_H*/])
-AM_INIT_AUTOMAKE([foreign subdir-objects])
 
-LT_INIT([win32-dll])
+# Require Automake 1.11.2 for AM_PROG_AR
+AM_INIT_AUTOMAKE([1.11.2 foreign subdir-objects])
 
 # Make the compilation flags quiet unless V=1 is used.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 PKG_PROG_PKG_CONFIG
 
-AC_PATH_TOOL(AR, ar)
-AC_PATH_TOOL(RANLIB, ranlib)
-AC_PATH_TOOL(STRIP, strip)
-
 AC_PROG_CC
 if test x"$ac_cv_prog_cc_c89" = x"no"; then
   AC_MSG_ERROR([c89 compiler support required])
 fi
 AM_PROG_AS
+AM_PROG_AR
+
+LT_INIT([win32-dll])
 
 build_windows=no
 


### PR DESCRIPTION
This uses AM_PROG_AR to discover ar, which is the recommended way to do
so. Among other advantages, it honors the AR environment variable (as
set from the outside). The macro has been around since automake 1.11.2
(Dec 2011).

This commit also removes code that discovers ranlib and strip. ranlib
has been obsolete for decades (ar does its task now automatically), and
anyway LT_INIT takes care of discovering it. The code we used to set
STRIP was last mentioned in the automake 1.5 manual. Since automake 1.6
(Mar 2002), strip is discovered automatically when necessary (look for
the *private* macro AM_PROG_INSTALL_STRIP in the automake manual).

Alternative to #1086.