### PR TITLE
configure: Remove redundant pkg-config code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,8 +32,6 @@ AM_INIT_AUTOMAKE([1.11.2 foreign subdir-objects])
 # Make the compilation flags quiet unless V=1 is used.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-PKG_PROG_PKG_CONFIG
-
 AC_PROG_CC
 if test x"$ac_cv_prog_cc_c89" = x"no"; then
   AC_MSG_ERROR([c89 compiler support required])
@@ -407,11 +405,6 @@ AM_CONDITIONAL([BUILD_WINDOWS], [test "$build_windows" = "yes"])
 AC_SUBST(LIB_VERSION_CURRENT, _LIB_VERSION_CURRENT)
 AC_SUBST(LIB_VERSION_REVISION, _LIB_VERSION_REVISION)
 AC_SUBST(LIB_VERSION_AGE, _LIB_VERSION_AGE)
-
-# Make sure nothing new is exported so that we don't break the cache.
-PKGCONFIG_PATH_TEMP="$PKG_CONFIG_PATH"
-unset PKG_CONFIG_PATH
-PKG_CONFIG_PATH="$PKGCONFIG_PATH_TEMP"
 
 AC_OUTPUT
 


### PR DESCRIPTION
This removes code that detects the pkg-config tool. We used this
back in the days when we had dependencies. ;) It can always be brought
back if we'll need it in the future.

Note that we still deliver a .pc file for this library, and there is
code in Makefile.am to install it. But this does not require the
pkg-config tool; only consumers of the .pc file will need it. This can
be verified by running `make install` (maybe after `mkdir /tmp/pre` and
`./configure --prefix=/tmp/pre` and checking that the .pc file is
installed correctly.