### PR TITLE
doc: Update README for --enable-dev-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ libsecp256k1 is built using autotools:
 Usage examples
 -----------
   Usage examples can be found in the [examples](examples) directory. To compile them you need to configure with `--enable-examples`.
-  For experimental modules, you will also need `--enable-experimental` as well as a flag for each individual module, e.g. `--enable-module-ecdh`.
+  For experimental modules, you will also need `--enable-dev-mode`.
   * [ECDSA example](examples/ecdsa.c)
   * [Schnorr Signatures example](examples/schnorr.c)
   * [Deriving a shared secret(ECDH) example](examples/ecdh.c)


### PR DESCRIPTION
Since #1079 the `--enable-dev-mode` flag turns on all experimental modules so update README to reflect this.