### PR TITLE
Fix the false positive of `SECP_64BIT_ASM_CHECK`

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -1,7 +1,7 @@
 dnl escape "$0x" below using the m4 quadrigaph @S|@, and escape it again with a \ for the shell.
 AC_DEFUN([SECP_64BIT_ASM_CHECK],[
 AC_MSG_CHECKING(for x86_64 assembly availability)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   #include <stdint.h>]],[[
   uint64_t a = 11, tmp;
   __asm__ __volatile__("movq \@S|@0x100000000,%1; mulq %%rsi" : "+a"(a) : "S"(tmp) : "cc", "%rdx");


### PR DESCRIPTION
I'm trying to compile this project for RISC-V architecture, and I encountered errors:
```
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%r15' in 'asm'
   28 | __asm__ __volatile__(
      | ^
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%r14' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%r13' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%r12' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%r11' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%r10' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%r9' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%r8' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%rdx' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%rcx' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: unknown register name '%rax' in 'asm'
src/field_5x52_asm_impl.h:28:1: error: output number 0 not directly addressable
src/field_5x52_asm_impl.h: In function 'secp256k1_fe_sqr':
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%r15' in 'asm'
  298 | __asm__ __volatile__(
      | ^
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%r14' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%r13' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%r12' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%r11' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%r10' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%r9' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%r8' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%rdx' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%rcx' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%rbx' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: unknown register name '%rax' in 'asm'
src/field_5x52_asm_impl.h:298:1: error: output number 0 not directly addressable
```

After further investigation I found that for RISC-V, macro `USE_ASM_X86_64` was defined unexpectedly, and `checking for x86_64 assembly availability... yes` appeared in the compilation log file, which means `SECP_64BIT_ASM_CHECK` was not working as expected.

For unknown reasons, `AC_COMPILE_IFELSE` does not check if `__asm__` can be compiled, and an example can verify this point:
```m4
AC_DEFUN([SECP_64BIT_ASM_CHECK],[
AC_MSG_CHECKING(for x86_64 assembly availability)
AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
  #include <stdint.h>]],[[
  __asm__ __volatile__("this is obviously wrong");
  ]])],[has_64bit_asm=yes],[has_64bit_asm=no])
AC_MSG_RESULT([$has_64bit_asm])
])
```

It always gives results: `checking for x86_64 assembly availability... yes`

After testing, replacing `AC_COMPILE_IFELSE` with `AC_LINK_IFELSE` can correctly check if `__asm__` can be compiled and make the project able to compile for RISC-V.
