### PR TITLE
Don't export symbols in static libraries

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -141,9 +141,13 @@ typedef int (*secp256k1_nonce_function)(
 # define SECP256K1_NO_BUILD
 #endif
 
+/** At secp256k1 build-time DLL_EXPORT is defined when building objects destined
+ *  for a shared library, but not for those intended for static libraries.
+ */
+
 #ifndef SECP256K1_API
 # if defined(_WIN32)
-#  ifdef SECP256K1_BUILD
+#  if defined(SECP256K1_BUILD) && defined(DLL_EXPORT)
 #   define SECP256K1_API __declspec(dllexport)
 #  else
 #   define SECP256K1_API


### PR DESCRIPTION
For context, Bitcoin Core has recently merged [libbitcoin-kernel](https://github.com/bitcoin/bitcoin/pull/24322), a small library that intends to eventually minimally encompass Core's validation engine. This kernel lib includes a static libsecp256k1. Without this change, because libsecp256k1.a ends up with exported symbols, we end up with libsecp256k1 symbols exported by our libbitcoin-kernel library (which causes unrelated problems not worth getting into here).

libtool takes care of building both object versions, and it automatically builds objects for shared libs with -DDLL_EXPORT. We just need to opt-in to its functionality.

I can't imagine this having any negative impact on any current statically-linking applications, if anything they'll just be a tiny bit smaller because they can now strip unused symbols.