### PR TITLE
Cross tests with libecc

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -6947,7 +6947,7 @@ void test_libecc_sign_secp256k1_verify(void) {
     ec_pub_key_export_to_aff_buf((const ec_pub_key *)&key_pair.pub_key,
                                  pubkey_buf + 1,
                                  pubkey_len - 1);
-    pubkey_buf[0] = 0x04; // libecc doesn't prepend a header
+    pubkey_buf[0] = 0x04; // libecc does not prepend a header
 
     /* generate random message */
     secp256k1_scalar msg;
@@ -6982,7 +6982,7 @@ void test_libecc_sign_secp256k1_verify(void) {
 
     secp256k1_ecdsa_signature sig;
     CHECK(secp256k1_ecdsa_signature_parse_compact(ctx, &sig, sig_buf) == 1);
-    secp256k1_ecdsa_signature_normalize(ctx, &sig, &sig); // libecc doesn't enforce lower half S
+    secp256k1_ecdsa_signature_normalize(ctx, &sig, &sig); // libecc does not enforce lower half S
 
     unsigned char to_verify[32];
     secp256k1_sha256 sha;

--- a/src/tests.c
+++ b/src/tests.c
@@ -6862,7 +6862,6 @@ void run_ecdsa_edge_cases(void) {
 
 #ifdef ENABLE_LIBECC_TESTS
 void test_secp256k1_sign_libecc_verify(void){
-    printf("In libecc test\n");
     /* generate public private key pair */
     secp256k1_scalar key;
     unsigned char privkey_buf[32];
@@ -6910,9 +6909,8 @@ void test_secp256k1_sign_libecc_verify(void){
     const ec_sig_mapping *sig_mapping;
     CHECK(get_sig_by_name("ECDSA", &sig_mapping) == 0);
 
-    pubkey_buf += 1; // this is needed because libecc only supports uncompressed points
-    pubkey_len -= 1; // and does not recoginze B0
-
+    // offsetting pubkey_buf is needed because libecc only supports uncompressed points
+    // and does not recognize B0 = 04
     ec_pub_key ec_pubkey;
     CHECK(ec_pub_key_import_from_aff_buf(&ec_pubkey, (const ec_params *)&params,
                                          pubkey_buf + 1, pubkey_len - 1,


### PR DESCRIPTION
See #1108 

TODO:

- [x] Try the test `test_secp256k1_sign_libecc_verify()`. (I still need to figure out how to try it without the whole ci overhead)
- [x] Write a test to sign with `libecc` and verify with `libsecp256k1`
- [x] Perform a byte-by-byte comparison
- [ ] Add to ci properly