### PR TITLE
`_scratch_destroy`: move `VERIFY_CHECK` after invalid scrach space check

### DIFF
--- a/src/scratch_impl.h
+++ b/src/scratch_impl.h
@@ -25,11 +25,11 @@ static secp256k1_scratch* secp256k1_scratch_create(const secp256k1_callback* err
 
 static void secp256k1_scratch_destroy(const secp256k1_callback* error_callback, secp256k1_scratch* scratch) {
     if (scratch != NULL) {
-        VERIFY_CHECK(scratch->alloc_size == 0); /* all checkpoints should be applied */
         if (secp256k1_memcmp_var(scratch->magic, "scratch", 8) != 0) {
             secp256k1_callback_call(error_callback, "invalid scratch space");
             return;
         }
+        VERIFY_CHECK(scratch->alloc_size == 0); /* all checkpoints should be applied */
         memset(scratch->magic, 0, sizeof(scratch->magic));
         free(scratch);
     }


### PR DESCRIPTION
If we pass an invalid scratch pointer to `secp256k1_scratch_destroy`, the `VERIFY_CHECK` will probably fail, and libsecp will crash with the message
```bash
src/scratch_impl.h:28: test condition failed: scratch->alloc_size == 0
```

If `VERIFY_CHECK` after the invalid scratch space check, libsecp will call the error callback function with the "invalid scratch space" message instead.