### PR TITLE
build: Fix #include "..." paths to get rid of further -I arguments

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,7 +87,7 @@ endif
 endif
 
 libsecp256k1_la_SOURCES = src/secp256k1.c
-libsecp256k1_la_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src $(SECP_INCLUDES)
+libsecp256k1_la_CPPFLAGS = $(SECP_INCLUDES)
 libsecp256k1_la_LIBADD = $(SECP_LIBS) $(COMMON_LIB) $(PRECOMPUTED_LIB)
 libsecp256k1_la_LDFLAGS = -no-undefined -version-info $(LIB_VERSION_CURRENT):$(LIB_VERSION_REVISION):$(LIB_VERSION_AGE)
 
@@ -112,7 +112,7 @@ TESTS =
 if USE_TESTS
 noinst_PROGRAMS += tests
 tests_SOURCES = src/tests.c
-tests_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/include $(SECP_INCLUDES) $(SECP_TEST_INCLUDES)
+tests_CPPFLAGS = $(SECP_INCLUDES) $(SECP_TEST_INCLUDES)
 if VALGRIND_ENABLED
 tests_CPPFLAGS += -DVALGRIND
 noinst_PROGRAMS += valgrind_ctime_test

--- a/src/modules/ecdh/bench_impl.h
+++ b/src/modules/ecdh/bench_impl.h
@@ -7,7 +7,7 @@
 #ifndef SECP256K1_MODULE_ECDH_BENCH_H
 #define SECP256K1_MODULE_ECDH_BENCH_H
 
-#include "../include/secp256k1_ecdh.h"
+#include "../../../include/secp256k1_ecdh.h"
 
 typedef struct {
     secp256k1_context *ctx;

--- a/src/modules/extrakeys/tests_exhaustive_impl.h
+++ b/src/modules/extrakeys/tests_exhaustive_impl.h
@@ -7,8 +7,8 @@
 #ifndef SECP256K1_MODULE_EXTRAKEYS_TESTS_EXHAUSTIVE_H
 #define SECP256K1_MODULE_EXTRAKEYS_TESTS_EXHAUSTIVE_H
 
-#include "src/modules/extrakeys/main_impl.h"
 #include "../../../include/secp256k1_extrakeys.h"
+#include "main_impl.h"
 
 static void test_exhaustive_extrakeys(const secp256k1_context *ctx, const secp256k1_ge* group) {
     secp256k1_keypair keypair[EXHAUSTIVE_TEST_ORDER - 1];

--- a/src/modules/recovery/bench_impl.h
+++ b/src/modules/recovery/bench_impl.h
@@ -7,7 +7,7 @@
 #ifndef SECP256K1_MODULE_RECOVERY_BENCH_H
 #define SECP256K1_MODULE_RECOVERY_BENCH_H
 
-#include "../include/secp256k1_recovery.h"
+#include "../../../include/secp256k1_recovery.h"
 
 typedef struct {
     secp256k1_context *ctx;

--- a/src/modules/recovery/tests_exhaustive_impl.h
+++ b/src/modules/recovery/tests_exhaustive_impl.h
@@ -7,7 +7,7 @@
 #ifndef SECP256K1_MODULE_RECOVERY_EXHAUSTIVE_TESTS_H
 #define SECP256K1_MODULE_RECOVERY_EXHAUSTIVE_TESTS_H
 
-#include "src/modules/recovery/main_impl.h"
+#include "main_impl.h"
 #include "../../../include/secp256k1_recovery.h"
 
 void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1_ge *group) {

--- a/src/modules/schnorrsig/tests_exhaustive_impl.h
+++ b/src/modules/schnorrsig/tests_exhaustive_impl.h
@@ -8,7 +8,7 @@
 #define SECP256K1_MODULE_SCHNORRSIG_TESTS_EXHAUSTIVE_H
 
 #include "../../../include/secp256k1_schnorrsig.h"
-#include "src/modules/schnorrsig/main_impl.h"
+#include "main_impl.h"
 
 static const unsigned char invalid_pubkey_bytes[][32] = {
     /* 0 */

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -342,15 +342,15 @@ void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_ge *grou
 }
 
 #ifdef ENABLE_MODULE_RECOVERY
-#include "src/modules/recovery/tests_exhaustive_impl.h"
+#include "modules/recovery/tests_exhaustive_impl.h"
 #endif
 
 #ifdef ENABLE_MODULE_EXTRAKEYS
-#include "src/modules/extrakeys/tests_exhaustive_impl.h"
+#include "modules/extrakeys/tests_exhaustive_impl.h"
 #endif
 
 #ifdef ENABLE_MODULE_SCHNORRSIG
-#include "src/modules/schnorrsig/tests_exhaustive_impl.h"
+#include "modules/schnorrsig/tests_exhaustive_impl.h"
 #endif
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This simplifies building without a build system.

This is in line with #925; the paths fixed here were either forgotten
there or only introduced later. This commit also makes the Makefile
stricter so that further "wrong" #include paths will lead to build
errors even in autotools builds.

This belongs to #929.