### PR TITLE
build: Link `bench` binary statically

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -100,6 +100,7 @@ if USE_BENCHMARK
 noinst_PROGRAMS += bench bench_internal bench_ecmult
 bench_SOURCES = src/bench.c
 bench_LDADD = libsecp256k1.la $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB)
+bench_LDFLAGS = -static
 bench_internal_SOURCES = src/bench_internal.c
 bench_internal_LDADD = $(SECP_LIBS) $(COMMON_LIB) $(PRECOMPUTED_LIB)
 bench_internal_CPPFLAGS = $(SECP_INCLUDES)


### PR DESCRIPTION
While testing bitcoin-core/secp256k1#1022 I've [noticed](https://github.com/bitcoin-core/secp256k1/pull/1022#issuecomment-986048847) a linker error when cross compiling with `--host=x86_64-w64-mingw32` in particular circumstances.

I cannot recall my building environment then, but currently, on Ubuntu 22.04 with gcc 11.2, this error raises unconditionally:
```
$ ./autogen.sh && ./configure --host=x86_64-w64-mingw32 && make clean
$ make
make  all-am
make[1]: Entering directory '/home/hebasto/git/secp256k1'
  CC       src/bench.o
  CC       src/libsecp256k1_la-secp256k1.lo
  CC       src/libsecp256k1_precomputed_la-precomputed_ecmult.lo
  CC       src/libsecp256k1_precomputed_la-precomputed_ecmult_gen.lo
  CCLD     libsecp256k1_precomputed.la
  CCLD     libsecp256k1.la
  CCLD     bench.exe
libtool:   error: Could not determine the host path corresponding to
libtool:   error:   '/home/hebasto/git/secp256k1/.libs'
libtool:   error: Continuing, but uninstalled executables may not work.
libtool:   error: Could not determine the host path corresponding to
libtool:   error:   '/home/hebasto/git/secp256k1/.libs:/usr/local/lib:/usr/local/bin'
libtool:   error: Continuing, but uninstalled executables may not work.
  CC       src/bench_internal-bench_internal.o
  CCLD     bench_internal.exe
  CC       src/bench_ecmult-bench_ecmult.o
  CCLD     bench_ecmult.exe
  CC       src/tests-tests.o
  CCLD     tests.exe
  CC       src/exhaustive_tests-tests_exhaustive.o
  CCLD     exhaustive_tests.exe
make[1]: Leaving directory '/home/hebasto/git/secp256k1'
```

This PR prevents linker errors when cross compiling with `--host=x86_64-w64-mingw32`.

Please note that the same linker flag is used for all of the tests and examples. Moreover, it was used in the initial Autotools commit:https://github.com/bitcoin-core/secp256k1/blob/78cd96b15153e209cf4829a511f9efdfdcf7e4d0/Makefile.am#L45