### PR TITLE
ecmult_gen: Skip RNG when creating blinding if no seed is available

### DIFF
--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -97,12 +97,11 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
         return;
     }
     /* The prior blinding value (if not reset) is chained forward by including it in the hash. */
-    secp256k1_scalar_get_b32(nonce32, &ctx->blind);
+    secp256k1_scalar_get_b32(keydata, &ctx->blind);
     /** Using a CSPRNG allows a failure free interface, avoids needing large amounts of random data,
      *   and guards against weak or adversarial seeds.  This is a simpler and safer interface than
      *   asking the caller for blinding values directly and expecting them to retry on failure.
      */
-    memcpy(keydata, nonce32, 32);
     VERIFY_CHECK(seed32 != NULL);
     memcpy(keydata + 32, seed32, 32);
     secp256k1_rfc6979_hmac_sha256_initialize(&rng, keydata, 64);

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -111,7 +111,8 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
     overflow = !secp256k1_fe_set_b32(&s, nonce32);
     overflow |= secp256k1_fe_is_zero(&s);
     secp256k1_fe_cmov(&s, &secp256k1_fe_one, overflow);
-    /* Randomize the projection to defend against multiplier sidechannels. */
+    /* Randomize the projection to defend against multiplier sidechannels.
+       Do this before our own call to secp256k1_ecmult_gen below. */
     secp256k1_gej_rescale(&ctx->initial, &s);
     secp256k1_fe_clear(&s);
     secp256k1_rfc6979_hmac_sha256_generate(&rng, nonce32, 32);
@@ -120,6 +121,7 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
     secp256k1_scalar_cmov(&b, &secp256k1_scalar_one, secp256k1_scalar_is_zero(&b));
     secp256k1_rfc6979_hmac_sha256_finalize(&rng);
     memset(nonce32, 0, 32);
+    /* The random projection in ctx->initial ensures that gb will have a random projection. */
     secp256k1_ecmult_gen(ctx, &gb, &b);
     secp256k1_scalar_negate(&b, &b);
     ctx->blind = b;


### PR DESCRIPTION
Running the RNG is pointless if no seed is available because the key
will be fixed. The computation just wastes time.

Previously, users could avoid this computation at least by asking for
a context without signing capabilities. But since 3b0c218 we always
build an ecmult_gen context, ignoring the context flags. Moreover,
users could never avoid this pointless computation when asking for
the creation of a signing context.

This fixes one item in #1065.