### PR TITLE
configure: Remove pkgconfig macros again (reintroduced by mismerge)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,8 +43,6 @@ AS_UNSET(ac_cv_prog_AR)
 AS_UNSET(ac_cv_prog_ac_ct_AR)
 LT_INIT([win32-dll])
 
-PKG_PROG_PKG_CONFIG
-
 build_windows=no
 
 case $host_os in


### PR DESCRIPTION
We had removed `PKG_PROG_PKG_CONFIG` in 21b2ebaf74222017f85123deb6f30a33c7678513
(#1090). But then then the not rebased (!) merge of 2be6ba0fedd0d2d62ba6f346d7ced7abde0d66e4
(#1084) brought that macro back at another location, without git
complaining about a conflict.

Fixes #1127.