### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ To create a CSV file for the benchmark result :
 
     $ ./bench_name | sed '2d;s/ \{1,\}//g' > bench_name.csv
 
+Building secp256k1 - Using vcpkg
+------------
+
+You can download and install secp256k1 using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install secp256k1
+
+The secp256k1 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.    
+
 Reporting a vulnerability
 ------------
 


### PR DESCRIPTION
secp256k1 is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for secp256k1 and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build secp256k1, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/secp256k1/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)
