### PR TITLE
Encapsulate `secp256k1_xonly_pubkey_load` for external access

### DIFF
--- a/include/secp256k1_extrakeys.h
+++ b/include/secp256k1_extrakeys.h
@@ -64,6 +64,25 @@ SECP256K1_API int secp256k1_xonly_pubkey_serialize(
     const secp256k1_xonly_pubkey* pubkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
+/**
+ * Convert a xonly_pubkey object to a pubkey object.
+ * This resulting pubkey will show the prefix 02 in the compressed format (even y).
+ *
+ * Returns: 0 if the arguments are invalid or the resulting public key would be
+ *           invalid. 1 otherwise.
+ *
+ * Args: ctx:          a secp256k1 context object.
+ * Out:  pubkey:       pointer to the created public key
+ * In:   xonly_pubkey: a pointer to a secp256k1_xonly_pubkey containing an initialized public key.
+ *
+ * @return SECP256K1_API
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_xonly_pubkey_to_pubkey(
+    const secp256k1_context* ctx,
+    secp256k1_pubkey *pubkey,
+    const secp256k1_xonly_pubkey* xonly_pubkey
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+
 /** Compare two x-only public keys using lexicographic order
  *
  *  Returns: <0 if the first public key is less than the second

--- a/src/modules/extrakeys/main_impl.h
+++ b/src/modules/extrakeys/main_impl.h
@@ -55,6 +55,22 @@ int secp256k1_xonly_pubkey_serialize(const secp256k1_context* ctx, unsigned char
     return 1;
 }
 
+int secp256k1_xonly_pubkey_to_pubkey(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const secp256k1_xonly_pubkey* xonly_pubkey) {
+    secp256k1_ge pk;
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(pubkey != NULL);
+    ARG_CHECK(xonly_pubkey != NULL);
+    memset(pubkey, 0, sizeof(*pubkey));
+
+    if (!secp256k1_xonly_pubkey_load(ctx, &pk, xonly_pubkey)) {
+        return 0;
+    }
+
+    secp256k1_pubkey_save(pubkey, &pk);
+    return 1;
+}
+
 int secp256k1_xonly_pubkey_cmp(const secp256k1_context* ctx, const secp256k1_xonly_pubkey* pk0, const secp256k1_xonly_pubkey* pk1) {
     unsigned char out[2][32];
     const secp256k1_xonly_pubkey* pk[2];


### PR DESCRIPTION
Apparently there is no way to sum public keys if they are x-only, even if the user knows how to handle the lost prefix byte.

I noticed that in the code currently, the `secp256k1_xonly_pubkey_load` function is already used to do this conversion safely, but it is not exposed to be used.

This PR creates a wrapper function for `secp256k1_xonly_pubkey_load` and adds in the function description the warning that the conversion always generates the public key with even y.