### PR TITLE
Revert "Add test logs to gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ libtool
 *.lo
 *.o
 *~
-*.log
-*.trs
 
 coverage/
 coverage.html


### PR DESCRIPTION
The #748 had some kind of a hidden merge conflict with the #806, which was merged earlier. Both PRs added the same lines into the `.gitignore` file:
```
*.log
*.trs
```
To de-duplicate these lines, it seems the easiest way is to revert the smallest commit.