### PR TITLE
ci: print env to allow reproducing the job outside of CI

### DIFF
--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -5,6 +5,26 @@ set -x
 
 export LC_ALL=C
 
+# Print relevant CI environment to allow reproducing the job outside of CI.
+print_environment() {
+    # Turn off -x because it messes up the output
+    set +x
+    # There are many ways to print variable names and their content. This one
+    # does not rely on bash.
+    for i in WERROR_CFLAGS MAKEFLAGS BUILD \
+            ECMULTWINDOW ECMULTGENPRECISION ASM WIDEMUL WITH_VALGRIND EXTRAFLAGS \
+            EXPERIMENTAL ECDH RECOVERY SCHNORRSIG \
+            SECP256K1_TEST_ITERS BENCH SECP256K1_BENCH_ITERS CTIMETEST\
+            EXAMPLES \
+            WRAPPER_CMD CC AR NM HOST
+    do
+        eval 'printf "%s %s " "$i=\"${'"$i"'}\""'
+    done
+    echo "$0"
+    set -x
+}
+print_environment
+
 # Start persistent wineserver if necessary.
 # This speeds up jobs with many invocations of wine (e.g., ./configure with MSVC) tremendously.
 case "$WRAPPER_CMD" in


### PR DESCRIPTION
Example output:

```
WERROR_CFLAGS="-Werror -pedantic-errors"  MAKEFLAGS="-j4"  BUILD="check"  ECMULTWINDOW="auto"  ECMULTGENPRECISION="auto"  ASM="no"  WIDEMUL="int64"  WITH_VALGRIND="no"  EXTRAFLAGS=""  EXPERIMENTAL="no"  ECDH="no"  RECOVERY="yes"  SCHNORRSIG="no"  SECP256K1_TEST_ITERS=""  BENCH="yes"  SECP256K1_BENCH_ITERS="2"  CTIMETEST="yes"  EXAMPLES="yes"  WRAPPER_CMD=""  CC="gcc"  AR=""  NM=""  HOST=""  ./ci/cirrus.sh
```