### PR TITLE
Conditionally include `stdio.h` and `stdlib.h`

### DIFF
--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -116,34 +116,42 @@ secp256k1_context* secp256k1_context_preallocated_create(void* prealloc, unsigne
 }
 
 secp256k1_context* secp256k1_context_create(unsigned int flags) {
+    secp256k1_context* ctx = NULL;
+
+#ifndef PREALLOC_INTERFACE_ONLY
     size_t const prealloc_size = secp256k1_context_preallocated_size(flags);
-    secp256k1_context* ctx = (secp256k1_context*)checked_malloc(&default_error_callback, prealloc_size);
+    ctx = (secp256k1_context*)checked_malloc(&default_error_callback, prealloc_size);
     if (EXPECT(secp256k1_context_preallocated_create(ctx, flags) == NULL, 0)) {
         free(ctx);
         return NULL;
     }
-
+#endif
     return ctx;
 }
 
 secp256k1_context* secp256k1_context_preallocated_clone(const secp256k1_context* ctx, void* prealloc) {
-    secp256k1_context* ret;
+    secp256k1_context* ret = NULL;
+
+#ifndef PREALLOC_INTERFACE_ONLY
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(prealloc != NULL);
 
     ret = (secp256k1_context*)prealloc;
     *ret = *ctx;
+#endif
     return ret;
 }
 
 secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
-    secp256k1_context* ret;
+    secp256k1_context* ret = NULL;
     size_t prealloc_size;
 
+#ifndef PREALLOC_INTERFACE_ONLY
     VERIFY_CHECK(ctx != NULL);
     prealloc_size = secp256k1_context_preallocated_clone_size(ctx);
     ret = (secp256k1_context*)checked_malloc(&ctx->error_callback, prealloc_size);
     ret = secp256k1_context_preallocated_clone(ctx, ret);
+#endif
     return ret;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -13,8 +13,11 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <limits.h>
+
+#if defined(VERIFY) || !defined(USE_EXTERNAL_DEFAULT_CALLBACKS)
+#include <stdio.h>
+#endif
 
 #define STR_(x) #x
 #define STR(x) STR_(x)

--- a/src/util.h
+++ b/src/util.h
@@ -11,12 +11,15 @@
 #include "libsecp256k1-config.h"
 #endif
 
-#include <stdlib.h>
 #include <stdint.h>
 #include <limits.h>
 
 #if defined(VERIFY) || !defined(USE_EXTERNAL_DEFAULT_CALLBACKS)
 #include <stdio.h>
+#endif
+
+#ifndef PREALLOC_INTERFACE_ONLY
+#include <stdlib.h>
 #endif
 
 #define STR_(x) #x


### PR DESCRIPTION
Currently in order to use `secp256k1` in WASM builds one must patch into the build system empty header files for `stdlib.h` and `stdio.h` [0].

- Patch 1: Removes the unconditional include of `stdio.h` based on the presence of `USE_EXTERNAL_DEFAULT_CALLBACKS` and `VERIFY`.
- Patch 2: Introduces `PREALLOC_INTERFACE_ONLY` and ifndef guards any calls to malloc and friends as well as the include of `stdio.h`.

Works towards fixing: #1095  

1095 does not mention `string.h` but it is a problem as well. I cannot work out how to resolve it so attempting to push this in without it. Happy to extend this further if anyone has any ideas.

### Notes on testing

I could not work out how to test this in `rust-secp256k1` so the I have not proved that this PR removes the requirement to include empty headers described above.

[0] - https://github.com/rust-bitcoin/rust-secp256k1/blob/master/secp256k1-sys/depend/secp256k1.c.patch