### PR TITLE
Remove usage of CHECK from non-test file

### DIFF
--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -200,9 +200,15 @@ static int secp256k1_ecmult_wnaf(int *wnaf, int len, const secp256k1_scalar *a, 
         bit += now;
     }
 #ifdef VERIFY
-    CHECK(carry == 0);
-    while (bit < 256) {
-        CHECK(secp256k1_scalar_get_bits(&s, bit++, 1) == 0);
+    {
+        int verify_bit = bit;
+
+        VERIFY_CHECK(carry == 0);
+
+        while (verify_bit < 256) {
+            VERIFY_CHECK(secp256k1_scalar_get_bits(&s, verify_bit, 1) == 0);
+            verify_bit++;
+        }
     }
 #endif
     return last_set_bit + 1;


### PR DESCRIPTION
Currently CHECK is used only in test and bench mark files except for one usage in `ecmult_impl.h`.

We would like to move the definition of CHECK out of `util.h` so that `util.h` no longer has a hard dependency on `stdio.h`.

Done as part of an effort to allow secp256k1 to be compiled to WASM as part of `rust-secp256k1`.

### Note to reviewers

Please review carefully, I don't actually know if this patch is correct. Done while working on #1095. I'm happy to make any changes both in concept and execution - I'm super rusty at C programming.

cc real-or-random 