### PR TITLE
Add MSan CI jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -340,6 +340,32 @@ task:
     - ./ci/cirrus.sh
   << : *CAT_LOGS
 
+# Memory sanitizers
+task:
+  << : *LINUX_CONTAINER
+  name: "MSan"
+  env:
+    ECDH: yes
+    RECOVERY: yes
+    SCHNORRSIG: yes
+    CTIMETEST: no
+    CC: clang
+    SECP256K1_TEST_ITERS: 32
+    ASM: no
+  container:
+    memory: 2G
+  matrix:
+    - env:
+        CFLAGS: "-fsanitize=memory -g"
+    - env:
+        ECMULTGENPRECISION: 2
+        ECMULTWINDOW: 2
+        CFLAGS: "-fsanitize=memory -g -O3"
+  << : *MERGE_BASE
+  test_script:
+    - ./ci/cirrus.sh
+  << : *CAT_LOGS
+
 task:
   name: "C++ -fpermissive (entire project)"
   << : *LINUX_CONTAINER


### PR DESCRIPTION
Add an MSan based sanitizer job, for a number of reasons:
* Does something memcheck (valgrind) like, but can also run on macOS (even post #1152), which can be added as a follow-up.
* We could extend to ctime testing to work on this instead (meaning against ctime testing, with some limitations, can be re-enabled on macOS post #1152).
