### PR TITLE
Add a secp256k1_i128_to_u64 function.

### DIFF
--- a/src/int128.h
+++ b/src/int128.h
@@ -66,7 +66,12 @@ static SECP256K1_INLINE void secp256k1_i128_det(secp256k1_int128 *r, int64_t a, 
  */
 static SECP256K1_INLINE void secp256k1_i128_rshift(secp256k1_int128 *r, unsigned int b);
 
-/* Return the low 64-bits of a 128-bit value interpreted as an signed 64-bit value. */
+/* Return the input value modulo 2^64. */
+static SECP256K1_INLINE uint64_t secp256k1_i128_to_u64(const secp256k1_int128 *a);
+
+/* Return the value as a signed 64-bit value.
+ * Requires the input to be between INT64_MIN and INT64_MAX.
+ */
 static SECP256K1_INLINE int64_t secp256k1_i128_to_i64(const secp256k1_int128 *a);
 
 /* Write a signed 64-bit value to r. */

--- a/src/int128_native_impl.h
+++ b/src/int128_native_impl.h
@@ -67,7 +67,12 @@ static SECP256K1_INLINE void secp256k1_i128_rshift(secp256k1_int128 *r, unsigned
    *r >>= n;
 }
 
+static SECP256K1_INLINE uint64_t secp256k1_i128_to_u64(const secp256k1_int128 *a) {
+   return (uint64_t)*a;
+}
+
 static SECP256K1_INLINE int64_t secp256k1_i128_to_i64(const secp256k1_int128 *a) {
+   VERIFY_CHECK(INT64_MIN <= *a && *a <= INT64_MAX);
    return *a;
 }
 

--- a/src/int128_struct_impl.h
+++ b/src/int128_struct_impl.h
@@ -170,8 +170,14 @@ static SECP256K1_INLINE void secp256k1_i128_rshift(secp256k1_int128 *r, unsigned
    }
 }
 
+static SECP256K1_INLINE uint64_t secp256k1_i128_to_u64(const secp256k1_int128 *a) {
+   return a->lo;
+}
+
 static SECP256K1_INLINE int64_t secp256k1_i128_to_i64(const secp256k1_int128 *a) {
-   return (int64_t)a->lo;
+   /* Verify that a represents a 64 bit signed value by checking that the high bits are a sign extension of the low bits. */
+   VERIFY_CHECK(a->hi == -(a->lo >> 63));
+   return (int64_t)secp256k1_i128_to_u64(a);
 }
 
 static SECP256K1_INLINE void secp256k1_i128_from_i64(secp256k1_int128 *r, int64_t a) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -1806,7 +1806,7 @@ void load256i128(uint16_t* out, const secp256k1_int128* v) {
     uint64_t lo;
     int64_t hi;
     secp256k1_int128 c = *v;
-    lo = secp256k1_i128_to_i64(&c);
+    lo = secp256k1_i128_to_u64(&c);
     secp256k1_i128_rshift(&c, 64);
     hi = secp256k1_i128_to_i64(&c);
     load256two64(out, hi, lo, 1);
@@ -1923,8 +1923,8 @@ void run_int128_test_case(void) {
     secp256k1_i128_rshift(&swz, uc % 127);
     load256i128(rswz, &swz);
     CHECK(secp256k1_memcmp_var(rswr, rswz, 16) == 0);
-    /* test secp256k1_i128_to_i64 */
-    CHECK((uint64_t)secp256k1_i128_to_i64(&swa) == v[0]);
+    /* test secp256k1_i128_to_u64 */
+    CHECK(secp256k1_i128_to_u64(&swa) == v[0]);
     /* test secp256k1_i128_from_i64 */
     secp256k1_i128_from_i64(&swz, sb);
     load256i128(rswz, &swz);
@@ -1988,20 +1988,20 @@ void run_int128_tests(void) {
         /* Compute INT128_MAX = 2^127 - 1 with secp256k1_i128_accum_mul */
         secp256k1_i128_mul(&res, INT64_MAX, INT64_MAX);
         secp256k1_i128_accum_mul(&res, INT64_MAX, INT64_MAX);
-        CHECK(secp256k1_i128_to_i64(&res) == 2);
+        CHECK(secp256k1_i128_to_u64(&res) == 2);
         secp256k1_i128_accum_mul(&res, 4, 9223372036854775807);
         secp256k1_i128_accum_mul(&res, 1, 1);
-        CHECK((uint64_t)secp256k1_i128_to_i64(&res) == UINT64_MAX);
+        CHECK(secp256k1_i128_to_u64(&res) == UINT64_MAX);
         secp256k1_i128_rshift(&res, 64);
         CHECK(secp256k1_i128_to_i64(&res) == INT64_MAX);
 
         /* Compute INT128_MIN = - 2^127 with secp256k1_i128_accum_mul */
         secp256k1_i128_mul(&res, INT64_MAX, INT64_MIN);
-        CHECK(secp256k1_i128_to_i64(&res) == INT64_MIN);
+        CHECK(secp256k1_i128_to_u64(&res) == (uint64_t)INT64_MIN);
         secp256k1_i128_accum_mul(&res, INT64_MAX, INT64_MIN);
-        CHECK(secp256k1_i128_to_i64(&res) == 0);
+        CHECK(secp256k1_i128_to_u64(&res) == 0);
         secp256k1_i128_accum_mul(&res, 2, INT64_MIN);
-        CHECK(secp256k1_i128_to_i64(&res) == 0);
+        CHECK(secp256k1_i128_to_u64(&res) == 0);
         secp256k1_i128_rshift(&res, 64);
         CHECK(secp256k1_i128_to_i64(&res) == INT64_MIN);
     }

--- a/src/tests.c
+++ b/src/tests.c
@@ -1929,6 +1929,8 @@ void run_int128_test_case(void) {
     secp256k1_i128_from_i64(&swz, sb);
     load256i128(rswz, &swz);
     CHECK(secp256k1_memcmp_var(rsb, rswz, 16) == 0);
+    /* test secp256k1_i128_to_i64 */
+    CHECK(secp256k1_i128_to_i64(&swz) == sb);
     /* test secp256k1_i128_eq_var */
     {
         int expect = (uc & 1);


### PR DESCRIPTION
I wanted to experiment with what would be required to split up `secp256k1_i128_to_i64` between those cases when a signed 64 bit value is being demoted, versus an unsigned 64 bit value is being extracted from the lower bits, and this is the result.

I'm not sure this is a useful PR, so feel free to close it.  However, since it is already written, I figured it is worth at least discussing.
