### PR TITLE
Makefile: build precomputed_ecmult generators using build-system toolchain to support cross-compiling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -180,8 +180,26 @@ endif
 endif
 
 ### Precomputed tables
-EXTRA_PROGRAMS = precompute_ecmult precompute_ecmult_gen
-CLEANFILES = $(EXTRA_PROGRAMS)
+PROGRAMS_FOR_BUILD = precompute_ecmult precompute_ecmult_gen
+$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CC = $(CC_FOR_BUILD)
+$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CFLAGS = $(CFLAGS_FOR_BUILD)
+$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
+$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override LDFLAGS = $(LDFLAGS_FOR_BUILD)
+# Automake has no support for PROGRAMS suffixed with BUILD_EXEEXT
+# instead of EXEEXT, so if those extensions differ, then we define a
+# recipe that builds the latter and renames it to the former. Since
+# Cygwin toolchains always append '.exe' to the output file name given
+# by '-o', we ignore rename failures since the toolchain will have
+# already created the right output file. (Note: The leading spaces
+# before ifneq and endif here are a hack so Automake won't try to
+# interpret them as an Automake conditional.)
+ ifneq ($(BUILD_EXEEXT),$(EXEEXT))
+%$(BUILD_EXEEXT) : %$(EXEEXT)
+	mv -- '$<' '$@' || :
+ endif
+
+EXTRA_PROGRAMS = $(PROGRAMS_FOR_BUILD)
+CLEANFILES = $(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD))
 
 precompute_ecmult_SOURCES = src/precompute_ecmult.c
 precompute_ecmult_CPPFLAGS = $(SECP_INCLUDES)
@@ -198,11 +216,11 @@ precompute_ecmult_gen_LDADD = $(SECP_LIBS) $(COMMON_LIB)
 # This means that rebuilds of the prebuilt files always need to be
 # forced by deleting them, e.g., by invoking `make clean-precomp`.
 src/precomputed_ecmult.c:
-	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult$(EXEEXT)
-	./precompute_ecmult$(EXEEXT)
+	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult$(BUILD_EXEEXT)
+	./precompute_ecmult$(BUILD_EXEEXT)
 src/precomputed_ecmult_gen.c:
-	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult_gen$(EXEEXT)
-	./precompute_ecmult_gen$(EXEEXT)
+	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult_gen$(BUILD_EXEEXT)
+	./precompute_ecmult_gen$(BUILD_EXEEXT)
 
 PRECOMP = src/precomputed_ecmult_gen.c src/precomputed_ecmult.c
 precomp: $(PRECOMP)

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_PROG_CC
 AM_PROG_AS
 AM_PROG_AR
+AX_PROG_CC_FOR_BUILD
 
 # Clear some cache variables as a workaround for a bug that appears due to a bad
 # interaction between AM_PROG_AR and LT_INIT when combining MSVC's archiver lib.exe.


### PR DESCRIPTION
When cross-compiling libsecp256k1, if the `precomputed_ecmult*.c` source files need to be regenerated, then the generators need to be built for the *build* system, not for the *host* system. Autoconf supports this fairly cleanly via the `AX_PROG_CC_FOR_BUILD` macro (from Autoconf Archive), but Automake requires some hackery. When building the generators, we override the `CC`, `CFLAGS`, `CPPFLAGS`, and `LDFLAGS` variables to their build-system counterparts, whose names are suffixed with `_FOR_BUILD` and whose values are populated by the aforementioned Autoconf macro and may be overridden on the `make` command line. Since Automake lacks support for overriding `EXEEXT` on a per-program basis, we define a recipe that builds the generator binaries with names suffixed with `$(EXEEXT)` and then renames them suffixed with `$(BUILD_EXEEXT)`.