### PR TITLE
Add support for msan instead of valgrind (for memcheck and ctime test)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -330,10 +330,11 @@ task:
     ECDH: yes
     RECOVERY: yes
     SCHNORRSIG: yes
-    CTIMETEST: no
+    CTIMETEST: yes
     CC: clang
     SECP256K1_TEST_ITERS: 32
     ASM: no
+    WITH_VALGRIND: no
   container:
     memory: 2G
   matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ env:
   SECP256K1_TEST_ITERS:
   BENCH: yes
   SECP256K1_BENCH_ITERS: 2
-  CTIMETEST: yes
+  CTIMETESTS: yes
   # Compile and run the tests
   EXAMPLES: yes
 
@@ -81,9 +81,9 @@ task:
     - env: {WIDEMUL: int128,                 ECDH: yes, SCHNORRSIG: yes}
     - env: {WIDEMUL: int128,  ASM: x86_64}
     - env: {                  RECOVERY: yes,            SCHNORRSIG: yes}
-    - env: {BUILD: distcheck, WITH_VALGRIND: no, CTIMETEST: no, BENCH: no}
+    - env: {BUILD: distcheck, WITH_VALGRIND: no, CTIMETESTS: no, BENCH: no}
     - env: {CPPFLAGS: -DDETERMINISTIC}
-    - env: {CFLAGS: -O0, CTIMETEST: no}
+    - env: {CFLAGS: -O0, CTIMETESTS: no}
     - env: { ECMULTGENPRECISION: 2, ECMULTWINDOW: 2 }
     - env: { ECMULTGENPRECISION: 8, ECMULTWINDOW: 4 }
   matrix:
@@ -128,7 +128,7 @@ task:
   env:
     ASM: no
     WITH_VALGRIND: no
-    CTIMETEST: no
+    CTIMETESTS: no
   matrix:
     - env:
         CC: gcc
@@ -153,7 +153,7 @@ task:
     ECDH: yes
     RECOVERY: yes
     SCHNORRSIG: yes
-    CTIMETEST: no
+    CTIMETESTS: no
   << : *MERGE_BASE
   test_script:
     # https://sourceware.org/bugzilla/show_bug.cgi?id=27008
@@ -172,7 +172,7 @@ task:
     ECDH: yes
     RECOVERY: yes
     SCHNORRSIG: yes
-    CTIMETEST: no
+    CTIMETESTS: no
   matrix:
     - env: {}
     - env: {EXPERIMENTAL: yes, ASM: arm}
@@ -192,7 +192,7 @@ task:
     ECDH: yes
     RECOVERY: yes
     SCHNORRSIG: yes
-    CTIMETEST: no
+    CTIMETESTS: no
   << : *MERGE_BASE
   test_script:
     - ./ci/cirrus.sh
@@ -209,7 +209,7 @@ task:
     ECDH: yes
     RECOVERY: yes
     SCHNORRSIG: yes
-    CTIMETEST: no
+    CTIMETESTS: no
   << : *MERGE_BASE
   test_script:
     - ./ci/cirrus.sh
@@ -223,7 +223,7 @@ task:
     ECDH: yes
     RECOVERY: yes
     SCHNORRSIG: yes
-    CTIMETEST: no
+    CTIMETESTS: no
   matrix:
     - name: "x86_64 (mingw32-w64): Windows (Debian stable, Wine)"
       env:
@@ -246,7 +246,7 @@ task:
     RECOVERY: yes
     EXPERIMENTAL: yes
     SCHNORRSIG: yes
-    CTIMETEST: no
+    CTIMETESTS: no
     # Use a MinGW-w64 host to tell ./configure we're building for Windows.
     # This will detect some MinGW-w64 tools but then make will need only
     # the MSVC tools CC, AR and NM as specified below.
@@ -285,7 +285,7 @@ task:
     ECDH: yes
     RECOVERY: yes
     SCHNORRSIG: yes
-    CTIMETEST: no
+    CTIMETESTS: no
   matrix:
     - name: "Valgrind (memcheck)"
       container:
@@ -330,7 +330,7 @@ task:
     ECDH: yes
     RECOVERY: yes
     SCHNORRSIG: yes
-    CTIMETEST: yes
+    CTIMETESTS: yes
     CC: clang
     SECP256K1_TEST_ITERS: 32
     ASM: no

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,8 +40,8 @@ cat_logs_snippet: &CAT_LOGS
       - cat noverify_tests.log || true
     cat_exhaustive_tests_log_script:
       - cat exhaustive_tests.log || true
-    cat_valgrind_ctime_test_log_script:
-      - cat valgrind_ctime_test.log || true
+    cat_ctime_tests_log_script:
+      - cat ctime_tests.log || true
     cat_bench_log_script:
       - cat bench.log || true
     cat_config_log_script:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ tests
 exhaustive_tests
 precompute_ecmult_gen
 precompute_ecmult
-valgrind_ctime_test
+ctime_tests
 ecdh_example
 ecdsa_example
 schnorr_example

--- a/Makefile.am
+++ b/Makefile.am
@@ -119,12 +119,6 @@ noverify_tests_SOURCES = src/tests.c
 noverify_tests_CPPFLAGS = $(SECP_INCLUDES) $(SECP_TEST_INCLUDES) $(SECP_CONFIG_DEFINES)
 noverify_tests_LDADD = $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB) $(PRECOMPUTED_LIB)
 noverify_tests_LDFLAGS = -static
-if VALGRIND_ENABLED
-noinst_PROGRAMS += ctime_tests
-ctime_tests_SOURCES = src/ctime_tests.c
-ctime_tests_LDADD = libsecp256k1.la $(SECP_LIBS) $(COMMON_LIB)
-ctime_tests_CPPFLAGS = $(SECP_CONFIG_DEFINES)
-endif
 if !ENABLE_COVERAGE
 TESTS += tests
 noinst_PROGRAMS += tests
@@ -133,6 +127,13 @@ tests_CPPFLAGS = $(noverify_tests_CPPFLAGS) -DVERIFY
 tests_LDADD    = $(noverify_tests_LDADD)
 tests_LDFLAGS  = $(noverify_tests_LDFLAGS)
 endif
+endif
+
+if USE_CTIME_TESTS
+noinst_PROGRAMS += ctime_tests
+ctime_tests_SOURCES = src/ctime_tests.c
+ctime_tests_LDADD = libsecp256k1.la $(SECP_LIBS) $(COMMON_LIB)
+ctime_tests_CPPFLAGS = $(SECP_CONFIG_DEFINES)
 endif
 
 if USE_EXHAUSTIVE_TESTS

--- a/Makefile.am
+++ b/Makefile.am
@@ -120,10 +120,10 @@ noverify_tests_CPPFLAGS = $(SECP_INCLUDES) $(SECP_TEST_INCLUDES) $(SECP_CONFIG_D
 noverify_tests_LDADD = $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB) $(PRECOMPUTED_LIB)
 noverify_tests_LDFLAGS = -static
 if VALGRIND_ENABLED
-noinst_PROGRAMS += valgrind_ctime_test
-valgrind_ctime_test_SOURCES = src/valgrind_ctime_test.c
-valgrind_ctime_test_LDADD = libsecp256k1.la $(SECP_LIBS) $(COMMON_LIB)
-valgrind_ctime_test_CPPFLAGS = $(SECP_CONFIG_DEFINES)
+noinst_PROGRAMS += ctime_tests
+ctime_tests_SOURCES = src/ctime_tests.c
+ctime_tests_LDADD = libsecp256k1.la $(SECP_LIBS) $(COMMON_LIB)
+ctime_tests_CPPFLAGS = $(SECP_CONFIG_DEFINES)
 endif
 if !ENABLE_COVERAGE
 TESTS += tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ noinst_HEADERS += src/modinv64_impl.h
 noinst_HEADERS += src/precomputed_ecmult.h
 noinst_HEADERS += src/precomputed_ecmult_gen.h
 noinst_HEADERS += src/assumptions.h
+noinst_HEADERS += src/checkmem.h
 noinst_HEADERS += src/util.h
 noinst_HEADERS += src/int128.h
 noinst_HEADERS += src/int128_impl.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -96,10 +96,6 @@ libsecp256k1_la_CPPFLAGS = $(SECP_INCLUDES) $(SECP_CONFIG_DEFINES)
 libsecp256k1_la_LIBADD = $(SECP_LIBS) $(COMMON_LIB) $(PRECOMPUTED_LIB)
 libsecp256k1_la_LDFLAGS = -no-undefined -version-info $(LIB_VERSION_CURRENT):$(LIB_VERSION_REVISION):$(LIB_VERSION_AGE)
 
-if VALGRIND_ENABLED
-libsecp256k1_la_CPPFLAGS += -DVALGRIND
-endif
-
 noinst_PROGRAMS =
 if USE_BENCHMARK
 noinst_PROGRAMS += bench bench_internal bench_ecmult
@@ -123,10 +119,10 @@ noverify_tests_CPPFLAGS = $(SECP_INCLUDES) $(SECP_TEST_INCLUDES) $(SECP_CONFIG_D
 noverify_tests_LDADD = $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB) $(PRECOMPUTED_LIB)
 noverify_tests_LDFLAGS = -static
 if VALGRIND_ENABLED
-noverify_tests_CPPFLAGS += -DVALGRIND
 noinst_PROGRAMS += valgrind_ctime_test
 valgrind_ctime_test_SOURCES = src/valgrind_ctime_test.c
 valgrind_ctime_test_LDADD = libsecp256k1.la $(SECP_LIBS) $(COMMON_LIB)
+valgrind_ctime_test_CPPFLAGS = $(SECP_CONFIG_DEFINES)
 endif
 if !ENABLE_COVERAGE
 TESTS += tests

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -13,7 +13,7 @@ print_environment() {
     for var in WERROR_CFLAGS MAKEFLAGS BUILD \
             ECMULTWINDOW ECMULTGENPRECISION ASM WIDEMUL WITH_VALGRIND EXTRAFLAGS \
             EXPERIMENTAL ECDH RECOVERY SCHNORRSIG \
-            SECP256K1_TEST_ITERS BENCH SECP256K1_BENCH_ITERS CTIMETEST\
+            SECP256K1_TEST_ITERS BENCH SECP256K1_BENCH_ITERS CTIMETESTS\
             EXAMPLES \
             HOST WRAPPER_CMD \
             CC CFLAGS CPPFLAGS AR NM
@@ -62,7 +62,7 @@ fi
     --enable-module-ecdh="$ECDH" --enable-module-recovery="$RECOVERY" \
     --enable-module-schnorrsig="$SCHNORRSIG" \
     --enable-examples="$EXAMPLES" \
-    --enable-ctime-tests="$CTIMETEST" \
+    --enable-ctime-tests="$CTIMETESTS" \
     --with-valgrind="$WITH_VALGRIND" \
     --host="$HOST" $EXTRAFLAGS
 
@@ -95,7 +95,7 @@ then
     } >> bench.log 2>&1
 fi
 
-if [ "$CTIMETEST" = "yes" ]
+if [ "$CTIMETESTS" = "yes" ]
 then
     if [ "$WITH_VALGRIND" = "yes" ]; then
         ./libtool --mode=execute valgrind --error-exitcode=42 ./ctime_tests > ctime_tests.log 2>&1

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -95,7 +95,7 @@ fi
 
 if [ "$CTIMETEST" = "yes" ]
 then
-    ./libtool --mode=execute valgrind --error-exitcode=42 ./valgrind_ctime_test > valgrind_ctime_test.log 2>&1
+    ./libtool --mode=execute valgrind --error-exitcode=42 ./ctime_tests > ctime_tests.log 2>&1
 fi
 
 # Rebuild precomputed files (if not cross-compiling).

--- a/configure.ac
+++ b/configure.ac
@@ -344,7 +344,7 @@ case $set_ecmult_gen_precision in
 esac
 
 if test x"$enable_valgrind" = x"yes"; then
-  SECP_INCLUDES="$SECP_INCLUDES $VALGRIND_CPPFLAGS"
+  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES $VALGRIND_CPPFLAGS -DVALGRIND"
 fi
 
 # Add -Werror and similar flags passed from the outside (for testing, e.g., in CI).

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,10 @@ AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--enable-tests],[compile tests [default=yes]]), [],
     [SECP_SET_DEFAULT([enable_tests], [yes], [yes])])
 
+AC_ARG_ENABLE(ctime_tests,
+    AS_HELP_STRING([--enable-ctime-tests],[compile constant-time tests [default=yes if valgrind enabled]]), [],
+    [SECP_SET_DEFAULT([enable_ctime_tests], [auto], [auto])])
+
 AC_ARG_ENABLE(experimental,
     AS_HELP_STRING([--enable-experimental],[allow experimental configure options [default=no]]), [],
     [SECP_SET_DEFAULT([enable_experimental], [no], [yes])])
@@ -225,7 +229,10 @@ else
     enable_valgrind=yes
   fi
 fi
-AM_CONDITIONAL([VALGRIND_ENABLED],[test "$enable_valgrind" = "yes"])
+
+if test x"$enable_ctime_tests" = x"auto"; then
+    enable_ctime_tests=$enable_valgrind
+fi
 
 if test x"$enable_coverage" = x"yes"; then
     SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DCOVERAGE=1"
@@ -407,6 +414,7 @@ AC_SUBST(SECP_CFLAGS)
 AC_SUBST(SECP_CONFIG_DEFINES)
 AM_CONDITIONAL([ENABLE_COVERAGE], [test x"$enable_coverage" = x"yes"])
 AM_CONDITIONAL([USE_TESTS], [test x"$enable_tests" != x"no"])
+AM_CONDITIONAL([USE_CTIME_TESTS], [test x"$enable_ctime_tests" = x"yes"])
 AM_CONDITIONAL([USE_EXHAUSTIVE_TESTS], [test x"$enable_exhaustive_tests" != x"no"])
 AM_CONDITIONAL([USE_EXAMPLES], [test x"$enable_examples" != x"no"])
 AM_CONDITIONAL([USE_BENCHMARK], [test x"$enable_benchmark" = x"yes"])
@@ -428,6 +436,7 @@ echo "Build Options:"
 echo "  with external callbacks = $enable_external_default_callbacks"
 echo "  with benchmarks         = $enable_benchmark"
 echo "  with tests              = $enable_tests"
+echo "  with ctime tests        = $enable_ctime_tests"
 echo "  with coverage           = $enable_coverage"
 echo "  with examples           = $enable_examples"
 echo "  module ecdh             = $enable_module_ecdh"

--- a/doc/safegcd_implementation.md
+++ b/doc/safegcd_implementation.md
@@ -410,7 +410,7 @@ sufficient even. Given that every loop iteration performs *N* divsteps, it will 
 
 To deal with the branches in `divsteps_n_matrix` we will replace them with constant-time bitwise
 operations (and hope the C compiler isn't smart enough to turn them back into branches; see
-`valgrind_ctime_test.c` for automated tests that this isn't the case). To do so, observe that a
+`ctime_tests.c` for automated tests that this isn't the case). To do so, observe that a
 divstep can be written instead as (compare to the inner loop of `gcd` in section 1).
 
 ```python

--- a/src/checkmem.h
+++ b/src/checkmem.h
@@ -1,0 +1,74 @@
+/***********************************************************************
+ * Copyright (c) 2022 Pieter Wuille                                    *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
+/* The code here is inspired by Kris Kwiatkowski's approach in
+ * https://github.com/kriskwiatkowski/pqc/blob/main/src/common/ct_check.h
+ * to provide a general interface for memory-checking mechanisms, primarily
+ * for constant-time checking.
+ */
+
+/* These macros are defined by this header file:
+ *
+ * - SECP256K1_CHECKMEM_ENABLED:
+ *   - 1 if memory-checking integration is available, 0 otherwise.
+ *     This is just a compile-time macro. Use the next macro to check it is actually
+ *     available at runtime.
+ * - SECP256K1_CHECKMEM_RUNNING():
+ *   - Acts like a function call, returning 1 if memory checking is available
+ *     at runtime.
+ * - SECP256K1_CHECKMEM_CHECK(p, len):
+ *   - Assert or otherwise fail in case the len-byte memory block pointed to by p is
+ *     not considered entirely defined.
+ * - SECP256K1_CHECKMEM_CHECK_VERIFY(p, len):
+ *   - Like SECP256K1_CHECKMEM_CHECK, but only works in VERIFY mode.
+ * - SECP256K1_CHECKMEM_UNDEFINE(p, len):
+ *   - marks the len-byte memory block pointed to by p as undefined data (secret data,
+ *     in the context of constant-time checking).
+ * - SECP256K1_CHECKMEM_DEFINE(p, len):
+ *   - marks the len-byte memory pointed to by p as defined data (public data, in the
+ *     context of constant-time checking).
+ *
+ */
+
+#ifndef SECP256K1_CHECKMEM_H
+#define SECP256K1_CHECKMEM_H
+
+/* Define a statement-like macro that ignores the arguments. */
+#define SECP256K1_CHECKMEM_NOOP(p, len) do { (void)(p); (void)(len); } while(0)
+
+/* If valgrind integration is desired (through the VALGRIND define), implement the
+ * SECP256K1_CHECKMEM_* macros using valgrind. */
+#if !defined SECP256K1_CHECKMEM_ENABLED
+#  if defined VALGRIND
+#    include <stddef.h>
+#    include <valgrind/memcheck.h>
+#    define SECP256K1_CHECKMEM_ENABLED 1
+#    define SECP256K1_CHECKMEM_UNDEFINE(p, len) VALGRIND_MAKE_MEM_UNDEFINED((p), (len))
+#    define SECP256K1_CHECKMEM_DEFINE(p, len) VALGRIND_MAKE_MEM_DEFINED((p), (len))
+#    define SECP256K1_CHECKMEM_CHECK(p, len) VALGRIND_CHECK_MEM_IS_DEFINED((p), (len))
+     /* VALGRIND_MAKE_MEM_DEFINED returns 0 iff not running on memcheck.
+      * This is more precise than the RUNNING_ON_VALGRIND macro, which
+      * checks for valgrind in general instead of memcheck specifically. */
+#    define SECP256K1_CHECKMEM_RUNNING() (VALGRIND_MAKE_MEM_DEFINED(NULL, 0) != 0)
+#  endif
+#endif
+
+/* As a fall-back, map these macros to dummy statements. */
+#if !defined SECP256K1_CHECKMEM_ENABLED
+#  define SECP256K1_CHECKMEM_ENABLED 0
+#  define SECP256K1_CHECKMEM_UNDEFINE(p, len) SECP256K1_CHECKMEM_NOOP((p), (len))
+#  define SECP256K1_CHECKMEM_DEFINE(p, len) SECP256K1_CHECKMEM_NOOP((p), (len))
+#  define SECP256K1_CHECKMEM_CHECK(p, len) SECP256K1_CHECKMEM_NOOP((p), (len))
+#  define SECP256K1_CHECKMEM_RUNNING() (0)
+#endif
+
+#if defined VERIFY
+#define SECP256K1_CHECKMEM_CHECK_VERIFY(p, len) SECP256K1_CHECKMEM_CHECK((p), (len))
+#else
+#define SECP256K1_CHECKMEM_CHECK_VERIFY(p, len) SECP256K1_CHECKMEM_NOOP((p), (len))
+#endif
+
+#endif /* SECP256K1_CHECKMEM_H */

--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -39,7 +39,7 @@ int main(void) {
 
     if (!SECP256K1_CHECKMEM_RUNNING()) {
         fprintf(stderr, "Unless compiled under msan, this test can only usefully be run inside valgrind.\n");
-        fprintf(stderr, "Usage: libtool --mode=execute valgrind ./valgrind_ctime_test\n");
+        fprintf(stderr, "Usage: libtool --mode=execute valgrind ./ctime_tests\n");
         return 1;
     }
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_DECLASSIFY);

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -7,6 +7,7 @@
 #ifndef SECP256K1_FIELD_REPR_IMPL_H
 #define SECP256K1_FIELD_REPR_IMPL_H
 
+#include "checkmem.h"
 #include "util.h"
 #include "field.h"
 #include "modinv32_impl.h"
@@ -1132,7 +1133,7 @@ static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a) {
 
 static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_fe *a, int flag) {
     uint32_t mask0, mask1;
-    VG_CHECK_VERIFY(r->n, sizeof(r->n));
+    SECP256K1_CHECKMEM_CHECK_VERIFY(r->n, sizeof(r->n));
     mask0 = flag + ~((uint32_t)0);
     mask1 = ~mask0;
     r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
@@ -1231,7 +1232,7 @@ static SECP256K1_INLINE void secp256k1_fe_half(secp256k1_fe *r) {
 
 static SECP256K1_INLINE void secp256k1_fe_storage_cmov(secp256k1_fe_storage *r, const secp256k1_fe_storage *a, int flag) {
     uint32_t mask0, mask1;
-    VG_CHECK_VERIFY(r->n, sizeof(r->n));
+    SECP256K1_CHECKMEM_CHECK_VERIFY(r->n, sizeof(r->n));
     mask0 = flag + ~((uint32_t)0);
     mask1 = ~mask0;
     r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -7,6 +7,7 @@
 #ifndef SECP256K1_FIELD_REPR_IMPL_H
 #define SECP256K1_FIELD_REPR_IMPL_H
 
+#include "checkmem.h"
 #include "util.h"
 #include "field.h"
 #include "modinv64_impl.h"
@@ -472,7 +473,7 @@ static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a) {
 
 static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_fe *a, int flag) {
     uint64_t mask0, mask1;
-    VG_CHECK_VERIFY(r->n, sizeof(r->n));
+    SECP256K1_CHECKMEM_CHECK_VERIFY(r->n, sizeof(r->n));
     mask0 = flag + ~((uint64_t)0);
     mask1 = ~mask0;
     r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
@@ -555,7 +556,7 @@ static SECP256K1_INLINE void secp256k1_fe_half(secp256k1_fe *r) {
 
 static SECP256K1_INLINE void secp256k1_fe_storage_cmov(secp256k1_fe_storage *r, const secp256k1_fe_storage *a, int flag) {
     uint64_t mask0, mask1;
-    VG_CHECK_VERIFY(r->n, sizeof(r->n));
+    SECP256K1_CHECKMEM_CHECK_VERIFY(r->n, sizeof(r->n));
     mask0 = flag + ~((uint64_t)0);
     mask1 = ~mask0;
     r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);

--- a/src/scalar_4x64_impl.h
+++ b/src/scalar_4x64_impl.h
@@ -7,6 +7,7 @@
 #ifndef SECP256K1_SCALAR_REPR_IMPL_H
 #define SECP256K1_SCALAR_REPR_IMPL_H
 
+#include "checkmem.h"
 #include "int128.h"
 #include "modinv64_impl.h"
 
@@ -810,7 +811,7 @@ SECP256K1_INLINE static void secp256k1_scalar_mul_shift_var(secp256k1_scalar *r,
 
 static SECP256K1_INLINE void secp256k1_scalar_cmov(secp256k1_scalar *r, const secp256k1_scalar *a, int flag) {
     uint64_t mask0, mask1;
-    VG_CHECK_VERIFY(r->d, sizeof(r->d));
+    SECP256K1_CHECKMEM_CHECK_VERIFY(r->d, sizeof(r->d));
     mask0 = flag + ~((uint64_t)0);
     mask1 = ~mask0;
     r->d[0] = (r->d[0] & mask0) | (a->d[0] & mask1);

--- a/src/scalar_8x32_impl.h
+++ b/src/scalar_8x32_impl.h
@@ -7,6 +7,7 @@
 #ifndef SECP256K1_SCALAR_REPR_IMPL_H
 #define SECP256K1_SCALAR_REPR_IMPL_H
 
+#include "checkmem.h"
 #include "modinv32_impl.h"
 
 /* Limbs of the secp256k1 order. */
@@ -631,7 +632,7 @@ SECP256K1_INLINE static void secp256k1_scalar_mul_shift_var(secp256k1_scalar *r,
 
 static SECP256K1_INLINE void secp256k1_scalar_cmov(secp256k1_scalar *r, const secp256k1_scalar *a, int flag) {
     uint32_t mask0, mask1;
-    VG_CHECK_VERIFY(r->d, sizeof(r->d));
+    SECP256K1_CHECKMEM_CHECK_VERIFY(r->d, sizeof(r->d));
     mask0 = flag + ~((uint32_t)0);
     mask1 = ~mask0;
     r->d[0] = (r->d[0] & mask0) | (a->d[0] & mask1);

--- a/src/scalar_low_impl.h
+++ b/src/scalar_low_impl.h
@@ -7,6 +7,7 @@
 #ifndef SECP256K1_SCALAR_REPR_IMPL_H
 #define SECP256K1_SCALAR_REPR_IMPL_H
 
+#include "checkmem.h"
 #include "scalar.h"
 
 #include <string.h>
@@ -115,7 +116,7 @@ SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar *a, const
 
 static SECP256K1_INLINE void secp256k1_scalar_cmov(secp256k1_scalar *r, const secp256k1_scalar *a, int flag) {
     uint32_t mask0, mask1;
-    VG_CHECK_VERIFY(r, sizeof(*r));
+    SECP256K1_CHECKMEM_CHECK_VERIFY(r, sizeof(*r));
     mask0 = flag + ~((uint32_t)0);
     mask1 = ~mask0;
     *r = (*r & mask0) | (*a & mask1);

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -99,6 +99,12 @@ size_t secp256k1_context_preallocated_size(unsigned int flags) {
             return 0;
     }
 
+    if (EXPECT(!SECP256K1_CHECKMEM_RUNNING() && (flags & SECP256K1_FLAGS_BIT_CONTEXT_DECLASSIFY), 0)) {
+            secp256k1_callback_call(&default_illegal_callback,
+                                    "Declassify flag requires running with memory checking");
+            return 0;
+    }
+
     return ret;
 }
 

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -21,6 +21,7 @@
 #include "../include/secp256k1_preallocated.h"
 
 #include "assumptions.h"
+#include "checkmem.h"
 #include "util.h"
 
 #include "field_impl.h"
@@ -38,10 +39,6 @@
 
 #ifdef SECP256K1_NO_BUILD
 # error "secp256k1.h processed without SECP256K1_BUILD defined while building secp256k1.c"
-#endif
-
-#if defined(VALGRIND)
-# include <valgrind/memcheck.h>
 #endif
 
 #define ARG_CHECK(cond) do { \
@@ -215,17 +212,10 @@ void secp256k1_scratch_space_destroy(const secp256k1_context *ctx, secp256k1_scr
 }
 
 /* Mark memory as no-longer-secret for the purpose of analysing constant-time behaviour
- *  of the software. This is setup for use with valgrind but could be substituted with
- *  the appropriate instrumentation for other analysis tools.
+ *  of the software.
  */
 static SECP256K1_INLINE void secp256k1_declassify(const secp256k1_context* ctx, const void *p, size_t len) {
-#if defined(VALGRIND)
-    if (EXPECT(ctx->declassify,0)) VALGRIND_MAKE_MEM_DEFINED(p, len);
-#else
-    (void)ctx;
-    (void)p;
-    (void)len;
-#endif
+    if (EXPECT(ctx->declassify, 0)) SECP256K1_CHECKMEM_DEFINE(p, len);
 }
 
 static int secp256k1_pubkey_load(const secp256k1_context* ctx, secp256k1_ge* ge, const secp256k1_pubkey* pubkey) {

--- a/src/util.h
+++ b/src/util.h
@@ -97,25 +97,6 @@ static const secp256k1_callback default_error_callback = {
 #define VERIFY_SETUP(stmt)
 #endif
 
-/* Define `VG_UNDEF` and `VG_CHECK` when VALGRIND is defined  */
-#if !defined(VG_CHECK)
-# if defined(VALGRIND)
-#  include <valgrind/memcheck.h>
-#  define VG_UNDEF(x,y) VALGRIND_MAKE_MEM_UNDEFINED((x),(y))
-#  define VG_CHECK(x,y) VALGRIND_CHECK_MEM_IS_DEFINED((x),(y))
-# else
-#  define VG_UNDEF(x,y)
-#  define VG_CHECK(x,y)
-# endif
-#endif
-
-/* Like `VG_CHECK` but on VERIFY only */
-#if defined(VERIFY)
-#define VG_CHECK_VERIFY(x,y) VG_CHECK((x), (y))
-#else
-#define VG_CHECK_VERIFY(x,y)
-#endif
-
 static SECP256K1_INLINE void *checked_malloc(const secp256k1_callback* cb, size_t size) {
     void *ret = malloc(size);
     if (ret == NULL) {

--- a/src/valgrind_ctime_test.c
+++ b/src/valgrind_ctime_test.c
@@ -11,7 +11,7 @@
 #include "checkmem.h"
 
 #if !SECP256K1_CHECKMEM_ENABLED
-#  error "This tool cannot be compiled without memory-checking interface (valgrind)"
+#  error "This tool cannot be compiled without memory-checking interface (valgrind or msan)"
 #endif
 
 #ifdef ENABLE_MODULE_ECDH
@@ -38,7 +38,7 @@ int main(void) {
     int ret, i;
 
     if (!SECP256K1_CHECKMEM_RUNNING()) {
-        fprintf(stderr, "This test can only usefully be run inside valgrind.\n");
+        fprintf(stderr, "Unless compiled under msan, this test can only usefully be run inside valgrind.\n");
         fprintf(stderr, "Usage: libtool --mode=execute valgrind ./valgrind_ctime_test\n");
         return 1;
     }

--- a/src/valgrind_ctime_test.c
+++ b/src/valgrind_ctime_test.c
@@ -10,6 +10,10 @@
 #include "assumptions.h"
 #include "checkmem.h"
 
+#if !SECP256K1_CHECKMEM_ENABLED
+#  error "This tool cannot be compiled without memory-checking interface (valgrind)"
+#endif
+
 #ifdef ENABLE_MODULE_ECDH
 # include "../include/secp256k1_ecdh.h"
 #endif

--- a/src/valgrind_ctime_test.c
+++ b/src/valgrind_ctime_test.c
@@ -4,12 +4,11 @@
  * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
  ***********************************************************************/
 
-#include <valgrind/memcheck.h>
 #include <stdio.h>
 
 #include "../include/secp256k1.h"
 #include "assumptions.h"
-#include "util.h"
+#include "checkmem.h"
 
 #ifdef ENABLE_MODULE_ECDH
 # include "../include/secp256k1_ecdh.h"
@@ -34,7 +33,7 @@ int main(void) {
     unsigned char key[32];
     int ret, i;
 
-    if (!RUNNING_ON_VALGRIND) {
+    if (!SECP256K1_CHECKMEM_RUNNING()) {
         fprintf(stderr, "This test can only usefully be run inside valgrind.\n");
         fprintf(stderr, "Usage: libtool --mode=execute valgrind ./valgrind_ctime_test\n");
         return 1;
@@ -51,9 +50,9 @@ int main(void) {
 
     /* Test context randomisation. Do this last because it leaves the context
      * tainted. */
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_context_randomize(ctx, key);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret);
 
     secp256k1_context_destroy(ctx);
@@ -83,89 +82,89 @@ void run_tests(secp256k1_context *ctx, unsigned char *key) {
     }
 
     /* Test keygen. */
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ec_pubkey_create(ctx, &pubkey, key);
-    VALGRIND_MAKE_MEM_DEFINED(&pubkey, sizeof(secp256k1_pubkey));
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&pubkey, sizeof(secp256k1_pubkey));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret);
     CHECK(secp256k1_ec_pubkey_serialize(ctx, spubkey, &outputlen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
 
     /* Test signing. */
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ecdsa_sign(ctx, &signature, msg, key, NULL, NULL);
-    VALGRIND_MAKE_MEM_DEFINED(&signature, sizeof(secp256k1_ecdsa_signature));
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&signature, sizeof(secp256k1_ecdsa_signature));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret);
     CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature));
 
 #ifdef ENABLE_MODULE_ECDH
     /* Test ECDH. */
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ecdh(ctx, msg, &pubkey, key, NULL, NULL);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 #endif
 
 #ifdef ENABLE_MODULE_RECOVERY
     /* Test signing a recoverable signature. */
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ecdsa_sign_recoverable(ctx, &recoverable_signature, msg, key, NULL, NULL);
-    VALGRIND_MAKE_MEM_DEFINED(&recoverable_signature, sizeof(recoverable_signature));
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&recoverable_signature, sizeof(recoverable_signature));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret);
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &recoverable_signature));
     CHECK(recid >= 0 && recid <= 3);
 #endif
 
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ec_seckey_verify(ctx, key);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ec_seckey_negate(ctx, key);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
-    VALGRIND_MAKE_MEM_UNDEFINED(msg, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(msg, 32);
     ret = secp256k1_ec_seckey_tweak_add(ctx, key, msg);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
-    VALGRIND_MAKE_MEM_UNDEFINED(msg, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(msg, 32);
     ret = secp256k1_ec_seckey_tweak_mul(ctx, key, msg);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 
     /* Test keypair_create and keypair_xonly_tweak_add. */
 #ifdef ENABLE_MODULE_EXTRAKEYS
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_keypair_create(ctx, &keypair, key);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 
     /* The tweak is not treated as a secret in keypair_tweak_add */
-    VALGRIND_MAKE_MEM_DEFINED(msg, 32);
+    SECP256K1_CHECKMEM_DEFINE(msg, 32);
     ret = secp256k1_keypair_xonly_tweak_add(ctx, &keypair, msg);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
-    VALGRIND_MAKE_MEM_UNDEFINED(&keypair, sizeof(keypair));
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
     ret = secp256k1_keypair_sec(ctx, key, &keypair);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 #endif
 
 #ifdef ENABLE_MODULE_SCHNORRSIG
-    VALGRIND_MAKE_MEM_UNDEFINED(key, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_keypair_create(ctx, &keypair, key);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
     ret = secp256k1_schnorrsig_sign32(ctx, sig, msg, &keypair, NULL);
-    VALGRIND_MAKE_MEM_DEFINED(&ret, sizeof(ret));
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 #endif
 }


### PR DESCRIPTION
This introduces an abstraction layer `src/checkmem.h`, which defines macros for interacting with memory checking tools. Depending on the environment, they're mapped to MemorySanitizer builtins, Valgrind integration macros, or nothing at all.

This means that msan builds immediately benefit from existing undefined memory checks in the tests. It also means those builds result in a `ctime_tests` (new name for `valgrind_ctime_test`) binary that can usefully test constant-timeness (not inside Valgrind, and with the downside that it's not running against a production library build, but it's faster and available on more platforms).

Such an msan-ctime test is added to the Linux x86_64 msan CI job, as an example. More CI cases could be added (e.g. for MacOs or ARM Linux) later.