### PR TITLE
Change ARG_CHECK_NO_RETURN to ARG_CHECK_VOID which returns (void) 

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -849,7 +849,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
  * kind of elliptic curve point multiplication and thus does not benefit from
  * enhanced protection against side-channel leakage currently.
  *
- * It is safe call this function on a copy of secp256k1_context_static in writable
+ * It is safe to call this function on a copy of secp256k1_context_static in writable
  * memory (e.g., obtained via secp256k1_context_clone). In that case, this
  * function is guaranteed to return 1, but the call will have no effect because
  * the static context (or a copy thereof) is not meant to be randomized.

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -51,9 +51,10 @@
     } \
 } while(0)
 
-#define ARG_CHECK_NO_RETURN(cond) do { \
+#define ARG_CHECK_VOID(cond) do { \
     if (EXPECT(!(cond), 0)) { \
         secp256k1_callback_call(&ctx->illegal_callback, #cond); \
+        return; \
     } \
 } while(0)
 
@@ -166,7 +167,7 @@ secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
 }
 
 void secp256k1_context_preallocated_destroy(secp256k1_context* ctx) {
-    ARG_CHECK_NO_RETURN(ctx != secp256k1_context_static);
+    ARG_CHECK_VOID(ctx != secp256k1_context_static);
     if (ctx != NULL) {
         secp256k1_ecmult_gen_context_clear(&ctx->ecmult_gen_ctx);
     }
@@ -183,7 +184,7 @@ void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(
     /* We compare pointers instead of checking secp256k1_context_is_proper() here
        because setting callbacks is allowed on *copies* of the static context:
        it's harmless and makes testing easier. */
-    ARG_CHECK_NO_RETURN(ctx != secp256k1_context_static);
+    ARG_CHECK_VOID(ctx != secp256k1_context_static);
     if (fun == NULL) {
         fun = secp256k1_default_illegal_callback_fn;
     }
@@ -195,7 +196,7 @@ void secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(co
     /* We compare pointers instead of checking secp256k1_context_is_proper() here
        because setting callbacks is allowed on *copies* of the static context:
        it's harmless and makes testing easier. */
-    ARG_CHECK_NO_RETURN(ctx != secp256k1_context_static);
+    ARG_CHECK_VOID(ctx != secp256k1_context_static);
     if (fun == NULL) {
         fun = secp256k1_default_error_callback_fn;
     }

--- a/src/tests.c
+++ b/src/tests.c
@@ -156,8 +156,7 @@ int context_eq(const secp256k1_context *a, const secp256k1_context *b) {
     return a->declassify == b->declassify
             && ecmult_gen_context_eq(&a->ecmult_gen_ctx, &b->ecmult_gen_ctx)
             && a->illegal_callback.fn == b->illegal_callback.fn
-            && a->illegal_callback.data == b->illegal_callback.
-data
+            && a->illegal_callback.data == b->illegal_callback.data
             && a->error_callback.fn == b->error_callback.fn
             && a->error_callback.data == b->error_callback.data;
 }


### PR DESCRIPTION
And a few other commits cherry-picked from #1170. In particular I included the first commit because the ARG_CHECK_VOID commit doesn't cleanly apply without this first commit. The new helper function is currently unused but that's not a problem.

I also added a commit to fix the typo that was pointed out in #1126 (which #1170 would solved differently -- by removing the text entirely).