### PR TITLE
Drop `SECP_CONFIG_DEFINES` from examples

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -149,7 +149,7 @@ endif
 if USE_EXAMPLES
 noinst_PROGRAMS += ecdsa_example
 ecdsa_example_SOURCES = examples/ecdsa.c
-ecdsa_example_CPPFLAGS = -I$(top_srcdir)/include $(SECP_CONFIG_DEFINES)
+ecdsa_example_CPPFLAGS = -I$(top_srcdir)/include
 ecdsa_example_LDADD = libsecp256k1.la
 ecdsa_example_LDFLAGS = -static
 if BUILD_WINDOWS
@@ -159,7 +159,7 @@ TESTS += ecdsa_example
 if ENABLE_MODULE_ECDH
 noinst_PROGRAMS += ecdh_example
 ecdh_example_SOURCES = examples/ecdh.c
-ecdh_example_CPPFLAGS = -I$(top_srcdir)/include $(SECP_CONFIG_DEFINES)
+ecdh_example_CPPFLAGS = -I$(top_srcdir)/include
 ecdh_example_LDADD = libsecp256k1.la
 ecdh_example_LDFLAGS = -static
 if BUILD_WINDOWS
@@ -170,7 +170,7 @@ endif
 if ENABLE_MODULE_SCHNORRSIG
 noinst_PROGRAMS += schnorr_example
 schnorr_example_SOURCES = examples/schnorr.c
-schnorr_example_CPPFLAGS = -I$(top_srcdir)/include $(SECP_CONFIG_DEFINES)
+schnorr_example_CPPFLAGS = -I$(top_srcdir)/include
 schnorr_example_LDADD = libsecp256k1.la
 schnorr_example_LDFLAGS = -static
 if BUILD_WINDOWS


### PR DESCRIPTION
User applications shouldn't need or rely on `SECP_CONFIG_DEFINES`.

See https://github.com/bitcoin-core/secp256k1/pull/1178#discussion_r1059457252.