### PR TITLE
ctime_tests: improve output when CHECKMEM_RUNNING is not defined

### DIFF
--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -38,7 +38,7 @@ int main(void) {
     int ret, i;
 
     if (!SECP256K1_CHECKMEM_RUNNING()) {
-        fprintf(stderr, "Unless compiled under msan, this test can only usefully be run inside valgrind.\n");
+        fprintf(stderr, "This test can only usefully be run inside valgrind because it was not compiled under msan.\n");
         fprintf(stderr, "Usage: libtool --mode=execute valgrind ./ctime_tests\n");
         return 1;
     }


### PR DESCRIPTION
When seeing the output
```
Unless compiled under msan, this test can only usefully be run inside valgrind.
```
I thought that I would have to go back to the `configure` output to manually check if it was compiled under memsan to determine whether this test can be usefully run outside valgrind. But when we go into this branch then it was definitely not compiled under msan, which means that we can make the output clearer.