### PR TITLE
Faster const-time modinv divsteps (rebase of #1031)

### DIFF
--- a/doc/safegcd_implementation.md
+++ b/doc/safegcd_implementation.md
@@ -697,7 +697,7 @@ def divsteps_n_matrix(theta, f, g):
         # Conditionally subtract x, y, z from g, q, r.
         g, q, r = g - (x & c2), q - (y & c2), r - (z & c2)
         c3 = ~c1 & c2
-        # Conditionally completement theta, and then increment it by 1.
+        # Conditionally complement theta, and then increment it by 1.
         theta = (theta ^ c3) + 1
         # Conditionally add g, q, r to f, u, v.
         f, u, v = f + (g & c3), u + (q & c3), v + (r & c3)

--- a/src/modinv32_impl.h
+++ b/src/modinv32_impl.h
@@ -187,11 +187,11 @@ static int32_t secp256k1_modinv32_divsteps_30(int32_t theta, uint32_t f0, uint32
     for (i = 0; i < 30; ++i) {
         /* f must always be odd */
         VERIFY_CHECK((f & 1) == 1);
+        /* Minimum trailing zeros count for matrix elements decreases in each iteration */
+        VERIFY_CHECK(!((u | v | q | r) & (0xFFFFFFFFULL >> (i + 2))));
         /* Applying the matrix so far to the initial f,g gives current f,g. */
         VERIFY_CHECK((u >> (30 - i)) * f0 + (v >> (30 - i)) * g0 == f << i);
         VERIFY_CHECK((q >> (30 - i)) * f0 + (r >> (30 - i)) * g0 == g << i);
-        /* At the beginning of every loop, the matrix variables are even. */
-        VERIFY_CHECK(!((u | v | q | r) & 1));
         /* Compute conditional masks for (theta < 0) and for (g & 1). */
         c1 = theta >> 31;
         c2 = -(g & 1);
@@ -228,8 +228,9 @@ static int32_t secp256k1_modinv32_divsteps_30(int32_t theta, uint32_t f0, uint32
     VERIFY_CHECK(q * f0 + r * g0 == g << 30);
     /* The determinant of t must be a power of two. This guarantees that multiplication with t
      * does not change the gcd of f and g, apart from adding a power-of-2 factor to it (which
-     * will be divided out again). As each divstep's individual matrix has determinant 2, the
-     * aggregate of 30 of them will have determinant 2^30. */
+     * will be divided out again). As each divstep's individual matrix has determinant 2^-1,
+     * the aggregate of 30 of them will have determinant 2^-30. Multiplying with the initial
+     * 2^30*identity (which has determinant 2^60) means the result has determinant 2^30. */
     VERIFY_CHECK((int64_t)t->u * t->r - (int64_t)t->v * t->q == ((int64_t)1) << 30);
     return theta;
 }


### PR DESCRIPTION
Algorithm by Peter Dettman, with original comments:

> Changes to _divsteps_59 (_30) that give maybe 4% speed improvement to const-time modinv on 64 bit. I see a larger gain on 32 bit but measured on 64 bit so might not be real.
>
> Start the result matrix scaled by 2^62 (resp. 2^30) and shift q, r down instead of u, v up at each step (should make life easier for vectorization). Since we're always shifting away the LSB of g, q, r, we can avoid doing a full negation for x, y, z (after a few tweaks).

A new variable $\theta = \delta - 1/2$ is introduced then, which is slightly cheaper than the $\zeta = -\delta-1/2$ used before.