### PR TITLE
ci: Do not set git's `user.{email,name}` config options

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -55,8 +55,6 @@ cat_logs_snippet: &CAT_LOGS
 
 merge_base_script_snippet: &MERGE_BASE
   merge_base_script:
-    - git config --global user.email "ci@ci.ci"
-    - git config --global user.name "ci"
     - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
     - git fetch --depth=1 $CIRRUS_REPO_CLONE_URL "pull/${CIRRUS_PR}/merge"
     - git checkout FETCH_HEAD  # Use merged changes to detect silent merge conflicts


### PR DESCRIPTION
A cleanup after https://github.com/bitcoin-core/secp256k1/pull/1199.

git's `user.{email,name}` config options have been no longer required since 0ecf3188515e46b4da5580b4b9805d2cb927eb91.