### PR TITLE
field: Improve docs +tests of secp256k1_fe_set_b32

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -75,7 +75,9 @@ static int secp256k1_fe_equal_var(const secp256k1_fe *a, const secp256k1_fe *b);
 /** Compare two field elements. Requires both inputs to be normalized */
 static int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b);
 
-/** Set a field element equal to 32-byte big endian value. If successful, the resulting field element is normalized. */
+/** Set a field element equal to 32-byte big endian value.
+ *  Returns 1 if no overflow occurred, and then the output is normalized.
+ *  Returns 0 if overflow occurred, and then the output is only weakly normalized. */
 static int secp256k1_fe_set_b32(secp256k1_fe *r, const unsigned char *a);
 
 /** Convert a field element to a 32-byte big endian value. Requires the input to be normalized */

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -372,6 +372,7 @@ static int secp256k1_fe_set_b32(secp256k1_fe *r, const unsigned char *a) {
         secp256k1_fe_verify(r);
     } else {
         r->normalized = 0;
+        secp256k1_fe_verify(r);
     }
 #endif
     return ret;

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -367,13 +367,8 @@ static int secp256k1_fe_set_b32(secp256k1_fe *r, const unsigned char *a) {
     ret = !((r->n[9] == 0x3FFFFFUL) & ((r->n[8] & r->n[7] & r->n[6] & r->n[5] & r->n[4] & r->n[3] & r->n[2]) == 0x3FFFFFFUL) & ((r->n[1] + 0x40UL + ((r->n[0] + 0x3D1UL) >> 26)) > 0x3FFFFFFUL));
 #ifdef VERIFY
     r->magnitude = 1;
-    if (ret) {
-        r->normalized = 1;
-        secp256k1_fe_verify(r);
-    } else {
-        r->normalized = 0;
-        secp256k1_fe_verify(r);
-    }
+    r->normalized = ret;
+    secp256k1_fe_verify(r);
 #endif
     return ret;
 }

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -347,6 +347,7 @@ static int secp256k1_fe_set_b32(secp256k1_fe *r, const unsigned char *a) {
         secp256k1_fe_verify(r);
     } else {
         r->normalized = 0;
+        secp256k1_fe_verify(r);
     }
 #endif
     return ret;

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -342,13 +342,8 @@ static int secp256k1_fe_set_b32(secp256k1_fe *r, const unsigned char *a) {
     ret = !((r->n[4] == 0x0FFFFFFFFFFFFULL) & ((r->n[3] & r->n[2] & r->n[1]) == 0xFFFFFFFFFFFFFULL) & (r->n[0] >= 0xFFFFEFFFFFC2FULL));
 #ifdef VERIFY
     r->magnitude = 1;
-    if (ret) {
-        r->normalized = 1;
-        secp256k1_fe_verify(r);
-    } else {
-        r->normalized = 0;
-        secp256k1_fe_verify(r);
-    }
+    r->normalized = ret;
+    secp256k1_fe_verify(r);
 #endif
     return ret;
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -44,6 +44,25 @@ static int all_bytes_equal(const void* s, unsigned char value, size_t n) {
     return 1;
 }
 
+/* Debug helper for printing arrays of unsigned char. */
+#define PRINT_BUF(buf, len) do { \
+    printf("%s[%lu] = ", #buf, (unsigned long)len); \
+    print_buf_plain(buf, len); \
+} while(0);
+static void print_buf_plain(const unsigned char *buf, size_t len) {
+    size_t i;
+    printf("{");
+    for (i = 0; i < len; i++) {
+        if (i % 8 == 0) {
+            printf("\n    ");
+        } else {
+            printf(" ");
+        }
+        printf("0x%02X,", buf[i]);
+    }
+    printf("\n}\n");
+}
+
 /* TODO Use CHECK_ILLEGAL(_VOID) everywhere and get rid of the uncounting callback */
 /* CHECK that expr_or_stmt calls the illegal callback of ctx exactly once
  *


### PR DESCRIPTION
We could also change the interface to accept an explicit `overflow` output variable, like for the scalar function. I think this makes handling (and ignoring!) overflow much more explicit in the code. What do you think?