### PR TITLE
build: Add -Wreserved-identifier supported by clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,7 @@ AC_DEFUN([SECP_TRY_APPEND_DEFAULT_CFLAGS], [
       SECP_TRY_APPEND_CFLAGS([-Wcast-align], $1) # GCC >= 2.95
       SECP_TRY_APPEND_CFLAGS([-Wcast-align=strict], $1) # GCC >= 8.0
       SECP_TRY_APPEND_CFLAGS([-Wconditional-uninitialized], $1) # Clang >= 3.0 only
+      SECP_TRY_APPEND_CFLAGS([-Wreserved-identifier], $1) # Clang >= 13.0 only
       SECP_TRY_APPEND_CFLAGS([-fvisibility=hidden], $1) # GCC >= 4.0
 
       CFLAGS="$SECP_TRY_APPEND_DEFAULT_CFLAGS_saved_CFLAGS"


### PR DESCRIPTION
This warns on certain identifiers reserved by the C standard, namely
 * identifiers that begin with an underscore followed by an uppercase letter, and
 * identifiers in the global namespace that begin with an underscore.

We had used such identifiers in the past for macros in include guards, and we should make sure that we don't reintroduce such identifiers going forward.

Note that C reserves more identifiers for "future library directions", e.g., identifiers that begin with "str" followed by a lowercase letter. But even the C standards committee has decided that this is somewhat silly and adopted a proposal [1] for C23 that removes the restriction that programs using these identifiers have UB. Instead, these identifiers are now "potentially reserved", which is not a normative restriction but simply an informative warning that the identifiers may become fully reserved in the future.

[1] https://www.open-std.org/jtc1/sc22/WG14/www/docs/n2625.pdf