### PR TITLE
Convert type of eta to int

### DIFF
--- a/src/modinv32_impl.h
+++ b/src/modinv32_impl.h
@@ -242,7 +242,7 @@ static int32_t secp256k1_modinv32_divsteps_30(int32_t zeta, uint32_t f0, uint32_
  *
  * Implements the divsteps_n_matrix_var function from the explanation.
  */
-static int32_t secp256k1_modinv32_divsteps_30_var(int32_t eta, uint32_t f0, uint32_t g0, secp256k1_modinv32_trans2x2 *t) {
+static int secp256k1_modinv32_divsteps_30_var(int eta, uint32_t f0, uint32_t g0, secp256k1_modinv32_trans2x2 *t) {
     /* inv256[i] = -(2*i+1)^-1 (mod 256) */
     static const uint8_t inv256[128] = {
         0xFF, 0x55, 0x33, 0x49, 0xC7, 0x5D, 0x3B, 0x11, 0x0F, 0xE5, 0xC3, 0x59,
@@ -292,7 +292,7 @@ static int32_t secp256k1_modinv32_divsteps_30_var(int32_t eta, uint32_t f0, uint
         /* eta is now >= 0. In what follows we're going to cancel out the bottom bits of g. No more
          * than i can be cancelled out (as we'd be done before that point), and no more than eta+1
          * can be done as its sign will flip once that happens. */
-        limit = ((int)eta + 1) > i ? i : ((int)eta + 1);
+        limit = eta + 1 > i ? i : eta + 1;
         /* m is a mask for the bottom min(limit, 8) bits (our table only supports 8 bits). */
         VERIFY_CHECK(limit > 0 && limit <= 30);
         m = (UINT32_MAX >> (32 - limit)) & 255U;
@@ -515,7 +515,7 @@ static void secp256k1_modinv32_var(secp256k1_modinv32_signed30 *x, const secp256
     int i = 0;
 #endif
     int j, len = 9;
-    int32_t eta = -1; /* eta = -delta; delta is initially 1 (faster for the variable-time code) */
+    int eta = -1; /* eta = -delta; delta is initially 1 (faster for the variable-time code) */
     int32_t cond, fn, gn;
 
     /* Do iterations of 30 divsteps each until g=0. */

--- a/src/modinv64_impl.h
+++ b/src/modinv64_impl.h
@@ -233,7 +233,7 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
  *
  * Implements the divsteps_n_matrix_var function from the explanation.
  */
-static int64_t secp256k1_modinv64_divsteps_62_var(int64_t eta, uint64_t f0, uint64_t g0, secp256k1_modinv64_trans2x2 *t) {
+static int secp256k1_modinv64_divsteps_62_var(int eta, uint64_t f0, uint64_t g0, secp256k1_modinv64_trans2x2 *t) {
     /* Transformation matrix; see comments in secp256k1_modinv64_divsteps_62. */
     uint64_t u = 1, v = 0, q = 0, r = 1;
     uint64_t f = f0, g = g0, m;
@@ -267,7 +267,7 @@ static int64_t secp256k1_modinv64_divsteps_62_var(int64_t eta, uint64_t f0, uint
             /* Use a formula to cancel out up to 6 bits of g. Also, no more than i can be cancelled
              * out (as we'd be done before that point), and no more than eta+1 can be done as its
              * will flip again once that happens. */
-            limit = ((int)eta + 1) > i ? i : ((int)eta + 1);
+            limit = eta + 1 > i ? i : eta + 1;
             VERIFY_CHECK(limit > 0 && limit <= 62);
             /* m is a mask for the bottom min(limit, 6) bits. */
             m = (UINT64_MAX >> (64 - limit)) & 63U;
@@ -277,7 +277,7 @@ static int64_t secp256k1_modinv64_divsteps_62_var(int64_t eta, uint64_t f0, uint
         } else {
             /* In this branch, use a simpler formula that only lets us cancel up to 4 bits of g, as
              * eta tends to be smaller here. */
-            limit = ((int)eta + 1) > i ? i : ((int)eta + 1);
+            limit = eta + 1 > i ? i : eta + 1;
             VERIFY_CHECK(limit > 0 && limit <= 62);
             /* m is a mask for the bottom min(limit, 4) bits. */
             m = (UINT64_MAX >> (64 - limit)) & 15U;
@@ -557,7 +557,7 @@ static void secp256k1_modinv64_var(secp256k1_modinv64_signed62 *x, const secp256
     int i = 0;
 #endif
     int j, len = 5;
-    int64_t eta = -1; /* eta = -delta; delta is initially 1 */
+    int eta = -1; /* eta = -delta; delta is initially 1 */
     int64_t cond, fn, gn;
 
     /* Do iterations of 62 divsteps each until g=0. */

--- a/src/modinv64_impl.h
+++ b/src/modinv64_impl.h
@@ -153,7 +153,7 @@ static void secp256k1_modinv64_normalize_62(secp256k1_modinv64_signed62 *r, int6
 #endif
 }
 
-/* Compute the transition matrix and eta for 59 divsteps (where zeta=-(delta+1/2)).
+/* Compute the transition matrix and zeta for 59 divsteps (where zeta=-(delta+1/2)).
  * Note that the transformation matrix is scaled by 2^62 and not 2^59.
  *
  * Input:  zeta: initial zeta


### PR DESCRIPTION
Almost everywhere eta is cast to or otherwise treated as an int.

I suspect that the existing `int64_t` treatment of eta is a carryover from the constant time code where the specific type is perhaps more important.