### PR TITLE
Remove redundant checks.

### DIFF
--- a/src/modinv32_impl.h
+++ b/src/modinv32_impl.h
@@ -415,9 +415,7 @@ static void secp256k1_modinv32_update_de_30(secp256k1_modinv32_signed30 *d, secp
     VERIFY_CHECK(secp256k1_modinv32_mul_cmp_30(d, 9, &modinfo->modulus, 1) < 0);  /* d <    modulus */
     VERIFY_CHECK(secp256k1_modinv32_mul_cmp_30(e, 9, &modinfo->modulus, -2) > 0); /* e > -2*modulus */
     VERIFY_CHECK(secp256k1_modinv32_mul_cmp_30(e, 9, &modinfo->modulus, 1) < 0);  /* e <    modulus */
-    VERIFY_CHECK(labs(v) <= M30 + 1);             /*     |v| <= 2^30 */
     VERIFY_CHECK(labs(u) <= (M30 + 1 - labs(v))); /* |u|+|v| <= 2^30 */
-    VERIFY_CHECK(labs(r) <= M30 + 1);             /*     |r| <= 2^30 */
     VERIFY_CHECK(labs(q) <= (M30 + 1 - labs(r))); /* |q|+|r| <= 2^30 */
 #endif
     /* [md,me] start as zero; plus [u,q] if d is negative; plus [v,r] if e is negative. */

--- a/src/modinv64_impl.h
+++ b/src/modinv64_impl.h
@@ -419,9 +419,7 @@ static void secp256k1_modinv64_update_de_62(secp256k1_modinv64_signed62 *d, secp
     VERIFY_CHECK(secp256k1_modinv64_mul_cmp_62(d, 5, &modinfo->modulus, 1) < 0);  /* d <    modulus */
     VERIFY_CHECK(secp256k1_modinv64_mul_cmp_62(e, 5, &modinfo->modulus, -2) > 0); /* e > -2*modulus */
     VERIFY_CHECK(secp256k1_modinv64_mul_cmp_62(e, 5, &modinfo->modulus, 1) < 0);  /* e <    modulus */
-    VERIFY_CHECK(secp256k1_modinv64_abs(v) <= (int64_t)1 << 62);                                 /*     |v| <= 2^62 */
     VERIFY_CHECK(secp256k1_modinv64_abs(u) <= (((int64_t)1 << 62) - secp256k1_modinv64_abs(v))); /* |u|+|v| <= 2^62 */
-    VERIFY_CHECK(secp256k1_modinv64_abs(r) <= (int64_t)1 << 62);                                 /*     |r| <= 2^62 */
     VERIFY_CHECK(secp256k1_modinv64_abs(q) <= (((int64_t)1 << 62) - secp256k1_modinv64_abs(r))); /* |q|+|r| <= 2^62 */
 #endif
     /* [md,me] start as zero; plus [u,q] if d is negative; plus [v,r] if e is negative. */


### PR DESCRIPTION
These abs checks are implied by the subsequent line, and with the subsequent line written as it is, no underflow is possible with signed integers.

Follows up on https://github.com/bitcoin-core/secp256k1/pull/1218.