### PR TITLE
release: prepare for 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-03-08
+
 #### Added
  - Added experimental support for CMake builds. Traditional GNU Autotools builds (`./configure` and `make`) remain fully supported.
  - Usage examples: Added a recommended method for securely clearing sensitive data, e.g., secret keys, from memory.
@@ -21,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Removed
  - Removed the configuration header `src/libsecp256k1-config.h`. We recommend passing flags to `./configure` or `cmake` to set configuration options (see `./configure --help` or `cmake -LH`). If you cannot or do not want to use one of the supported build systems, pass configuration flags such as `-DSECP256K1_ENABLE_MODULE_SCHNORRSIG` manually to the compiler (see the file `configure.ac` for supported flags).
+
+#### ABI Compatibility
+
+Due to changes in the API regarding `secp256k1_context_static` described above, the ABI is *not* compatible with previous versions.
 
 ## [0.2.0] - 2022-12-12
 
@@ -49,6 +55,7 @@ This version was in fact never released.
 The number was given by the build system since the introduction of autotools in Jan 2014 (ea0fe5a5bf0c04f9cc955b2966b614f5f378c6f6).
 Therefore, this version number does not uniquely identify a set of source files.
 
-[unreleased]: https://github.com/bitcoin-core/secp256k1/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/bitcoin-core/secp256k1/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/bitcoin-core/secp256k1/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/bitcoin-core/secp256k1/compare/423b6d19d373f1224fd671a982584d7e7900bc93..v0.2.0
 [0.1.0]: https://github.com/bitcoin-core/secp256k1/commit/423b6d19d373f1224fd671a982584d7e7900bc93

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,15 +10,15 @@ endif()
 # The package (a.k.a. release) version is based on semantic versioning 2.0.0 of
 # the API. All changes in experimental modules are treated as
 # backwards-compatible and therefore at most increase the minor version.
-project(libsecp256k1 VERSION 0.2.1 LANGUAGES C)
+project(libsecp256k1 VERSION 0.3.0 LANGUAGES C)
 
 # The library version is based on libtool versioning of the ABI. The set of
 # rules for updating the version can be found here:
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 # All changes in experimental modules are treated as if they don't affect the
 # interface and therefore only increase the revision.
-set(${PROJECT_NAME}_LIB_VERSION_CURRENT 1)
-set(${PROJECT_NAME}_LIB_VERSION_REVISION 1)
+set(${PROJECT_NAME}_LIB_VERSION_CURRENT 2)
+set(${PROJECT_NAME}_LIB_VERSION_REVISION 0)
 set(${PROJECT_NAME}_LIB_VERSION_AGE 0)
 
 set(CMAKE_C_STANDARD 90)

--- a/configure.ac
+++ b/configure.ac
@@ -4,17 +4,17 @@ AC_PREREQ([2.60])
 # the API. All changes in experimental modules are treated as
 # backwards-compatible and therefore at most increase the minor version.
 define(_PKG_VERSION_MAJOR, 0)
-define(_PKG_VERSION_MINOR, 2)
-define(_PKG_VERSION_PATCH, 1)
-define(_PKG_VERSION_IS_RELEASE, false)
+define(_PKG_VERSION_MINOR, 3)
+define(_PKG_VERSION_PATCH, 0)
+define(_PKG_VERSION_IS_RELEASE, true)
 
 # The library version is based on libtool versioning of the ABI. The set of
 # rules for updating the version can be found here:
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 # All changes in experimental modules are treated as if they don't affect the
 # interface and therefore only increase the revision.
-define(_LIB_VERSION_CURRENT, 1)
-define(_LIB_VERSION_REVISION, 1)
+define(_LIB_VERSION_CURRENT, 2)
+define(_LIB_VERSION_REVISION, 0)
 define(_LIB_VERSION_AGE, 0)
 
 AC_INIT([libsecp256k1],m4_join([.], _PKG_VERSION_MAJOR, _PKG_VERSION_MINOR, _PKG_VERSION_PATCH)m4_if(_PKG_VERSION_IS_RELEASE, [true], [], [-dev]),[https://github.com/bitcoin-core/secp256k1/issues],[libsecp256k1],[https://github.com/bitcoin-core/secp256k1])


### PR DESCRIPTION
Based on #1221. The release date is set to tomorrow March 8th. This is a draft because we only want to merge this tomorrow and  make sure to tag the release immediately afterwards. 

`make dist` does not miss files as shown by this diff between the dist tar.gz and a clean checkout of the repo:
```
❯ diff -qr . ../../../secp256k1-clean
Only in .: aclocal.m4
Only in ./build-aux: ar-lib
Only in ./build-aux: compile
Only in ./build-aux: config.guess
Only in ./build-aux: config.sub
Only in ./build-aux: depcomp
Only in ./build-aux: install-sh
Only in ./build-aux: ltmain.sh
Only in ./build-aux/m4: libtool.m4
Only in ./build-aux/m4: lt~obsolete.m4
Only in ./build-aux/m4: ltoptions.m4
Only in ./build-aux/m4: ltsugar.m4
Only in ./build-aux/m4: ltversion.m4
Only in ./build-aux: missing
Only in ./build-aux: test-driver
Files ./CHANGELOG.md and ../../../secp256k1-clean/CHANGELOG.md differ
Only in ../../../secp256k1-clean: ci
Only in ../../../secp256k1-clean: .cirrus.yml
Only in .: configure
Files ./configure.ac and ../../../secp256k1-clean/configure.ac differ
Only in ../../../secp256k1-clean: .git
Only in ../../../secp256k1-clean: .gitattributes
Only in ../../../secp256k1-clean: .gitignore
Only in .: Makefile.in
```