### PR TITLE
cmake: Add dev-mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,7 @@ build-aux/compile
 build-aux/test-driver
 libsecp256k1.pc
 
+### CMake
+/CMakeUserPresets.json
 # Default CMake build directory.
 /build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,19 @@
+{
+  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0}, 
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "dev-mode",
+      "displayName": "Development mode (intended only for developers of the library)",
+      "cacheVariables": {
+        "SECP256K1_EXPERIMENTAL": "ON",
+        "SECP256K1_ENABLE_MODULE_RECOVERY": "ON",
+        "SECP256K1_BUILD_EXAMPLES": "ON"
+      },
+      "warnings": {
+        "dev": true,
+        "uninitialized": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
To use, invoke `cmake` with argument `--preset dev-mode`.

One disadvantage over `./configure --enable-dev-mode` is that CMake does not provide a way to "hide" presets from users. That is, `cmake --list-presets` will list dev-mode, and it will also appear in `cmake-gui`, even though it's not selectable there due to a bug in cmake-gui.

Solves one item in #1224.