### PR TITLE
build: Improve `SECP_TRY_APPEND_DEFAULT_CFLAGS` macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,11 +88,14 @@ esac
 AC_DEFUN([SECP_TRY_APPEND_DEFAULT_CFLAGS], [
     # GCC and compatible (incl. clang)
     if test "x$GCC" = "xyes"; then
-      # Try to append -Werror=unknown-warning-option to CFLAGS temporarily. Otherwise clang will
-      # not error out if it gets unknown warning flags and the checks here will always succeed
-      # no matter if clang knows the flag or not.
+      # Try to append -Werror to CFLAGS temporarily. Otherwise checks for some unsupported
+      # flags will succeed.
+      # Note that failure to append -Werror does not necessarily mean that -Werror is not
+      # supported. The compiler may already be warning about something unrelated, for example
+      # about some path issue. If that is the case, -Werror cannot be used because all
+      # of those warnings would be turned into errors.
       SECP_TRY_APPEND_DEFAULT_CFLAGS_saved_CFLAGS="$CFLAGS"
-      SECP_TRY_APPEND_CFLAGS([-Werror=unknown-warning-option], CFLAGS)
+      SECP_TRY_APPEND_CFLAGS([-Werror], CFLAGS)
 
       SECP_TRY_APPEND_CFLAGS([-std=c89 -pedantic -Wno-long-long -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef], $1) # GCC >= 3.0, -Wlong-long is implied by -pedantic.
       SECP_TRY_APPEND_CFLAGS([-Wno-overlength-strings], $1) # GCC >= 4.2, -Woverlength-strings is implied by -pedantic.


### PR DESCRIPTION
While the `SECP_TRY_APPEND_DEFAULT_CFLAGS` macro works with the current compiler flag set, it is not perfect.

For example, it will accept `-fvisibility-inlines-hidden` flag, which actually causes:
```
cc1: warning: command-line option ‘-fvisibility-inlines-hidden’ is valid for C++/ObjC++ but not for C
```

This PR improves robustness of the `SECP_TRY_APPEND_DEFAULT_CFLAGS` macro.

FWIW, the same approach is used in our [CMake-based](https://github.com/bitcoin-core/secp256k1/blob/427bc3cdcfbc74778070494daab1ae5108c71368/cmake/TryAddCompileOption.cmake#L9) build system, and in [Bitcoin Core](https://github.com/bitcoin/bitcoin/blob/f088949fcfe6ba5000caa2f6adc6803e81925afb/configure.ac#L437-L472).