### PR TITLE
Set ARM ASM symbol visibility to `hidden`

### DIFF
--- a/src/asm/field_10x26_arm.s
+++ b/src/asm/field_10x26_arm.s
@@ -29,6 +29,7 @@ Note:
 	.align	2
 	.global secp256k1_fe_mul_inner
 	.type	secp256k1_fe_mul_inner, %function
+	.hidden secp256k1_fe_mul_inner
 	@ Arguments:
 	@  r0  r      Restrict: can overlap with a, not with b
 	@  r1  a
@@ -516,6 +517,7 @@ secp256k1_fe_mul_inner:
 	.align	2
 	.global secp256k1_fe_sqr_inner
 	.type	secp256k1_fe_sqr_inner, %function
+	.hidden secp256k1_fe_sqr_inner
 	@ Arguments:
 	@  r0  r	 Can overlap with a
 	@  r1  a


### PR DESCRIPTION
Solves one item in #1181.

To test on arm-32bit hardware, run:
```
$ ./autogen.sh && ./configure --enable-experimental --with-asm=arm && make
```

On master branch (427bc3cdcfbc74778070494daab1ae5108c71368):
```
$ nm -D .libs/libsecp256k1.so | grep secp256k1_fe
0000e2bc T secp256k1_fe_mul_inner
0000e8dc T secp256k1_fe_sqr_inner
```

With this PR:
```
$ nm -D .libs/libsecp256k1.so | grep secp256k1_fe | wc -l
0
```

For reference, see https://sourceware.org/binutils/docs/as/Hidden.html.
