### PR TITLE
build: Make `SECP_VALGRIND_CHECK` preserve `CPPFLAGS`

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -21,6 +21,7 @@ if test x"$has_valgrind" != x"yes"; then
     #  error "Valgrind does not support this platform."
     #endif
   ]])], [has_valgrind=yes])
+  CPPFLAGS="$CPPFLAGS_TEMP"
 fi
 AC_MSG_RESULT($has_valgrind)
 ])


### PR DESCRIPTION
It was overlooked in #862 and #1027.