### PR TITLE
test: Silent noisy clang warnings about Valgrind code on macOS x86_64

### DIFF
--- a/src/checkmem.h
+++ b/src/checkmem.h
@@ -58,7 +58,14 @@
 #if !defined SECP256K1_CHECKMEM_ENABLED
 #  if defined VALGRIND
 #    include <stddef.h>
+#  if defined(__clang__) && defined(__APPLE__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wreserved-identifier"
+#  endif
 #    include <valgrind/memcheck.h>
+#  if defined(__clang__) && defined(__APPLE__)
+#    pragma clang diagnostic pop
+#  endif
 #    define SECP256K1_CHECKMEM_ENABLED 1
 #    define SECP256K1_CHECKMEM_UNDEFINE(p, len) VALGRIND_MAKE_MEM_UNDEFINED((p), (len))
 #    define SECP256K1_CHECKMEM_DEFINE(p, len) VALGRIND_MAKE_MEM_DEFINED((p), (len))


### PR DESCRIPTION
Since #1206, on macOS x86_64 with Valgrind installed, clang emits a massive amount of `-Wreserved-identifier` and `-Wreserved-macro-identifier` warnings from the `valgrind/valgrind.h` and `valgrind/memcheck.h` headers.

This PR prevents warnings emitted for the Valgrind code.