### PR TITLE
build: Fix C4005 "macro redefinition" MSVC warnings in examples

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,6 @@ AC_DEFUN([SECP_TRY_APPEND_DEFAULT_CFLAGS], [
     # Note that "/opt" and "-opt" are equivalent for MSVC; we use "-opt" because "/opt" looks like a path.
     if test x"$GCC" != x"yes" && test x"$build_windows" = x"yes"; then
       SECP_TRY_APPEND_CFLAGS([-W2 -wd4146], $1) # Moderate warning level, disable warning C4146 "unary minus operator applied to unsigned type, result still unsigned"
-      SECP_TRY_APPEND_CFLAGS([-external:anglebrackets -external:W0], $1) # Suppress warnings from #include <...> files
       # We pass -ignore:4217 to the MSVC linker to suppress warning 4217 when
       # importing variables from a statically linked secp256k1.
       # (See the libtool manual, section "Windows DLLs" for background.)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,9 +2,6 @@ add_library(example INTERFACE)
 target_include_directories(example INTERFACE
   ${PROJECT_SOURCE_DIR}/include
 )
-target_compile_options(example INTERFACE
-  $<$<C_COMPILER_ID:MSVC>:/wd4005>
-)
 target_link_libraries(example INTERFACE
   $<$<PLATFORM_ID:Windows>:bcrypt>
 )

--- a/examples/examples_util.h
+++ b/examples/examples_util.h
@@ -17,7 +17,13 @@
  */
 
 #if defined(_WIN32)
+/*
+ * The defined WIN32_NO_STATUS macro disables return code definitions in
+ * windows.h, which avoids "macro redefinition" MSVC warnings in ntstatus.h.
+ */
+#define WIN32_NO_STATUS
 #include <windows.h>
+#undef WIN32_NO_STATUS
 #include <ntstatus.h>
 #include <bcrypt.h>
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)


### PR DESCRIPTION
This PR:
- fixes C4005 "macro redefinition" MSVC warnings in examples
- removes warning suppressions in both build systems, Autotools-based and CMake-based ones