### PR TITLE
autotools: Don't regenerate Wycheproof header automatically

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -255,8 +255,8 @@ EXTRA_DIST += tools/tests_wycheproof_generate.py
 
 TESTVECTORS = src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h
 
-src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h: src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
-	python3 tools/tests_wycheproof_generate.py $< > $@
+src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h:
+	python3 tools/tests_wycheproof_generate.py src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json > $@
 
 testvectors: $(TESTVECTORS)
 


### PR DESCRIPTION
This is a hot fix for https://github.com/bitcoin/bitcoin/pull/27445 .

--- 

Pregenerated files that we distribute should not have dependencies in Makefile.am. For rationale, see the comments about the precomputed table files.

See also https://github.com/bitcoin/bitcoin/pull/27445#issuecomment-1502994264 .
