### PR TITLE
autotools: Clean up after adding Wycheproof

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,3 @@
-.PHONY: clean-precomp precomp
-
 ACLOCAL_AMFLAGS = -I build-aux/m4
 
 # AM_CFLAGS will be automatically prepended to CFLAGS by Automake when compiling some foo
@@ -218,10 +216,10 @@ precomp: $(PRECOMP)
 # e.g., after `make maintainer-clean`).
 BUILT_SOURCES = $(PRECOMP)
 
-maintainer-clean-local: clean-precomp
-
+.PHONY: clean-precomp
 clean-precomp:
 	rm -f $(PRECOMP)
+maintainer-clean-local: clean-precomp
 
 ### Pregenerated test vectors
 ### (see the comments in the previous section for detailed rationale)
@@ -234,10 +232,10 @@ testvectors: $(TESTVECTORS)
 
 BUILT_SOURCES += $(TESTVECTORS)
 
-maintainer-clean-local: clean-testvectors
-
+.PHONY: clean-testvectors
 clean-testvectors:
 	rm -f $(TESTVECTORS)
+maintainer-clean-local: clean-testvectors
 
 ### Additional files to distribute
 EXTRA_DIST = autogen.sh CHANGELOG.md SECURITY.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -203,7 +203,7 @@ precompute_ecmult_gen_LDADD = $(COMMON_LIB)
 # otherwise make's decision whether to rebuild them (even in the first
 # build by a normal user) depends on mtimes, and thus is very fragile.
 # This means that rebuilds of the prebuilt files always need to be
-# forced by deleting them, e.g., by invoking `make clean-precomp`.
+# forced by deleting them.
 src/precomputed_ecmult.c:
 	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult$(EXEEXT)
 	./precompute_ecmult$(EXEEXT)
@@ -224,6 +224,7 @@ clean-precomp:
 	rm -f $(PRECOMP)
 
 ### Pregenerated test vectors
+### (see the comments in the previous section for detailed rationale)
 TESTVECTORS = src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h
 
 src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h:
@@ -231,7 +232,9 @@ src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h:
 
 testvectors: $(TESTVECTORS)
 
-maintainer-clean-testvectors: clean-testvectors
+BUILT_SOURCES += $(TESTVECTORS)
+
+maintainer-clean-local: clean-testvectors
 
 clean-testvectors:
 	rm -f $(TESTVECTORS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -226,6 +226,7 @@ maintainer-clean-local: clean-precomp
 TESTVECTORS = src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h
 
 src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h:
+	mkdir -p $(@D)
 	python3 tools/tests_wycheproof_generate.py src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json > $@
 
 testvectors: $(TESTVECTORS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -223,6 +223,20 @@ maintainer-clean-local: clean-precomp
 clean-precomp:
 	rm -f $(PRECOMP)
 
+### Pregenerated test vectors
+TESTVECTORS = src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h
+
+src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h:
+	python3 tools/tests_wycheproof_generate.py src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json > $@
+
+testvectors: $(TESTVECTORS)
+
+maintainer-clean-testvectors: clean-testvectors
+
+clean-testvectors:
+	rm -f $(TESTVECTORS)
+
+### Additional files to distribute
 EXTRA_DIST = autogen.sh CHANGELOG.md SECURITY.md
 EXTRA_DIST += doc/release-process.md doc/safegcd_implementation.md
 EXTRA_DIST += examples/EXAMPLES_COPYING
@@ -232,6 +246,9 @@ EXTRA_DIST += sage/group_prover.sage
 EXTRA_DIST += sage/prove_group_implementations.sage
 EXTRA_DIST += sage/secp256k1_params.sage
 EXTRA_DIST += sage/weierstrass_prover.sage
+EXTRA_DIST += src/wycheproof/WYCHEPROOF_COPYING
+EXTRA_DIST += src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
+EXTRA_DIST += tools/tests_wycheproof_generate.py
 
 if ENABLE_MODULE_ECDH
 include src/modules/ecdh/Makefile.am.include
@@ -248,19 +265,3 @@ endif
 if ENABLE_MODULE_SCHNORRSIG
 include src/modules/schnorrsig/Makefile.am.include
 endif
-
-EXTRA_DIST += src/wycheproof/WYCHEPROOF_COPYING
-EXTRA_DIST += src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
-EXTRA_DIST += tools/tests_wycheproof_generate.py
-
-TESTVECTORS = src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h
-
-src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h:
-	python3 tools/tests_wycheproof_generate.py src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json > $@
-
-testvectors: $(TESTVECTORS)
-
-maintainer-clean-testvectors: clean-testvectors
-
-clean-testvectors:
-	rm -f $(TESTVECTORS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,7 @@ noinst_HEADERS += src/hash_impl.h
 noinst_HEADERS += src/field.h
 noinst_HEADERS += src/field_impl.h
 noinst_HEADERS += src/bench.h
+noinst_HEADERS += src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h
 noinst_HEADERS += contrib/lax_der_parsing.h
 noinst_HEADERS += contrib/lax_der_parsing.c
 noinst_HEADERS += contrib/lax_der_privatekey_parsing.h
@@ -249,7 +250,6 @@ include src/modules/schnorrsig/Makefile.am.include
 endif
 
 EXTRA_DIST += src/wycheproof/WYCHEPROOF_COPYING
-EXTRA_DIST += src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h
 EXTRA_DIST += src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
 EXTRA_DIST += tools/tests_wycheproof_generate.py
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -227,7 +227,7 @@ TESTVECTORS = src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h
 
 src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.h:
 	mkdir -p $(@D)
-	python3 tools/tests_wycheproof_generate.py src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json > $@
+	python3 $(top_srcdir)/tools/tests_wycheproof_generate.py $(top_srcdir)/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json > $@
 
 testvectors: $(TESTVECTORS)
 


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin-core/secp256k1/pull/1245.

This builds on top of https://github.com/bitcoin-core/secp256k1/pull/1276. Let's only merge https://github.com/bitcoin-core/secp256k1/pull/1276 as a hotfix for the Core build.