### PR TITLE
cmake: Some improvements using `PROJECT_IS_TOP_LEVEL` variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,13 +38,14 @@ set(CMAKE_C_EXTENSIONS OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(BUILD_SHARED_LIBS "Build shared libraries." ON)
 option(SECP256K1_DISABLE_SHARED "Disable shared library. Overrides BUILD_SHARED_LIBS." OFF)
 if(SECP256K1_DISABLE_SHARED)
   set(BUILD_SHARED_LIBS OFF)
 endif()
 
-option(SECP256K1_INSTALL "Enable installation" ON)
+include(CMakeDependentOption)
+cmake_dependent_option(SECP256K1_INSTALL "Enable installation." ON "PROJECT_IS_TOP_LEVEL" OFF)
 
 option(SECP256K1_ENABLE_MODULE_ECDH "Enable ECDH module." ON)
 if(SECP256K1_ENABLE_MODULE_ECDH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,18 @@ endif()
 # backwards-compatible and therefore at most increase the minor version.
 project(libsecp256k1 VERSION 0.3.2 LANGUAGES C)
 
+if(CMAKE_VERSION VERSION_LESS 3.21)
+  get_directory_property(parent_directory PARENT_DIRECTORY)
+  if(parent_directory)
+    set(PROJECT_IS_TOP_LEVEL OFF CACHE INTERNAL "Emulates CMake 3.21+ behavior.")
+    set(${PROJECT_NAME}_IS_TOP_LEVEL OFF CACHE INTERNAL "Emulates CMake 3.21+ behavior.")
+  else()
+    set(PROJECT_IS_TOP_LEVEL ON CACHE INTERNAL "Emulates CMake 3.21+ behavior.")
+    set(${PROJECT_NAME}_IS_TOP_LEVEL ON CACHE INTERNAL "Emulates CMake 3.21+ behavior.")
+  endif()
+  unset(parent_directory)
+endif()
+
 # The library version is based on libtool versioning of the ABI. The set of
 # rules for updating the version can be found here:
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,8 @@ endif()
 get_target_property(use_pic secp256k1 POSITION_INDEPENDENT_CODE)
 set_target_properties(secp256k1_precomputed PROPERTIES POSITION_INDEPENDENT_CODE ${use_pic})
 
-target_include_directories(secp256k1 PUBLIC
+target_include_directories(secp256k1 INTERFACE
+  $<BUILD_INTERFACE:$<$<NOT:$<BOOL:${PROJECT_IS_TOP_LEVEL}>>:${PROJECT_SOURCE_DIR}/include>>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 set_target_properties(secp256k1 PROPERTIES


### PR DESCRIPTION
This PR:
1. Emulates [`PROJECT_IS_TOP_LEVEL`](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html) variable for CMake versions where it is not available.
2. Makes the `SECP256K1_INSTALL` option dependent on `PROJECT_IS_TOP_LEVEL` (a [follow up](https://github.com/bitcoin-core/secp256k1/pull/1263#issuecomment-1516564300) of https://github.com/bitcoin-core/secp256k1/pull/1263).
3. Makes integration of this project as a subtree easier. A top project can `#include <secp256k1.h>` with no additional `target_include_directories()` commands. For example, see https://github.com/hebasto/secp256k1-CMake-example/tree/subtree.