### PR TITLE
bench: Make sys/time.h a system include

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -15,7 +15,7 @@
 #if (defined(_MSC_VER) && _MSC_VER >= 1900)
 #  include <time.h>
 #else
-#  include "sys/time.h"
+#  include <sys/time.h>
 #endif
 
 static int64_t gettime_i64(void) {


### PR DESCRIPTION
just because it is minimally more correct