### PR TITLE
Skip unrelated files when using `git archive`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 src/precomputed_ecmult.c linguist-generated
 src/precomputed_ecmult_gen.c linguist-generated
+
+ci/ export-ignore
+.cirrus.yml export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
An option for https://github.com/bitcoin-core/secp256k1/issues/1175:

```sh
$ git fetch origin pull/1287/head
$ git archive --output=libsecp256k1-PR1287.tar.gz FETCH_HEAD 
$ sha256sum libsecp256k1-PR1287.tar.gz 
6e6fd21afd935e572b138258f782fed60bb11fa88aa51a9866f10cca5d25c39c  libsecp256k1-PR1287.tar.gz
$ git archive --output=libsecp256k1-PR1287.zip FETCH_HEAD 
$ sha256sum libsecp256k1-PR1287.zip 
e108fc4902502640eee2cf4bb69501a494904c4dcd0763c072cc4acaed565861  libsecp256k1-PR1287.zip
```