### PR TITLE
refactor: Avoid unary minus on unsigned integers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -397,7 +397,7 @@ task:
     - PowerShell -NoLogo -Command if ($env:CIRRUS_PR -ne $null) { git fetch $env:CIRRUS_REPO_CLONE_URL pull/$env:CIRRUS_PR/merge; git reset --hard FETCH_HEAD; }
   configure_script:
     - '%x64_NATIVE_TOOLS%'
-    - cmake -G "Visual Studio 17 2022" -A x64 -S . -B build -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON
+    - cmake -E env CFLAGS="/WX" cmake -G "Visual Studio 17 2022" -A x64 -S . -B build -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON
   build_script:
     - '%x64_NATIVE_TOOLS%'
     - cmake --build build --config RelWithDebInfo -- -property:UseMultiToolTask=true;CL_MPcount=5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,6 @@ include(TryAppendCFlags)
 if(MSVC)
   # Keep the following commands ordered lexicographically.
   try_append_c_flags(/W2) # Moderate warning level.
-  try_append_c_flags(/wd4146) # Disable warning C4146 "unary minus operator applied to unsigned type, result still unsigned".
 else()
   # Keep the following commands ordered lexicographically.
   try_append_c_flags(-pedantic)

--- a/configure.ac
+++ b/configure.ac
@@ -121,7 +121,7 @@ AC_DEFUN([SECP_TRY_APPEND_DEFAULT_CFLAGS], [
     # libtool makes the same assumption internally.
     # Note that "/opt" and "-opt" are equivalent for MSVC; we use "-opt" because "/opt" looks like a path.
     if test x"$GCC" != x"yes" && test x"$build_windows" = x"yes"; then
-      SECP_TRY_APPEND_CFLAGS([-W2 -wd4146], $1) # Moderate warning level, disable warning C4146 "unary minus operator applied to unsigned type, result still unsigned"
+      SECP_TRY_APPEND_CFLAGS([-W2], $1) # Moderate warning level.
       # We pass -ignore:4217 to the MSVC linker to suppress warning 4217 when
       # importing variables from a statically linked secp256k1.
       # (See the libtool manual, section "Windows DLLs" for background.)

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -1169,7 +1169,7 @@ static SECP256K1_INLINE void secp256k1_fe_half(secp256k1_fe *r) {
     uint32_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4],
              t5 = r->n[5], t6 = r->n[6], t7 = r->n[7], t8 = r->n[8], t9 = r->n[9];
     uint32_t one = (uint32_t)1;
-    uint32_t mask = -(t0 & one) >> 6;
+    uint32_t mask = (0 - (t0 & one)) >> 6;
 
 #ifdef VERIFY
     secp256k1_fe_verify(r);

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -503,7 +503,7 @@ static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_
 static SECP256K1_INLINE void secp256k1_fe_half(secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
     uint64_t one = (uint64_t)1;
-    uint64_t mask = -(t0 & one) >> 12;
+    uint64_t mask = (0 - (t0 & one)) >> 12;
 
 #ifdef VERIFY
     secp256k1_fe_verify(r);

--- a/src/int128_struct_impl.h
+++ b/src/int128_struct_impl.h
@@ -177,7 +177,7 @@ static SECP256K1_INLINE uint64_t secp256k1_i128_to_u64(const secp256k1_int128 *a
 
 static SECP256K1_INLINE int64_t secp256k1_i128_to_i64(const secp256k1_int128 *a) {
    /* Verify that a represents a 64 bit signed value by checking that the high bits are a sign extension of the low bits. */
-   VERIFY_CHECK(a->hi == -(a->lo >> 63));
+   VERIFY_CHECK(a->hi == 0 - (a->lo >> 63));
    return (int64_t)secp256k1_i128_to_u64(a);
 }
 

--- a/src/modinv32_impl.h
+++ b/src/modinv32_impl.h
@@ -195,7 +195,7 @@ static int32_t secp256k1_modinv32_divsteps_30(int32_t zeta, uint32_t f0, uint32_
         VERIFY_CHECK((q * f0 + r * g0) == g << i);
         /* Compute conditional masks for (zeta < 0) and for (g & 1). */
         c1 = zeta >> 31;
-        c2 = -(g & 1);
+        c2 = 0 - (g & 1);
         /* Compute x,y,z, conditionally negated versions of f,u,v. */
         x = (f ^ c1) - c1;
         y = (u ^ c1) - c1;
@@ -285,9 +285,9 @@ static int32_t secp256k1_modinv32_divsteps_30_var(int32_t eta, uint32_t f0, uint
         if (eta < 0) {
             uint32_t tmp;
             eta = -eta;
-            tmp = f; f = g; g = -tmp;
-            tmp = u; u = q; q = -tmp;
-            tmp = v; v = r; r = -tmp;
+            tmp = f; f = g; g = 0 - tmp;
+            tmp = u; u = q; q = 0 - tmp;
+            tmp = v; v = r; r = 0 - tmp;
         }
         /* eta is now >= 0. In what follows we're going to cancel out the bottom bits of g. No more
          * than i can be cancelled out (as we'd be done before that point), and no more than eta+1

--- a/src/modinv64_impl.h
+++ b/src/modinv64_impl.h
@@ -184,7 +184,7 @@ static int64_t secp256k1_modinv64_divsteps_59(int64_t zeta, uint64_t f0, uint64_
         VERIFY_CHECK((q * f0 + r * g0) == g << i);
         /* Compute conditional masks for (zeta < 0) and for (g & 1). */
         c1 = zeta >> 63;
-        c2 = -(g & 1);
+        c2 = 0 - (g & 1);
         /* Compute x,y,z, conditionally negated versions of f,u,v. */
         x = (f ^ c1) - c1;
         y = (u ^ c1) - c1;
@@ -263,9 +263,9 @@ static int64_t secp256k1_modinv64_divsteps_62_var(int64_t eta, uint64_t f0, uint
         if (eta < 0) {
             uint64_t tmp;
             eta = -eta;
-            tmp = f; f = g; g = -tmp;
-            tmp = u; u = q; q = -tmp;
-            tmp = v; v = r; r = -tmp;
+            tmp = f; f = g; g = 0 - tmp;
+            tmp = u; u = q; q = 0 - tmp;
+            tmp = v; v = r; r = 0 - tmp;
             /* Use a formula to cancel out up to 6 bits of g. Also, no more than i can be cancelled
              * out (as we'd be done before that point), and no more than eta+1 can be done as its
              * sign will flip again once that happens. */
@@ -286,7 +286,7 @@ static int64_t secp256k1_modinv64_divsteps_62_var(int64_t eta, uint64_t f0, uint
             /* Find what multiple of f must be added to g to cancel its bottom min(limit, 4)
              * bits. */
             w = f + (((f + 1) & 4) << 1);
-            w = (-w * g) & m;
+            w = ((0 - w) * g) & m;
         }
         g += f * w;
         q += u * w;
@@ -377,7 +377,7 @@ static int64_t secp256k1_modinv64_posdivsteps_62_var(int64_t eta, uint64_t f0, u
             /* Find what multiple of f must be added to g to cancel its bottom min(limit, 4)
              * bits. */
             w = f + (((f + 1) & 4) << 1);
-            w = (-w * g) & m;
+            w = ((0 - w) * g) & m;
         }
         g += f * w;
         q += u * w;

--- a/src/util.h
+++ b/src/util.h
@@ -285,7 +285,7 @@ static SECP256K1_INLINE int secp256k1_ctz32_var_debruijn(uint32_t x) {
         0x10, 0x07, 0x0C, 0x1A, 0x1F, 0x17, 0x12, 0x05, 0x15, 0x09, 0x0F, 0x0B,
         0x1E, 0x11, 0x08, 0x0E, 0x1D, 0x0D, 0x1C, 0x1B
     };
-    return debruijn[(uint32_t)((x & -x) * 0x04D7651FU) >> 27];
+    return debruijn[(uint32_t)((x & (0 - x)) * 0x04D7651FU) >> 27];
 }
 
 /* Determine the number of trailing zero bits in a (non-zero) 64-bit x.
@@ -298,7 +298,7 @@ static SECP256K1_INLINE int secp256k1_ctz64_var_debruijn(uint64_t x) {
         63, 52, 6, 26, 37, 40, 33, 47, 61, 45, 43, 21, 23, 58, 17, 10,
         51, 25, 36, 32, 60, 20, 57, 16, 50, 31, 19, 15, 30, 14, 13, 12
     };
-    return debruijn[(uint64_t)((x & -x) * 0x022FDD63CC95386DU) >> 58];
+    return debruijn[(uint64_t)((x & (0 - x)) * 0x022FDD63CC95386DU) >> 58];
 }
 
 /* Determine the number of trailing zero bits in a (non-zero) 32-bit x. */


### PR DESCRIPTION
The assembly code remains unchanged.

In addition, this PR enables MSVC warning [C4146](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146) for the entire codebase.