### PR TITLE
cmake: Emulate GNU Autotools 'make check -jN'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,15 +228,18 @@ endif()
 
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 
-# Ask CTest to create a "check" target (e.g., make check) as alias for the "test" target.
-# CTEST_TEST_TARGET_ALIAS is not documented but supposed to be user-facing.
-# See: https://gitlab.kitware.com/cmake/cmake/-/commit/816c9d1aa1f2b42d40c81a991b68c96eb12b6d2
-set(CTEST_TEST_TARGET_ALIAS check)
 include(CTest)
 # We do not use CTest's BUILD_TESTING because a single toggle for all tests is too coarse for our needs.
 mark_as_advanced(BUILD_TESTING)
 if(SECP256K1_BUILD_BENCHMARK OR SECP256K1_BUILD_TESTS OR SECP256K1_BUILD_EXHAUSTIVE_TESTS OR SECP256K1_BUILD_CTIME_TESTS OR SECP256K1_BUILD_EXAMPLES)
   enable_testing()
+  if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+    # Emulate GNU Autotools 'make check -jN'.
+    add_custom_target(check
+      COMMAND @$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan \"Running tests...\"
+      COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process -$(MAKEFLAGS)
+    )
+  endif()
 endif()
 
 add_subdirectory(src)


### PR DESCRIPTION
It seems parallelism is requested for `make check` target when building with CMake and the "Unix Makefiles" generator which is the default on Linux and macOS. See:
- https://gnusha.org/secp256k1/2023-03-08.log:
> 13:53 \< sipa\> `make -j check` doesn't actually parallellize in the cmake build, which is a bit unfortunate
- https://github.com/hebasto/bitcoin/pull/15#issuecomment-1531155633:
> Is `make check` being run with multiple jobs? I assume not

With this PR, it is possible to build like that:
```
cmake -S . -B  build
make -C build -j $(nproc)
make check -C build -j $(nproc)
```

Making this PR a draft as it seems low priority and the diff seems a bit hackish.

My personal preference is to use the CMake's native `ctest` command :)

Anyway, this PR fixes an item in https://github.com/bitcoin-core/secp256k1/issues/1235.