### PR TITLE
docs: complete interface description for `secp256k1_schnorrsig_sign_custom`

### DIFF
--- a/include/secp256k1_schnorrsig.h
+++ b/include/secp256k1_schnorrsig.h
@@ -144,9 +144,13 @@ SECP256K1_API int secp256k1_schnorrsig_sign(
  *  Creates the same signatures as schnorrsig_sign if msglen is 32 and the
  *  extraparams.ndata is the same as aux_rand32.
  *
+ *  Returns 1 on success, 0 on failure.
+ *  Args:   ctx: pointer to a context object (not secp256k1_context_static).
+ *  Out:  sig64: pointer to a 64-byte array to store the serialized signature.
  *  In:     msg: the message being signed. Can only be NULL if msglen is 0.
- *       msglen: length of the message
- *  extraparams: pointer to a extraparams object (can be NULL)
+ *       msglen: length of the message.
+ *      keypair: pointer to an initialized keypair.
+ *  extraparams: pointer to an extraparams object (can be NULL).
  */
 SECP256K1_API int secp256k1_schnorrsig_sign_custom(
     const secp256k1_context *ctx,


### PR DESCRIPTION
For the sake of completeness, add the missing descriptions for the return value and parameters (`ctx`, `sig64`, `keypair`), in the same wording/style as for the function `secp256k1_schnorrsig_sign32`.