### PR TITLE
Avoid normalize conditional on VERIFY

### DIFF
--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -279,9 +279,6 @@ static void secp256k1_ecmult_strauss_wnaf(const struct secp256k1_strauss_state *
          */
         tmp = a[np];
         if (no) {
-#ifdef VERIFY
-            secp256k1_fe_normalize_var(&Z);
-#endif
             secp256k1_gej_rescale(&tmp, &Z);
         }
         secp256k1_ecmult_odd_multiples_table(ECMULT_TABLE_SIZE(WINDOW_A), state->pre_a + no * ECMULT_TABLE_SIZE(WINDOW_A), state->aux + no * ECMULT_TABLE_SIZE(WINDOW_A), &Z, &tmp);

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -748,7 +748,9 @@ static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *s) {
     secp256k1_fe zz;
     secp256k1_gej_verify(r);
     secp256k1_fe_verify(s);
-    VERIFY_CHECK(!secp256k1_fe_is_zero(s));
+#ifdef VERIFY
+    VERIFY_CHECK(!secp256k1_fe_normalizes_to_zero_var(s));
+#endif
     secp256k1_fe_sqr(&zz, s);
     secp256k1_fe_mul(&r->x, &r->x, &zz);                /* r->x *= s^2 */
     secp256k1_fe_mul(&r->y, &r->y, &zz);


### PR DESCRIPTION
In the old code, `secp256k1_gej_rescale` requires a normalized input in VERIFY mode, but not otherwise. Its requirements shouldn't depend on this mode being enabled or not.