### PR TITLE
build: Make tests work with external default callbacks

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -10,7 +10,12 @@
 
 #include <time.h>
 
+#ifdef USE_EXTERNAL_DEFAULT_CALLBACKS
+    #pragma message("Ignoring USE_EXTERNAL_CALLBACKS in tests.")
+    #undef USE_EXTERNAL_DEFAULT_CALLBACKS
+#endif
 #include "secp256k1.c"
+
 #include "../include/secp256k1.h"
 #include "../include/secp256k1_preallocated.h"
 #include "testrand_impl.h"

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -13,7 +13,12 @@
 #define EXHAUSTIVE_TEST_ORDER 13
 #endif
 
+#ifdef USE_EXTERNAL_DEFAULT_CALLBACKS
+    #pragma message("Ignoring USE_EXTERNAL_CALLBACKS in exhaustive_tests.")
+    #undef USE_EXTERNAL_DEFAULT_CALLBACKS
+#endif
 #include "secp256k1.c"
+
 #include "../include/secp256k1.h"
 #include "assumptions.h"
 #include "group.h"


### PR DESCRIPTION
Supersedes #971.

After that, we still want to fix the build systems:
benchmarks and examples should be disabled when external callbacks are enabled.