### PR TITLE
ci: Test on development snapshots of GCC and Clang

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,7 +67,7 @@ linux_container_snippet: &LINUX_CONTAINER
 task:
   name: "x86_64: Linux (Debian stable)"
   << : *LINUX_CONTAINER
-  matrix: &ENV_MATRIX
+  matrix:
     - env: {WIDEMUL:  int64,  RECOVERY: yes}
     - env: {WIDEMUL:  int64,                 ECDH: yes, SCHNORRSIG: yes, ELLSWIFT: yes}
     - env: {WIDEMUL: int128}
@@ -122,17 +122,20 @@ task:
     HOMEBREW_NO_INSTALL_CLEANUP: 1
     # Cirrus gives us a fixed number of 4 virtual CPUs. Not that we even have that many jobs at the moment...
     MAKEFLAGS: -j5
-  matrix:
-    << : *ENV_MATRIX
   env:
     ASM: no
     WITH_VALGRIND: no
     CTIMETESTS: no
+    CC: clang
   matrix:
-    - env:
-        CC: gcc
-    - env:
-        CC: clang
+    - env: {WIDEMUL:  int64,  RECOVERY: yes, ECDH: yes, SCHNORRSIG: yes, ELLSWIFT: yes}
+    - env: {WIDEMUL:  int64,  RECOVERY: yes, ECDH: yes, SCHNORRSIG: yes, ELLSWIFT: yes, CC: gcc}
+    - env: {WIDEMUL: int128_struct, ECMULTGENPRECISION: 2, ECMULTWINDOW: 4}
+    - env: {WIDEMUL: int128,                 ECDH: yes, SCHNORRSIG: yes, ELLSWIFT: yes}
+    - env: {WIDEMUL: int128,  RECOVERY: yes,            SCHNORRSIG: yes}
+    - env: {WIDEMUL: int128,  RECOVERY: yes, ECDH: yes, SCHNORRSIG: yes, ELLSWIFT: yes, CC: gcc}
+    - env: {WIDEMUL: int128,  RECOVERY: yes, ECDH: yes, SCHNORRSIG: yes, ELLSWIFT: yes, CPPFLAGS: -DVERIFY}
+    - env: {BUILD: distcheck}
   brew_script:
     - brew install automake libtool gcc
   test_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,7 @@ linux_container_snippet: &LINUX_CONTAINER
     # Gives us more CPUs for free if they're available.
     greedy: true
     # More than enough for our scripts.
-    memory: 1G
+    memory: 2G
 
 task:
   name: "x86_64: Linux (Debian stable)"
@@ -88,6 +88,10 @@ task:
         CC: gcc
     - env:
         CC: clang
+    - env:
+        CC: gcc-snapshot
+    - env:
+        CC: clang-snapshot
   test_script:
     - ./ci/cirrus.sh
   << : *CAT_LOGS

--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -57,7 +57,7 @@ RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.
     ln -s $(ls /usr/bin/clang-?? | sort | tail -1) /usr/bin/clang-snapshot && \
     ln -s $(ls /usr/bin/clang-?? | sort | head -1) /usr/bin/clang
 
-# The "wine" package provides a convience wrapper that we need
+# The "wine" package provides a convenience wrapper that we need
 RUN apt-get update && apt-get install --no-install-recommends -y \
         git ca-certificates wine64 wine python3-simplejson python3-six msitools winbind procps && \
 # Workaround for `wine` package failure to employ the Debian alternatives system properly.

--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stable
 
+SHELL ["/bin/bash", "-c"]
+
 RUN dpkg --add-architecture i386 && \
     dpkg --add-architecture s390x && \
     dpkg --add-architecture armhf && \
@@ -9,7 +11,7 @@ RUN dpkg --add-architecture i386 && \
 # dkpg-dev: to make pkg-config work in cross-builds
 # llvm: for llvm-symbolizer, which is used by clang's UBSan for symbolized stack traces
 RUN apt-get update && apt-get install --no-install-recommends -y \
-        git ca-certificates \
+        git ca-certificates wget \
         make automake libtool pkg-config dpkg-dev valgrind qemu-user \
         gcc clang llvm libclang-rt-dev libc6-dbg \
         g++ \
@@ -23,6 +25,38 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         sagemath
 
 WORKDIR /root
+
+# Build and install gcc snapshot
+ARG GCC_SNAPSHOT_MAJOR=14
+RUN wget --progress=dot:giga --https-only --recursive --accept '*.tar.xz' --level 1 --no-directories "https://gcc.gnu.org/pub/gcc/snapshots/LATEST-${GCC_SNAPSHOT_MAJOR}" && \
+    wget "https://gcc.gnu.org/pub/gcc/snapshots/LATEST-${GCC_SNAPSHOT_MAJOR}/sha512.sum" && \
+    sha512sum --check --ignore-missing sha512.sum && \
+    # We should have downloaded exactly one tar.xz file
+    ls && \
+    [[ $(ls *.tar.xz | wc -l) -eq "1" ]] && \
+    tar xf *.tar.xz && \
+    mkdir gcc-build && cd gcc-build && \
+    apt-get update && apt-get install --no-install-recommends -y libgmp-dev libmpfr-dev libmpc-dev flex && \
+    ../*/configure --prefix=/opt/gcc-snapshot --enable-languages=c --disable-bootstrap --disable-multilib --without-isl && \
+    make -j $(nproc) && \
+    make install && \
+    ln -s /opt/gcc-snapshot/bin/gcc /usr/bin/gcc-snapshot
+
+# Install clang snapshot
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    # Add repository for this Debian release
+    . /etc/os-release && echo "deb http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME} main" >> /etc/apt/sources.list && \
+    # Install clang snapshot
+    apt-get update && apt-get install --no-install-recommends -y clang && \
+    # Remove just the "clang" symlink again
+    apt-get remove -y clang && \
+    # We should have exactly two clang versions now
+    ls /usr/bin/clang* && \
+    [[    $(ls /usr/bin/clang-?? | sort | wc -l) -eq "2" ]] && \
+    # Create symlinks for them
+    ln -s $(ls /usr/bin/clang-?? | sort | tail -1) /usr/bin/clang-snapshot && \
+    ln -s $(ls /usr/bin/clang-?? | sort | head -1) /usr/bin/clang
+
 # The "wine" package provides a convience wrapper that we need
 RUN apt-get update && apt-get install --no-install-recommends -y \
         git ca-certificates wine64 wine python3-simplejson python3-six msitools winbind procps && \


### PR DESCRIPTION
This adds development snapshots of GCC and Clang to our Dockerfile, and -- as a prototype -- checks if CI likes this. I will later add a commit that actually defines some separate jobs.

It's not clear yet if it's a good idea to have these in a Dockerfile, or if this should be a separate Dockerfile, or no Docker CI environment at all. The advantage of the Docker CI environment is that the built Docker images are cached. But that's also the disadvantage. We probably want to rebuild the Docker image from time to time, and we can't do this automatically. The images are cached based [on the contents of the Dockerfile](https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment). I think it's possible to nuke the cache from the web interface, but we'd need to do this on a regular basis then.

Moreover, it's not clear to me yet if these should be run as part of PRs and on master (as currently), or as cron/nightly builds or something else. I lean towards adding a few jobs to the current strategy (PRs+master) because I think moving some builds to nightly is an orthogonal question.
