### PR TITLE
Make fe_cmov take max of magnitudes

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -310,7 +310,9 @@ static void secp256k1_fe_storage_cmov(secp256k1_fe_storage *r, const secp256k1_f
  *
  * On input, both r and a must be valid field elements. Flag must be 0 or 1.
  * Performs {r = flag ? a : r}.
- * On output, r's magnitude and normalized will equal a's in case of flag=1, unchanged otherwise.
+ *
+ * On output, r's magnitude will be the maximum of both input magnitudes.
+ * It will be normalized if and only if both inputs were normalized.
  */
 static void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_fe *a, int flag);
 

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -352,10 +352,8 @@ SECP256K1_INLINE static void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_
     secp256k1_fe_verify(a);
     secp256k1_fe_verify(r);
     secp256k1_fe_impl_cmov(r, a, flag);
-    if (flag) {
-        r->magnitude = a->magnitude;
-        r->normalized = a->normalized;
-    }
+    if (a->magnitude > r->magnitude) r->magnitude = a->magnitude;
+    if (!a->normalized) r->normalized = 0;
     secp256k1_fe_verify(r);
 }
 


### PR DESCRIPTION
This addresses part of #1001.

The magnitude and normalization of the output of `secp256k1_fe_cmov` should not depend on the runtime value of `flag`.