### PR TITLE
ci: Remove quirk that runs dummy command after wineserver

### DIFF
--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -36,8 +36,7 @@ case "$WRAPPER_CMD" in
     *wine*)
         # Make sure to shutdown wineserver whenever we exit.
         trap "wineserver -k || true" EXIT INT HUP
-        # This is apparently only reliable when we run a dummy command such as "hh.exe" afterwards.
-        wineserver -p && wine hh.exe
+        wineserver -p
         ;;
 esac
 


### PR DESCRIPTION
The underlying issue is now worked around in upstream, see https://github.com/mstorsjo/msvc-wine/issues/47 for details.