### PR TITLE
doc: add copyright headers

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,5 @@
 Copyright (c) 2013 Pieter Wuille
+Copyright (c) 2023 Bank of Italy (Frost module)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile.am
+++ b/Makefile.am
@@ -184,3 +184,9 @@ endif
 if ENABLE_MODULE_SCHNORRSIG
 include src/modules/schnorrsig/Makefile.am.include
 endif
+
+# FROST_SPECIFIC - START
+if ENABLE_MODULE_FROST
+include src/modules/frost/Makefile.am.include
+endif
+# FROST_SPECIFIC - END

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ secp256k1-frost
 This repository extends the [secp256k1](https://github.com/bitcoin-core/secp256k1) library to implement FROST,
 a Schnorr threshold signature scheme originally designed by C. Komlo and I. Goldberg.
 
-The codebase of secp256k1-frost is a fork of the [secp256k1](https://github.com/bitcoin-core/secp256k1) repository.
+The codebase of secp256k1-frost is a fork of the [secp256k1](https://github.com/bitcoin-core/secp256k1)
+repository and was originally developed by Bank of Italy as part of the [itcoin project](https://bancaditalia.github.io/itcoin/).
 
 You can find more information about `secp256k1-frost` in the [dedicated README.md](./src/modules/frost/README.md) file.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+secp256k1-frost
+=====================================
+
+This repository extends the [secp256k1](https://github.com/bitcoin-core/secp256k1) library to implement FROST,
+a Schnorr threshold signature scheme originally designed by C. Komlo and I. Goldberg. 
+
+The codebase of secp256k1-frost is a fork of the [secp256k1](https://github.com/bitcoin-core/secp256k1) repository.
+
+You can find more information about `secp256k1-frost` in the [dedicated README.md](./src/modules/frost/README.md) file.
+
+Please note that this software is solely intended for testing and experimentation purposes, and is not ready for use 
+in a production environment.
+
+👇👇👇 That's all for now; hereafter, you find the README.md of the original secp256k1 repository. 👇👇👇
+
 libsecp256k1
 ============
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@ secp256k1-frost
 =====================================
 
 This repository extends the [secp256k1](https://github.com/bitcoin-core/secp256k1) library to implement FROST,
-a Schnorr threshold signature scheme originally designed by C. Komlo and I. Goldberg. 
+a Schnorr threshold signature scheme originally designed by C. Komlo and I. Goldberg.
 
 The codebase of secp256k1-frost is a fork of the [secp256k1](https://github.com/bitcoin-core/secp256k1) repository.
 
 You can find more information about `secp256k1-frost` in the [dedicated README.md](./src/modules/frost/README.md) file.
 
-Please note that this software is solely intended for testing and experimentation purposes, and is not ready for use 
+Please note that this software is solely intended for testing and experimentation purposes, and is not ready for use
 in a production environment.
 
 👇👇👇 That's all for now; hereafter, you find the README.md of the original secp256k1 repository. 👇👇👇

--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,13 @@ AC_ARG_ENABLE(module_schnorrsig,
     [enable_module_schnorrsig=$enableval],
     [enable_module_schnorrsig=no])
 
+# FROST_SPECIFIC - START
+AC_ARG_ENABLE(module_frost,
+    AS_HELP_STRING([--enable-module-frost],[enable FROST module (experimental)]),
+    [enable_module_frost=$enableval],
+    [enable_module_frost=no])
+# FROST_SPECIFIC - END
+
 AC_ARG_ENABLE(external_default_callbacks,
     AS_HELP_STRING([--enable-external-default-callbacks],[enable external default callback functions [default=no]]),
     [use_external_default_callbacks=$enableval],
@@ -327,6 +334,13 @@ if test x"$enable_module_schnorrsig" = x"yes"; then
   enable_module_extrakeys=yes
 fi
 
+# FROST_SPECIFIC - START
+if test x"$enable_module_frost" = x"yes"; then
+  AC_DEFINE(ENABLE_MODULE_FROST, 1, [Define this symbol to enable the FROST module])
+  enable_module_frost=yes
+fi
+# FROST_SPECIFIC - END
+
 # Test if extrakeys is set after the schnorrsig module to allow the schnorrsig
 # module to set enable_module_extrakeys=yes
 if test x"$enable_module_extrakeys" = x"yes"; then
@@ -347,6 +361,7 @@ if test x"$enable_experimental" = x"yes"; then
   AC_MSG_NOTICE([Experimental features do not have stable APIs or properties, and may not be safe for production use.])
   AC_MSG_NOTICE([Building extrakeys module: $enable_module_extrakeys])
   AC_MSG_NOTICE([Building schnorrsig module: $enable_module_schnorrsig])
+  AC_MSG_NOTICE([Building frost module: $enable_module_frost]) # FROST_SPECIFIC
   AC_MSG_NOTICE([******])
 else
   if test x"$enable_module_extrakeys" = x"yes"; then
@@ -355,6 +370,11 @@ else
   if test x"$enable_module_schnorrsig" = x"yes"; then
     AC_MSG_ERROR([schnorrsig module is experimental. Use --enable-experimental to allow.])
   fi
+  # FROST_SPECIFIC - START
+  if test x"$enable_module_frost" = x"yes"; then
+    AC_MSG_ERROR([frost module is experimental. Use --enable-experimental to allow.])
+  fi
+  # FROST_SPECIFIC - END
   if test x"$set_asm" = x"arm"; then
     AC_MSG_ERROR([ARM assembly optimization is experimental. Use --enable-experimental to allow.])
   fi
@@ -379,6 +399,7 @@ AM_CONDITIONAL([ENABLE_MODULE_ECDH], [test x"$enable_module_ecdh" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_RECOVERY], [test x"$enable_module_recovery" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_EXTRAKEYS], [test x"$enable_module_extrakeys" = x"yes"])
 AM_CONDITIONAL([ENABLE_MODULE_SCHNORRSIG], [test x"$enable_module_schnorrsig" = x"yes"])
+AM_CONDITIONAL([ENABLE_MODULE_FROST], [test x"$enable_module_frost" != x"no"]) # FROST_SPECIFIC
 AM_CONDITIONAL([USE_EXTERNAL_ASM], [test x"$use_external_asm" = x"yes"])
 AM_CONDITIONAL([USE_ASM_ARM], [test x"$set_asm" = x"arm"])
 
@@ -399,6 +420,7 @@ echo "  module ecdh             = $enable_module_ecdh"
 echo "  module recovery         = $enable_module_recovery"
 echo "  module extrakeys        = $enable_module_extrakeys"
 echo "  module schnorrsig       = $enable_module_schnorrsig"
+echo "  module frost            = $enable_module_frost" # FROST_SPECIFIC
 echo
 echo "  asm                     = $set_asm"
 echo "  ecmult window size      = $set_ecmult_window"

--- a/include/secp256k1_frost.h
+++ b/include/secp256k1_frost.h
@@ -1,3 +1,9 @@
+/***********************************************************************
+ * Copyright (c) 2023 Bank of Italy                                    *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_FROST_H
 #define SECP256K1_FROST_H
 

--- a/include/secp256k1_frost.h
+++ b/include/secp256k1_frost.h
@@ -1,0 +1,324 @@
+#ifndef SECP256K1_FROST_H
+#define SECP256K1_FROST_H
+
+#include "secp256k1.h"
+#include "secp256k1_extrakeys.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ------ Data structures ------ */
+typedef struct {
+    uint32_t generator_index;
+    uint32_t receiver_index;
+    unsigned char value[32];
+} secp256k1_frost_keygen_secret_share;
+
+typedef struct {
+    unsigned char data[64];
+} secp256k1_frost_vss_commitment;
+
+typedef struct {
+    uint32_t index;
+    uint32_t num_coefficients;
+    secp256k1_frost_vss_commitment *coefficient_commitments;
+    unsigned char zkp_r[64];
+    unsigned char zkp_z[32];
+} secp256k1_frost_vss_commitments;
+
+typedef struct {
+    uint32_t index;
+    unsigned char hiding[64];
+    unsigned char binding[64];
+} secp256k1_frost_nonce_commitment;
+
+typedef struct {
+    int used; /* 1 if true, 0 if false */
+    unsigned char hiding[32];
+    unsigned char binding[32];
+    secp256k1_frost_nonce_commitment commitments;
+} secp256k1_frost_nonce;
+
+typedef struct {
+    uint32_t index;
+    uint32_t max_participants;
+    unsigned char public_key[64];
+    unsigned char group_public_key[64];
+} secp256k1_frost_pubkey;
+
+typedef struct {
+    unsigned char secret[32];
+    secp256k1_frost_pubkey public_keys;
+} secp256k1_frost_keypair;
+
+typedef struct {
+    uint32_t index;
+    unsigned char response[32];
+} secp256k1_frost_signature_share;
+
+/* ------ Keygen-related functions ------ */
+
+/*
+ * Initialize a secp256k1_frost_pubkey using information in secp256k1_frost_keypair.
+ *  Returns 1 on success, 0 on failure.
+ *  Out:   pubkey: pointer to a secp256k1_frost_pubkey to update.
+ *  In:   keypair: pointer to an initialized secp256k1_frost_keypair.
+ */
+SECP256K1_API int secp256k1_frost_pubkey_from_keypair(secp256k1_frost_pubkey *pubkey,
+                                                      const secp256k1_frost_keypair *keypair)
+SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+
+/*
+ * Create a secp256k1 frost vss_commitments object (in dynamically allocated memory).
+ *  This function uses malloc to allocate memory.
+ *
+ *  Returns: a newly created vss_commitments object.
+ *  In:     threshold: minimum number of participants needed to compute a valid signature.
+ */
+SECP256K1_API secp256k1_frost_vss_commitments *secp256k1_frost_vss_commitments_create(uint32_t threshold);
+
+/*
+ * Destroy a secp256k1 vss_commitments object (created in dynamically allocated memory).
+ *
+ *  The vss_commitments pointer should not be used afterwards.
+ *
+ *  The nonce to destroy must have been created using secp256k1_frost_nonce_create.
+ *  Args:   vss_commitments: an existing vss_commitments to destroy,
+ *                           constructed using secp256k1_frost_vss_commitments_create
+ */
+SECP256K1_API void secp256k1_frost_vss_commitments_destroy(secp256k1_frost_vss_commitments *vss_commitments)
+SECP256K1_ARG_NONNULL(1);
+
+/*
+ * Create a secp256k1 frost nonce object (in dynamically allocated memory).
+ *
+ *  This function uses malloc to allocate memory.
+ *
+ *  Returns: a newly created nonce object.
+ *  Args:         ctx: pointer to a context object, initialized for signing.
+ *  In:       keypair: pointer to an initialized keypair.
+ *     binding_seed32: pointer to a 32-byte random seed (NULL resets to initial state)
+ *      hiding_seed32: pointer to a 32-byte random seed (NULL resets to initial state)
+ */
+SECP256K1_API secp256k1_frost_nonce *secp256k1_frost_nonce_create(
+        const secp256k1_context *ctx,
+        const secp256k1_frost_keypair *keypair,
+        const unsigned char *binding_seed32,
+        const unsigned char *hiding_seed32
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+
+/*
+ *  Destroy a secp256k1 nonce object (created in dynamically allocated memory).
+ *
+ *  The context pointer should not be used afterwards.
+ *
+ *  The nonce to destroy must have been created using secp256k1_frost_nonce_create.
+ *  Args:   nonce: an existing nonce to destroy, constructed using
+ *               secp256k1_frost_nonce_create
+ */
+SECP256K1_API void secp256k1_frost_nonce_destroy(secp256k1_frost_nonce *nonce) SECP256K1_ARG_NONNULL(1);
+
+/*
+ * Create a secp256k1 frost keypair object (in dynamically allocated memory).
+ *
+ *  This function uses malloc to allocate memory.
+ *
+ *  Returns: a newly created keypair object.
+ *  Args:         ctx: pointer to a context object, initialized for signing.
+ */
+SECP256K1_API secp256k1_frost_keypair *secp256k1_frost_keypair_create(uint32_t participant_index);
+
+/*
+ * Destroy a secp256k1 frost keypair object (created in dynamically allocated memory).
+ *
+ *  The context pointer should not be used afterwards.
+ *
+ *  The keypair to destroy must have been created using secp256k1_frost_keypair_create.
+ *  Args:   nonce: an existing keypair to destroy, constructed using secp256k1_frost_keypair_create
+ */
+SECP256K1_API void secp256k1_frost_keypair_destroy(secp256k1_frost_keypair *keypair) SECP256K1_ARG_NONNULL(1);
+
+/*
+ * secp256k1_frost_keygen_dkg_begin() is performed by each participant to initialize a Pedersen
+ *
+ * This function assumes there is an additional layer which performs the
+ * distribution of shares to their intended participants.
+ *
+ * Note that while secp256k1_frost_keygen_dkg_begin() returns Shares, these shares
+ * should be sent *after* participants have exchanged commitments via
+ * secp256k1_frost_keygen_dkg_commitment_validate(). So, the caller of
+ * secp256k1_frost_keygen_dkg_begin() should store shares until after
+ * secp256k1_frost_keygen_dkg_commitment_validate() is complete, and then
+ * exchange shares via secp256k1_frost_keygen_dkg_finalize().
+ *
+ *  Returns 1 on success, 0 on failure.
+ *  Args:            ctx: pointer to a context object, initialized for signing.
+ *  Out:  dkg_commitment: pointer to a secp256k1_frost_vss_commitments to store the DKG first phase result.
+ *                shares: pointer to an array of num_shares shares
+ *  In: num_participants: number of participants and shares that will be produced.
+ *             threshold: validity threshold for signatures.
+ *       generator_index: index of the participant running the DKG.
+ *               context: pointer to a char array containing DKG context tag.
+ *        context_length: length of the char array with the DKG context.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_begin(
+        const secp256k1_context *ctx,
+        secp256k1_frost_vss_commitments *dkg_commitment,
+        secp256k1_frost_keygen_secret_share *shares,
+        uint32_t num_participants,
+        uint32_t threshold,
+        uint32_t generator_index,
+        const unsigned char *context,
+        uint32_t context_length
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(7);
+
+/*
+ * secp256k1_frost_keygen_dkg_commitment_validate() gathers commitments from
+ * peers and validates the zero knowledge proof of knowledge for the peer's
+ * secret term. It returns a list of all participants who failed the check, a
+ * list of commitments for the peers that remain in a valid state, and an error
+ * term.
+ *
+ * Here, we return a DKG commitment that is explicitly marked as valid, to
+ * ensure that this step of the protocol is performed before going on to
+ * secp256k1_frost_keygen_dkg_finalize().
+ *
+ * Returns 1 on success, 0 on failure.
+ *  Args:                        ctx: pointer to a context object, initialized for signing.
+ *  In:              peer_commitment: pointer to commitment to validate.
+ *                           context: pointer to a char array containing DKG context tag.
+ *                    context_length: length of the char array with the DKG context.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_commitment_validate(
+        const secp256k1_context *ctx,
+        const secp256k1_frost_vss_commitments *peer_commitment,
+        const unsigned char *context,
+        uint32_t context_length
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+
+/*
+ * secp256k1_frost_keygen_dkg_finalize() finalizes the distributed key generation protocol.
+ * It is performed once per participant.
+ *
+ * Returns 1 on success, 0 on failure.
+ *  Args:            ctx: pointer to a context object, initialized for signing.
+ *  Out:         keypair: pointer to a frost_keypair to store the generated keypairs.
+ *  In:            index: participant index.
+ *      num_participants: number of shares and commitments.
+ *                shares: shares of the current participant.
+ *           commitments: all participants' commitments exchanged during DKG.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_finalize(
+        const secp256k1_context *ctx,
+        secp256k1_frost_keypair *keypair,
+        uint32_t index,
+        uint32_t num_participants,
+        const secp256k1_frost_keygen_secret_share *shares,
+        secp256k1_frost_vss_commitments **commitments
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6);
+
+/*
+ * secp256k1_frost_keygen_with_dealer() allows to create keygen for each participant.
+ * This function is intended to be executed by a trusted dealer that generates and
+ * distributes the secret shares.
+ *
+ *  Returns 1 on success, 0 on failure.
+ *  Args:            ctx: pointer to a context object, initialized for signing.
+ *  Out: share_commitment: pointer to a secp256k1_frost_vss_commitments to store the dealer commitments.
+ *                shares: pointer to an array of num_shares shares
+ *               keypair: pointer to a frost_keypair to store the generated keypairs.
+ *  In: num_participants: number of participants and shares that will be produced.
+ *             threshold: validity threshold for signatures.
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_with_dealer(
+        const secp256k1_context *ctx,
+        secp256k1_frost_vss_commitments *share_commitment,
+        secp256k1_frost_keygen_secret_share *shares,
+        secp256k1_frost_keypair *keypairs,
+        uint32_t num_participants,
+        uint32_t threshold
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
+
+/* ------ Signing-related functions ------ */
+
+/*
+ * Create a FROST signature share.
+ *
+ *  This function only signs 32-byte messages. If you have messages of a
+ *  different size (or the same size but without a context-specific tag
+ *  prefix), it is recommended to create a 32-byte message hash with
+ *  secp256k1_tagged_sha256 and then sign the hash. Tagged hashing allows
+ *  providing a context-specific tag for domain separation. This prevents
+ *  signatures from being valid in multiple contexts by accident.
+ *
+ *  Returns 1 on success, 0 on failure.
+ *  Out:  signature_share: pointer to a 64-byte array to store the serialized signature.
+ *  In:             msg32: the 32-byte message being signed.
+ *                keypair: pointer to an initialized keypair.
+ *                  nonce: pointer to an initialized nonce.
+ */
+SECP256K1_API int secp256k1_frost_sign(
+        secp256k1_frost_signature_share *signature_share,
+        const unsigned char *msg32,
+        uint32_t num_signers,
+        const secp256k1_frost_keypair *keypair,
+        secp256k1_frost_nonce *nonce,
+        secp256k1_frost_nonce_commitment *signing_commitments
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(4)
+SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6);
+
+/*
+ * Combine FROST signature shares to obtain an aggregated signature.
+ *
+ *  This function combines signature shares of 32-byte messages. If you have
+ *  messages of a different size (or the same size but without a context-specific
+ *  tag prefix), it is recommended to create a 32-byte message hash with
+ *  secp256k1_tagged_sha256 and then sign the hash. Tagged hashing allows
+ *  providing a context-specific tag for domain separation. This prevents
+ *  signatures from being valid in multiple contexts by accident.
+ *
+ *  Returns 1 on success, 0 on failure.
+ *  Args:          ctx: pointer to a context object, initialized for signing.
+ *  Out:         sig64: pointer to a 64-byte array to store the serialized signature.
+ *  In:          msg32: the 32-byte message being signed.
+ *             keypair: pointer to an initialized keypair.
+ *         public_keys: pointer to an array of public keys of signers.
+ *         commitments: pointer to an array of commitments.
+ *    signature_shares: pointer to an array of signature shares.
+ *          num_signer: number of signers.
+ */
+SECP256K1_API int secp256k1_frost_aggregate(
+        const secp256k1_context *ctx,
+        unsigned char *sig64,
+        const unsigned char *msg32,
+        const secp256k1_frost_keypair *keypair,
+        const secp256k1_frost_pubkey *public_keys,
+        secp256k1_frost_nonce_commitment *commitments,
+        const secp256k1_frost_signature_share *signature_shares,
+        uint32_t num_signers
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(4)
+SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6) SECP256K1_ARG_NONNULL(7);
+
+/*
+ * Verify a FROST aggregated signature.
+ *
+ *  Returns: 1: correct signature
+ *           0: incorrect signature
+ *  Args:    ctx: a secp256k1 context object, initialized for verification.
+ *  In:    sig64: pointer to the 64-byte signature to verify.
+ *         msg32: the 32-byte length message being verified.
+ *        pubkey: pointer to (group) pubkey (cannot be NULL).
+ */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_verify(
+        const secp256k1_context *ctx,
+        const unsigned char *sig64,
+        const unsigned char *msg32,
+        const secp256k1_frost_pubkey *pubkey
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(4);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SECP256K1_FROST_H */

--- a/src/modules/frost/Makefile.am.include
+++ b/src/modules/frost/Makefile.am.include
@@ -1,0 +1,3 @@
+include_HEADERS += include/secp256k1_frost.h
+noinst_HEADERS += src/modules/frost/main_impl.h
+noinst_HEADERS += src/modules/frost/tests_impl.h

--- a/src/modules/frost/README.md
+++ b/src/modules/frost/README.md
@@ -13,6 +13,8 @@ the [Cryptology ePrint Archive (Paper 2020/852)](https://eprint.iacr.org/2020/85
 
 Currently, FROST is undergoing an IETF standardization process ([status](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/)).
 
+This module was originally developed by Bank of Italy as part of the [itcoin project](https://bancaditalia.github.io/itcoin/).
+
 ## Build
 
 FROST is implemented as a module of the secp256k1 library. Currently, it is an experimental module.

--- a/src/modules/frost/README.md
+++ b/src/modules/frost/README.md
@@ -1,19 +1,19 @@
 # FROST: Flexible Round-Optimized Schnorr Threshold Signatures
 
-This module implements a threshold signature scheme based on the FROST protocol. 
-FROST has been originally designed in 2020 by Chelsea Komlo and Ian Goldberg, who presented it at 
-the 2020 International Conference on Selected Areas in Cryptography. 
+This module implements a threshold signature scheme based on the FROST protocol.
+FROST has been originally designed in 2020 by Chelsea Komlo and Ian Goldberg, who presented it at
+the 2020 International Conference on Selected Areas in Cryptography.
 
 > C. Komlo and I. Goldberg, "FROST: Flexible Round-Optimized Schnorr Threshold Signatures".
 > International Conference on Selected Areas in Cryptography, 2020, Springer.
 > https://doi.org/10.1007/978-3-030-81652-0_2
 
-A technical report describing the protocol with further details is available at 
-the [Cryptology ePrint Archive (Paper 2020/852)](https://eprint.iacr.org/2020/852). 
+A technical report describing the protocol with further details is available at
+the [Cryptology ePrint Archive (Paper 2020/852)](https://eprint.iacr.org/2020/852).
 
 Currently, FROST is undergoing an IETF standardization process ([status](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/)).
-  
-## Build 
+
+## Build
 
 FROST is implemented as a module of the secp256k1 library. Currently, it is an experimental module.
 To enable FROST, configure with `--enable-module-frost`:
@@ -27,23 +27,23 @@ Run the tests:
 
 ## Compliance with the IETF Standardized version of FROST
 
-FROST is an experimental module of the `secp256k1` library. 
+FROST is an experimental module of the `secp256k1` library.
 
 The implemented version follows the design choices of the original [FROST paper](https://eprint.iacr.org/2020/852).
-Later, different versions of FROST appeared in the literature (e.g. [ROAST](https://eprint.iacr.org/2022/550)); among them, the original authors of FROST concentrated their efforts to standardize a version at the [IETF](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/).  
+Later, different versions of FROST appeared in the literature (e.g. [ROAST](https://eprint.iacr.org/2022/550)); among them, the original authors of FROST concentrated their efforts to standardize a version at the [IETF](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/).
 
-In the long term, we would like to release an implementation of FROST fully compliant with the standard. To ease the process of development and adoption, in the following, we keep track of each function defined in the standard, indicating whether the implemented version is fully compliant or not. 
+In the long term, we would like to release an implementation of FROST fully compliant with the standard. To ease the process of development and adoption, in the following, we keep track of each function defined in the standard, indicating whether the implemented version is fully compliant or not.
 
 ### IETF Standard
 
-We refer to [draft v12](https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-12.html) of the IETF standardization proposal of FROST. 
+We refer to [draft v12](https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-12.html) of the IETF standardization proposal of FROST.
 
 #### Helper Functions (Section 4 of IETF Standard)
 
 - [x] nonce_generate(): our implementation expects to receive random 32-byte as a parameter (we want to remove dependencies from random generators);
 - [x] derive_interpolating_value()
 - [x] encode_group_commitment_list(): in our implementation, this function is named `encode_group_commitments()`
-- [x] participants_from_commitment_list(): in our implementation, it is implemented using arrays 
+- [x] participants_from_commitment_list(): in our implementation, it is implemented using arrays
 - [x] binding_factor_for_participant()
 - [x] compute_binding_factors()
 - [x] compute_group_commitment()
@@ -58,35 +58,35 @@ We refer to [draft v12](https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-12
 
 #### Ciphersuite (Section 6 of IETF Standard)
 
-This library only implements `FROST(secp256k1, SHA-256)`. 
+This library only implements `FROST(secp256k1, SHA-256)`.
 - [x] Group: secp256k1
 - [ ] Hash, H1(m): requires hash-to-curve
 - [ ] Hash, H2(m): requires hash-to-curve
 - [ ] Hash, H3(m): requires hash-to-curve
 - [x] Hash, H4(m);
 - [x] Hash, H5(m);
- 
+
 
 ### secp256k1-frost
 
 The `FROST` module of `secp256k1-frost` implements supplementary functions, which are not included in the version of FROST under standardization.
 The following list keeps track of such functions.
 
-#### Keygen 
+#### Keygen
 
-The IETF standard does not include a distributed key generation protocol. 
-This library implements the DKG protocol described in the [FROST paper](https://eprint.iacr.org/2020/852) and implemented 
+The IETF standard does not include a distributed key generation protocol.
+This library implements the DKG protocol described in the [FROST paper](https://eprint.iacr.org/2020/852) and implemented
 by Chelsea Komlo in the prototype [FROST repository](https://git.uwaterloo.ca/ckomlo/frost/).
 
 - secp256k1_frost_keygen_dkg_begin();
 - secp256k1_frost_keygen_dkg_commitment_validate();
 - secp256k1_frost_keygen_dkg_finalize();
 
-#### Signature 
+#### Signature
 
-Our implementation follows BIP-340, which requires using x-only coordinates of points. 
+Our implementation follows BIP-340, which requires using x-only coordinates of points.
 
-- secp256k1_frost_sign(): to follow BIP-340, it adjusts the signature if the group commitment is odd.  
-- secp256k1_frost_aggregate(): differently from the standard, our implementation verifies each signature share before computing the aggregated signature. 
-- secp256k1_frost_aggregate(): to follow BIP-340, it returns the group commitment with even y coordinate. 
+- secp256k1_frost_sign(): to follow BIP-340, it adjusts the signature if the group commitment is odd.
+- secp256k1_frost_aggregate(): differently from the standard, our implementation verifies each signature share before computing the aggregated signature.
+- secp256k1_frost_aggregate(): to follow BIP-340, it returns the group commitment with even y coordinate.
 - secp256k1_frost_verify(): verify an aggregated signature. This is equivalent to a tradition Schnorr verification (e.g., as implemented in `secp256k1_schnorrsig_verify()`)

--- a/src/modules/frost/README.md
+++ b/src/modules/frost/README.md
@@ -1,0 +1,92 @@
+# FROST: Flexible Round-Optimized Schnorr Threshold Signatures
+
+This module implements a threshold signature scheme based on the FROST protocol. 
+FROST has been originally designed in 2020 by Chelsea Komlo and Ian Goldberg, who presented it at 
+the 2020 International Conference on Selected Areas in Cryptography. 
+
+> C. Komlo and I. Goldberg, "FROST: Flexible Round-Optimized Schnorr Threshold Signatures".
+> International Conference on Selected Areas in Cryptography, 2020, Springer.
+> https://doi.org/10.1007/978-3-030-81652-0_2
+
+A technical report describing the protocol with further details is available at 
+the [Cryptology ePrint Archive (Paper 2020/852)](https://eprint.iacr.org/2020/852). 
+
+Currently, FROST is undergoing an IETF standardization process ([status](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/)).
+  
+## Build 
+
+FROST is implemented as a module of the secp256k1 library. Currently, it is an experimental module.
+To enable FROST, configure with `--enable-module-frost`:
+
+    $ ./configure --enable-module-frost --enable-experimental
+
+This library aims to have full coverage of the reachable lines and branches, also for the FROST module.
+Run the tests:
+
+    $ make check
+
+## Compliance with the IETF Standardized version of FROST
+
+FROST is an experimental module of the `secp256k1` library. 
+
+The implemented version follows the design choices of the original [FROST paper](https://eprint.iacr.org/2020/852).
+Later, different versions of FROST appeared in the literature (e.g. [ROAST](https://eprint.iacr.org/2022/550)); among them, the original authors of FROST concentrated their efforts to standardize a version at the [IETF](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/).  
+
+In the long term, we would like to release an implementation of FROST fully compliant with the standard. To ease the process of development and adoption, in the following, we keep track of each function defined in the standard, indicating whether the implemented version is fully compliant or not. 
+
+### IETF Standard
+
+We refer to [draft v12](https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-12.html) of the IETF standardization proposal of FROST. 
+
+#### Helper Functions (Section 4 of IETF Standard)
+
+- [x] nonce_generate(): our implementation expects to receive random 32-byte as a parameter (we want to remove dependencies from random generators);
+- [x] derive_interpolating_value()
+- [x] encode_group_commitment_list(): in our implementation, this function is named `encode_group_commitments()`
+- [x] participants_from_commitment_list(): in our implementation, it is implemented using arrays 
+- [x] binding_factor_for_participant()
+- [x] compute_binding_factors()
+- [x] compute_group_commitment()
+- [ ] compute_challenge(): our implementation follows BIP-340 and initializes SHA256 with fixed midstate (SHA256("BIP0340/challenge")||SHA256("BIP0340/challenge"));
+
+#### Two-Round FROST Signing Protocol (Section 5 of IETF Standard)
+
+- [x] commit(): in our implementation, this function is named `secp256k1_frost_nonce_create()`
+- [x] sign(): in our implementation, this function is named `secp256k1_frost_sign()`
+- [x] aggregate(): in our implementation, this function is named `secp256k1_frost_aggregate()`
+- [x] verify_signature_share()
+
+#### Ciphersuite (Section 6 of IETF Standard)
+
+This library only implements `FROST(secp256k1, SHA-256)`. 
+- [x] Group: secp256k1
+- [ ] Hash, H1(m): requires hash-to-curve
+- [ ] Hash, H2(m): requires hash-to-curve
+- [ ] Hash, H3(m): requires hash-to-curve
+- [x] Hash, H4(m);
+- [x] Hash, H5(m);
+ 
+
+### secp256k1-frost
+
+The `FROST` module of `secp256k1-frost` implements supplementary functions, which are not included in the version of FROST under standardization.
+The following list keeps track of such functions.
+
+#### Keygen 
+
+The IETF standard does not include a distributed key generation protocol. 
+This library implements the DKG protocol described in the [FROST paper](https://eprint.iacr.org/2020/852) and implemented 
+by Chelsea Komlo in the prototype [FROST repository](https://git.uwaterloo.ca/ckomlo/frost/).
+
+- secp256k1_frost_keygen_dkg_begin();
+- secp256k1_frost_keygen_dkg_commitment_validate();
+- secp256k1_frost_keygen_dkg_finalize();
+
+#### Signature 
+
+Our implementation follows BIP-340, which requires using x-only coordinates of points. 
+
+- secp256k1_frost_sign(): to follow BIP-340, it adjusts the signature if the group commitment is odd.  
+- secp256k1_frost_aggregate(): differently from the standard, our implementation verifies each signature share before computing the aggregated signature. 
+- secp256k1_frost_aggregate(): to follow BIP-340, it returns the group commitment with even y coordinate. 
+- secp256k1_frost_verify(): verify an aggregated signature. This is equivalent to a tradition Schnorr verification (e.g., as implemented in `secp256k1_schnorrsig_verify()`)

--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -1,3 +1,9 @@
+/***********************************************************************
+ * Copyright (c) 2023 Bank of Italy                                    *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_MODULE_FROST_MAIN_H
 #define SECP256K1_MODULE_FROST_MAIN_H
 

--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -1,0 +1,1383 @@
+#ifndef SECP256K1_MODULE_FROST_MAIN_H
+#define SECP256K1_MODULE_FROST_MAIN_H
+
+#include <sys/random.h>
+#include "../../../include/secp256k1.h"
+#include "../../../include/secp256k1_frost.h"
+
+static const unsigned char hash_context_prefix[26] = "FROST-secp256k1-SHA256-v11";
+#define SCALAR_SIZE (32U)
+#define SHA256_SIZE (32U)
+#define SERIALIZED_PUBKEY_X_ONLY_SIZE (32U)
+#define SERIALIZED_PUBKEY_XY_SIZE (64U)
+#define ECMULT_CONST_256_BIT_SIZE 256
+
+typedef struct {
+    uint32_t index;
+    uint32_t num_coefficients;
+    secp256k1_scalar *coefficients;
+} shamir_coefficients;
+
+typedef struct {
+    uint32_t num_binding_factors;
+    uint32_t *participant_indexes;
+    secp256k1_scalar *binding_factors;
+    unsigned char **binding_factors_inputs;
+} secp256k1_frost_binding_factors;
+
+typedef struct {
+    secp256k1_gej r;
+    secp256k1_scalar z;
+} secp256k1_frost_signature;
+
+/* *********** *********** Section: Extension of secp256k1 functions *********** *********** */
+static void secp256k1_ge_set_gej_safe(secp256k1_ge *r, const secp256k1_gej *a) {
+    secp256k1_fe z2, z3;
+    secp256k1_gej tmp;
+    r->infinity = a->infinity;
+    secp256k1_fe_inv(&tmp.z, &a->z);
+    secp256k1_fe_sqr(&z2, &tmp.z);
+    secp256k1_fe_mul(&z3, &tmp.z, &z2);
+    secp256k1_fe_mul(&tmp.x, &a->x, &z2);
+    secp256k1_fe_mul(&tmp.y, &a->y, &z3);
+    secp256k1_fe_set_int(&tmp.z, 1);
+    r->x = tmp.x;
+    r->y = tmp.y;
+}
+
+static void secp256k1_gej_mul_scalar(secp256k1_gej *result, const secp256k1_gej *pt, const secp256k1_scalar *sc) {
+    secp256k1_ge pt_ge;
+    secp256k1_ge_set_gej_safe(&pt_ge, pt);
+    secp256k1_ecmult_const(result, &pt_ge, sc, ECMULT_CONST_256_BIT_SIZE);
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_eq(const secp256k1_gej *a, const secp256k1_gej *b) {
+    secp256k1_ge a_ge, b_ge;
+    secp256k1_ge_set_gej_safe(&a_ge, a);
+    secp256k1_ge_set_gej_safe(&b_ge, b);
+    return (secp256k1_fe_equal(&(a_ge.x), &(b_ge.x)) && secp256k1_fe_equal(&(a_ge.y), &(b_ge.y)));
+}
+
+/* *********** *********** End of section: Extension of secp256k1 functions *********** *********** */
+/*
+ * Convert a 32-byte buffer to scalar.
+ * Returns:
+ *  1: if the conversion was successful and no overflow occurred
+ *  0: otherwise
+ */
+static int convert_b32_to_scalar(const unsigned char *hash_value, secp256k1_scalar *output) {
+    int overflow = 0;
+    secp256k1_scalar_set_b32(output, hash_value, &overflow);
+    if (overflow != 0){
+        return 0;
+    }
+    return 1;
+}
+
+static void serialize_point(const secp256k1_gej *point, unsigned char *output64) {
+    secp256k1_ge normalized_point;
+    secp256k1_ge_set_gej_safe(&normalized_point, point);
+    VERIFY_CHECK(!normalized_point.infinity);
+    secp256k1_fe_normalize_var(&normalized_point.x);
+    secp256k1_fe_normalize_var(&normalized_point.y);
+    secp256k1_fe_get_b32(output64, &normalized_point.x);
+    secp256k1_fe_get_b32(output64 + SERIALIZED_PUBKEY_X_ONLY_SIZE, &normalized_point.y);
+}
+
+static void deserialize_point(secp256k1_gej *output, const unsigned char *point64) {
+    secp256k1_ge normalized_point;
+    secp256k1_fe_set_b32(&normalized_point.x, point64);
+    secp256k1_fe_set_b32(&normalized_point.y, point64 + SERIALIZED_PUBKEY_X_ONLY_SIZE);
+    normalized_point.infinity = 0;
+    secp256k1_gej_set_ge(output, &normalized_point);
+}
+
+static void serialize_point_xonly(const secp256k1_gej *point, unsigned char *output) {
+    secp256k1_ge commitment;
+    secp256k1_ge_set_gej_safe(&commitment, point);
+    secp256k1_fe_normalize_var(&(commitment.x));
+    secp256k1_fe_get_b32(output, &(commitment.x));
+}
+
+static void serialize_scalar(const uint32_t value, unsigned char *ret) {
+    secp256k1_scalar value_as_scalar;
+    secp256k1_scalar_set_int(&value_as_scalar, value);
+    secp256k1_scalar_get_b32(ret, &value_as_scalar);
+}
+
+static void serialize_frost_signature(unsigned char *output64,
+                                      const secp256k1_frost_signature *signature) {
+    serialize_point_xonly(&(signature->r), output64);
+    secp256k1_scalar_get_b32(&output64[SERIALIZED_PUBKEY_X_ONLY_SIZE], &(signature->z));
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int deserialize_frost_signature(secp256k1_frost_signature *signature,
+                                        const unsigned char *serialized_signature) {
+    secp256k1_fe x;
+    secp256k1_ge deserialized_point;
+    secp256k1_fe_set_b32(&x, serialized_signature);
+    secp256k1_ge_set_xo_var(&deserialized_point, &x, 0);
+    secp256k1_gej_set_ge(&(signature->r), &deserialized_point);
+    if (convert_b32_to_scalar(&serialized_signature[SERIALIZED_PUBKEY_X_ONLY_SIZE], &(signature->z)) == 0){
+        return 0;
+    }
+    return 1;
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int initialize_random_scalar(secp256k1_scalar *nonce) {
+    /*
+     * simplified from:
+     * https://github.com/bitcoin/bitcoin/blob/747cdf1d652d8587e9f2e3d4436c3ecdbf56d0a5/src/secp256k1/examples/random.h
+     * TODO: If `getrandom(2)` is not available you should fall back to /dev/urandom */
+    unsigned char seed[SCALAR_SIZE];
+    ssize_t random_bytes;
+    random_bytes = getrandom(seed, SCALAR_SIZE, 0);
+    if (random_bytes != SCALAR_SIZE) {
+        return 0;
+    }
+    /* Overflow ignored on purpose */
+    convert_b32_to_scalar(seed, nonce);
+    return 1;
+}
+
+static void compute_sha256(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
+    secp256k1_sha256 sha;
+    secp256k1_sha256_initialize(&sha);
+    secp256k1_sha256_write(&sha, msg, msg_len);
+    secp256k1_sha256_finalize(&sha, hash_value);
+}
+
+static void compute_hash_with_prefix(const unsigned char *prefix, uint32_t prefix_len,
+                                     const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
+    uint32_t ext_msg_len = prefix_len + msg_len;
+    unsigned char *ext_msg = (unsigned char *) checked_malloc(&default_error_callback, ext_msg_len);
+    memcpy(ext_msg, prefix, prefix_len);
+    memcpy(ext_msg + prefix_len, msg, msg_len);
+    compute_sha256(ext_msg, ext_msg_len, hash_value);
+    if (ext_msg != NULL) {
+        free(ext_msg);
+    }
+}
+
+static void compute_hash_h1(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
+    /* TODO: replace with hash-to-curve
+    * H1(m): Implemented using hash_to_field from [HASH-TO-CURVE], Section 5.3 using L = 48,
+    * expand_message_xmd with SHA-256, DST = contextString || "rho", and prime modulus equal to Order(). */
+    unsigned char prefix[26 + 3];
+    memcpy(prefix, hash_context_prefix, 26);
+    memcpy(prefix + 26, "rho", 3);
+    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+}
+
+static void compute_hash_h2(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
+    /* TODO: replace with hash-to-curve
+    * H2(m): Implemented using hash_to_field from [HASH-TO-CURVE], Section 5.2 using L = 48,
+    * expand_message_xmd with SHA-256, DST = contextString || "chal", and prime modulus equal to Order().*/
+    const unsigned char prefix[17] = "BIP0340/challenge";
+    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+}
+
+static void compute_hash_h3(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
+    /* TODO: replace with hash-to-curve
+    * H3(m): Implemented using hash_to_field from [HASH-TO-CURVE], Section 5.2 using L = 48,
+    * expand_message_xmd with SHA-256, DST = contextString || "nonce", and prime modulus equal to Order(). */
+    unsigned char prefix[26 + 5];
+    memcpy(prefix, hash_context_prefix, 26);
+    memcpy(prefix + 26, "nonce", 5);
+    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+}
+
+static void compute_hash_h4(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
+    /* H4(m): Implemented by computing H(contextString || "msg" || m). */
+    unsigned char prefix[26 + 3];
+    memcpy(prefix, hash_context_prefix, 26);
+    memcpy(prefix + 26, "msg", 3);
+    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+}
+
+static void compute_hash_h5(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
+    /* H5(m): Implemented by computing H(contextString || "com" || m */
+    unsigned char prefix[26 + 3];
+    memcpy(prefix, hash_context_prefix, 26);
+    memcpy(prefix + 26, "com", 3);
+    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+}
+
+static void nonce_generate(unsigned char *out32, const secp256k1_frost_keypair *keypair,
+                           const unsigned char *seed32) {
+    unsigned char buffer[64] = {0};
+    if (seed32 != NULL) {
+        memcpy(buffer, seed32, SCALAR_SIZE);
+    }
+    memcpy(buffer + SCALAR_SIZE, keypair->secret, SCALAR_SIZE);
+    compute_hash_h3(buffer, 64, out32);
+    memset(buffer, 0, sizeof(buffer));
+}
+
+SECP256K1_API secp256k1_frost_vss_commitments *secp256k1_frost_vss_commitments_create(uint32_t threshold) {
+    uint32_t num_coefficients;
+    secp256k1_frost_vss_commitments *vss;
+    if (threshold < 1) {
+        return NULL;
+    }
+    num_coefficients = threshold - 1;
+    vss = (secp256k1_frost_vss_commitments *) checked_malloc(&default_error_callback,
+                                                             sizeof(secp256k1_frost_vss_commitments));
+    if (EXPECT(vss == NULL, 0)) {
+        free(vss);
+        return NULL;
+    }
+    vss->index = 0;
+    memset(vss->zkp_z, 0, SCALAR_SIZE);
+    memset(vss->zkp_r, 0, 64);
+
+    vss->num_coefficients = num_coefficients + 1;
+    vss->coefficient_commitments = (secp256k1_frost_vss_commitment *)
+            checked_malloc(&default_error_callback, (num_coefficients + 1) * sizeof(secp256k1_frost_vss_commitment));
+    return vss;
+}
+
+SECP256K1_API void secp256k1_frost_vss_commitments_destroy(secp256k1_frost_vss_commitments *vss_commitments) {
+    if (vss_commitments == NULL) {
+        return;
+    }
+
+    vss_commitments->index = 0;
+    vss_commitments->num_coefficients = 0;
+    memset(vss_commitments->zkp_z, 0, SCALAR_SIZE);
+    memset(vss_commitments->zkp_r, 0, SERIALIZED_PUBKEY_XY_SIZE);
+    free(vss_commitments->coefficient_commitments);
+    free(vss_commitments);
+}
+
+static SECP256K1_WARN_UNUSED_RESULT shamir_coefficients *shamir_coefficients_create(uint32_t threshold) {
+    const uint32_t num_coefficients = threshold - 1;
+    shamir_coefficients *s;
+    s = (shamir_coefficients *) checked_malloc(&default_error_callback,
+                                               sizeof(shamir_coefficients));
+    if (EXPECT(s == NULL, 0)) {
+        free(s);
+        return NULL;
+    }
+    s->index = 0;
+    s->num_coefficients = num_coefficients;
+    s->coefficients = (secp256k1_scalar *)
+            checked_malloc(&default_error_callback, num_coefficients * sizeof(secp256k1_scalar));
+    return s;
+}
+
+static void shamir_coefficients_destroy(shamir_coefficients *coefficients) {
+    if (coefficients == NULL) {
+        return;
+    }
+
+    coefficients->index = 0;
+    coefficients->num_coefficients = 0;
+    free(coefficients->coefficients);
+    free(coefficients);
+}
+
+SECP256K1_API secp256k1_frost_nonce *secp256k1_frost_nonce_create(const secp256k1_context *ctx,
+                                                                  const secp256k1_frost_keypair *keypair,
+                                                                  const unsigned char *binding_seed32,
+                                                                  const unsigned char *hiding_seed32) {
+    secp256k1_scalar hiding, binding;
+    secp256k1_gej hiding_cmt, binding_cmt;
+    secp256k1_frost_nonce *nonce;
+    if (EXPECT(ctx == NULL, 0) || EXPECT(keypair == NULL, 0)
+        || EXPECT(binding_seed32 == NULL, 0) || EXPECT(hiding_seed32 == NULL, 0)) {
+        return NULL;
+    }
+
+    nonce = (secp256k1_frost_nonce *) checked_malloc(&default_error_callback,
+                                                     sizeof(secp256k1_frost_nonce));
+    if (EXPECT(nonce == NULL, 0)) {
+        free(nonce);
+        return NULL;
+    }
+    /* Initialize random nonces */
+    nonce_generate(nonce->binding, keypair, binding_seed32);
+    nonce_generate(nonce->hiding, keypair, hiding_seed32);
+    secp256k1_scalar_set_b32(&binding, nonce->binding, NULL);
+    secp256k1_scalar_set_b32(&hiding, nonce->hiding, NULL);
+
+    /* Compute commitments */
+    (nonce->commitments).index = keypair->public_keys.index;
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &binding_cmt, &binding);
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &hiding_cmt, &hiding);
+    serialize_point(&binding_cmt, nonce->commitments.binding);
+    serialize_point(&hiding_cmt, nonce->commitments.hiding);
+
+    nonce->used = 0;
+    return nonce;
+}
+
+SECP256K1_API void secp256k1_frost_nonce_destroy(secp256k1_frost_nonce *nonce) {
+    if (nonce == NULL) {
+        return;
+    }
+
+    memset(nonce->binding, 0, SCALAR_SIZE);
+    memset(nonce->hiding, 0, SCALAR_SIZE);
+    nonce->commitments.index = 0;
+    memset(nonce->commitments.binding, 0, SERIALIZED_PUBKEY_XY_SIZE);
+    memset(nonce->commitments.hiding, 0, SERIALIZED_PUBKEY_XY_SIZE);
+    free(nonce);
+}
+
+SECP256K1_API secp256k1_frost_keypair *secp256k1_frost_keypair_create(uint32_t participant_index) {
+    secp256k1_frost_keypair *kp = (secp256k1_frost_keypair *) checked_malloc(&default_error_callback,
+                                                                             sizeof(secp256k1_frost_keypair));
+    if (EXPECT(kp == NULL, 0)) {
+        free(kp);
+        return NULL;
+    }
+    kp->public_keys.index = participant_index;
+    memset(kp->secret, 0, SCALAR_SIZE);
+    memset(kp->public_keys.public_key, 0, SERIALIZED_PUBKEY_XY_SIZE);
+    memset(kp->public_keys.group_public_key, 0, SERIALIZED_PUBKEY_XY_SIZE);
+    kp->public_keys.max_participants = 0;
+    return kp;
+}
+
+SECP256K1_API void secp256k1_frost_keypair_destroy(secp256k1_frost_keypair *keypair) {
+    if (keypair == NULL) {
+        return;
+    }
+
+    free(keypair);
+}
+
+/*
+ * Generate coefficients for Shamir Secret Sharing.
+ *
+ *  Returns: 1: on success; 0: on failure
+ *  Args:            ctx: a secp256k1 context object, initialized for verification.
+ *  Out: dkg_commitments: pointer to shamir_coefficients where coefficients will be stored.
+ *          coefficients: pointer to shamir_coefficients where coefficients will be stored.
+ *  In:  generator_index: index of participant generating coefficients.
+ *                secret: secret to be used as known term of the Shamir polynomial
+ *      num_participants: number of participants to the secret sharing
+ *             threshold: min number of participants needed to reconstruct the secret.
+ */
+static SECP256K1_WARN_UNUSED_RESULT int generate_coefficients(const secp256k1_context *ctx,
+                                 secp256k1_frost_vss_commitments *dkg_commitments, shamir_coefficients *coefficients,
+                                 uint32_t generator_index, const secp256k1_scalar *secret, uint32_t threshold) {
+    uint32_t c_idx;
+    secp256k1_gej coefficient_cmt;
+    const uint32_t num_coefficients = threshold - 1;
+
+    coefficients->index = generator_index;
+    dkg_commitments->index = generator_index;
+
+    /* Compute the commitment of the secret term (saved as commitment[0]) */
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &coefficient_cmt, secret);
+    serialize_point(&coefficient_cmt, dkg_commitments->coefficient_commitments[0].data);
+
+    for (c_idx = 0; c_idx < num_coefficients; c_idx++) {
+        /* Generate random coefficients */
+        if (initialize_random_scalar(&(coefficients->coefficients[c_idx])) == 0) {
+            return 0;
+        }
+
+        /* Compute the commitment of each random coefficient (saved as commitment[1...]) */
+        secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx,
+                             &coefficient_cmt,
+                             &(coefficients->coefficients[c_idx]));
+        serialize_point(&coefficient_cmt, dkg_commitments->coefficient_commitments[c_idx + 1].data);
+    }
+    return 1;
+}
+
+/*
+ * Evaluate Shamir polynomial for each participant.
+ *
+ *  Returns: 1: on success; 0: on failure
+ *  Out:   shares: pointer to shamir_coefficients where coefficients will be stored (expected to be already allocated).
+ *  In:   coefficients: pointer to shamir_coefficients where coefficients will be stored.
+ *     generator_index: index of participant generating coefficients.
+ *    num_participants: number of participants to the secret sharing
+ *        coefficients: pointer to shamir_coefficients.
+ *              secret: secret to be used as known term of the Shamir polynomial.
+ */
+static void evaluate_shamir_polynomial(secp256k1_frost_keygen_secret_share *shares,
+                                       uint32_t generator_index, uint32_t num_participants,
+                                       const shamir_coefficients *coefficients, const secp256k1_scalar *secret) {
+    /* For each participant, evaluate the polynomial and save in shares:
+     * {generator_index, participant_index, f(participant_index)} */
+    uint32_t index;
+    for (index = 1; index < num_participants + 1; index++) {
+        /* Evaluate the polynomial with `secret` as the constant term
+         * and `coefficients` as the other coefficients at the point x=share_index
+         * using Horner's method */
+        secp256k1_scalar scalar_index;
+        secp256k1_scalar value;
+        uint32_t c_idx;
+
+        secp256k1_scalar_set_int(&scalar_index, index);
+        secp256k1_scalar_set_int(&value, 0);
+        for (c_idx = coefficients->num_coefficients; c_idx > 0; c_idx--) {
+            secp256k1_scalar_add(&value, &value, &(coefficients->coefficients[c_idx - 1]));
+            secp256k1_scalar_mul(&value, &value, &scalar_index);
+        }
+
+        /* The secret is the *constant* term in the polynomial used for secret sharing,
+         * this is typical in schemes that build upon Shamir Secret Sharing. */
+        secp256k1_scalar_add(&value, &value, secret);
+        secp256k1_scalar_get_b32(shares[index - 1].value, &value);
+
+        shares[index - 1].generator_index = generator_index;
+        shares[index - 1].receiver_index = index;
+    }
+}
+
+/*
+ * Generate a random polynomial f for generator_index, commit to the secret and to each f coefficients,
+ * and f(p) for each participant p
+ *
+ * Returns 1 on success, 0 on failure.
+ *  Args:            ctx: pointer to a context object, initialized for signing.
+ *  Out:    coefficients: commitments to the Shamir polynomial coefficients.
+ *                shares: array containing the polynomial computed for each participant (expected to be allocated)
+ *  In: num_participants: number of shares and commitments.
+ *             threshold: Signature threshold
+ *       generator_index: participant index.
+ *                secret: Secret value to use as constant term of the polynomial
+ */
+static SECP256K1_WARN_UNUSED_RESULT int generate_shares(const secp256k1_context *ctx,
+                           secp256k1_frost_vss_commitments *dkg_commitments,
+                           secp256k1_frost_keygen_secret_share *shares,
+                           uint32_t num_participants, uint32_t threshold, uint32_t generator_index,
+                           const secp256k1_scalar *secret) {
+    int ret_coefficients;
+    shamir_coefficients *coefficients;
+    coefficients = shamir_coefficients_create(threshold);
+
+    ret_coefficients = generate_coefficients(ctx, dkg_commitments, coefficients, generator_index, secret, threshold);
+    if (ret_coefficients == 1) {
+        evaluate_shamir_polynomial(shares, generator_index,
+                                   num_participants, coefficients, secret);
+    }
+
+    shamir_coefficients_destroy(coefficients);
+    return ret_coefficients;
+}
+
+/*
+ * Generate a challenge for DKG.
+ *
+ * Returns 1 on success, 0 on failure.
+ *  Out:  challenge: pointer to scalar where the challenge will be stored.
+ *  In:       index: participant identifier.
+ *    context_nonce: tag to use during DKG
+ *     nonce_length: tag length
+ *       public_key: participant public key used for computing the challenge.
+ *       commitment: commitment to a random value.
+ */
+static SECP256K1_WARN_UNUSED_RESULT int generate_dkg_challenge(secp256k1_scalar *challenge,
+                                  const uint32_t index, const unsigned char *context_nonce, const uint32_t nonce_length,
+                                  const secp256k1_gej *public_key, const secp256k1_gej *commitment) {
+    uint32_t challenge_input_length;
+    unsigned char *challenge_input;
+    unsigned char hash_value[SHA256_SIZE];
+
+    /* challenge_input = commitment || pk || index || context_nonce */
+    challenge_input_length = SERIALIZED_PUBKEY_X_ONLY_SIZE + SERIALIZED_PUBKEY_X_ONLY_SIZE + SCALAR_SIZE + nonce_length;
+    challenge_input = (unsigned char *) checked_malloc(&default_error_callback, challenge_input_length);
+
+    serialize_point_xonly(commitment, challenge_input);
+    serialize_point_xonly(public_key, &(challenge_input[SERIALIZED_PUBKEY_X_ONLY_SIZE]));
+    serialize_scalar(index, &(challenge_input[SERIALIZED_PUBKEY_X_ONLY_SIZE + SERIALIZED_PUBKEY_X_ONLY_SIZE]));
+    memcpy(&challenge_input[SERIALIZED_PUBKEY_X_ONLY_SIZE + SERIALIZED_PUBKEY_X_ONLY_SIZE + SCALAR_SIZE],
+           context_nonce, nonce_length);
+
+    /* compute hash of the challenge_input */
+    compute_sha256(challenge_input, challenge_input_length, hash_value);
+    /* save hash value as scalar (overflow ignored on purpose) */
+    convert_b32_to_scalar(hash_value, challenge);
+
+    /* cleaning out the input buffer */
+    if (challenge_input != NULL) {
+        free(challenge_input);
+    }
+    return 1;
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int is_valid_zkp(const secp256k1_context *ctx, const secp256k1_scalar *challenge,
+                        const secp256k1_frost_vss_commitments *commitment) {
+    secp256k1_gej reference, z_commitment, commitment_challenge, zkp_r, coefficient_commitment;
+    secp256k1_scalar z;
+
+    deserialize_point(&coefficient_commitment, commitment->coefficient_commitments[0].data);
+    secp256k1_scalar_set_b32(&z, commitment->zkp_z, NULL);
+    secp256k1_ecmult_gen(&(ctx->ecmult_gen_ctx), &z_commitment, &z);
+    secp256k1_gej_mul_scalar(&commitment_challenge, &coefficient_commitment, challenge);
+    secp256k1_gej_neg(&commitment_challenge, &commitment_challenge);
+    secp256k1_gej_add_var(&reference, &z_commitment, &commitment_challenge, NULL);
+
+    deserialize_point(&zkp_r, commitment->zkp_r);
+    return secp256k1_gej_eq(&zkp_r, &reference);
+}
+
+/* TODO: to improve testability of this function, it should be deterministic. */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_begin(const secp256k1_context *ctx,
+                                                                                secp256k1_frost_vss_commitments *dkg_commitment,
+                                                                                secp256k1_frost_keygen_secret_share *shares,
+                                                                                uint32_t num_participants,
+                                                                                uint32_t threshold,
+                                                                                uint32_t generator_index,
+                                                                                const unsigned char *context,
+                                                                                uint32_t context_length) {
+    secp256k1_scalar secret, r, z, challenge;
+    secp256k1_gej s_pub, zkp_r;
+
+    if (ctx == NULL || dkg_commitment == NULL || shares == NULL || context == NULL) {
+        return 0;
+    }
+    if (threshold < 1 || num_participants < 1 || threshold > num_participants) {
+        return 0;
+    }
+
+    dkg_commitment->index = generator_index;
+    if (initialize_random_scalar(&secret) == 0) {
+        return 0;
+    }
+    if (generate_shares(ctx, dkg_commitment, shares, num_participants,
+                        threshold, generator_index, &secret) == 0) {
+        return 0;
+    }
+
+    if (initialize_random_scalar(&r) == 0) {
+        return 0;
+    }
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &s_pub, &secret);
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &zkp_r, &r);
+    serialize_point(&zkp_r, dkg_commitment->zkp_r);
+    if (generate_dkg_challenge(&challenge, generator_index, context, context_length, &s_pub, &zkp_r) == 0) {
+        return 0;
+    }
+
+    /* z = r + secret * H(context, G^secret, G^r) */
+    secp256k1_scalar_mul(&z, &secret, &challenge);
+    secp256k1_scalar_add(&z, &r, &z);
+    secp256k1_scalar_get_b32(dkg_commitment->zkp_z, &z);
+
+    /* Cleaning context */
+    secp256k1_scalar_set_int(&secret, 0);
+    secp256k1_scalar_set_int(&r, 0);
+    return 1;
+}
+
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_commitment_validate(
+        const secp256k1_context *ctx,
+        const secp256k1_frost_vss_commitments *peer_commitment,
+        const unsigned char *context, uint32_t context_length) {
+    secp256k1_scalar challenge;
+    secp256k1_gej peer_zkp_r, secret_commitment;
+
+    if (ctx == NULL || peer_commitment == NULL || context == NULL) {
+        return 0;
+    }
+
+    deserialize_point(&peer_zkp_r, peer_commitment->zkp_r);
+    deserialize_point(&secret_commitment, peer_commitment->coefficient_commitments[0].data);
+    if (generate_dkg_challenge(&challenge, peer_commitment->index,
+                           context, context_length,
+                           &secret_commitment,
+                           &peer_zkp_r) == 0) {
+        return 0;
+    }
+    return is_valid_zkp(ctx, &challenge, peer_commitment);
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int verify_secret_share(const secp256k1_context *ctx, const secp256k1_frost_keygen_secret_share *share,
+                               const secp256k1_frost_vss_commitments *commitment) {
+    secp256k1_scalar x, x_to_the_i, scalar_share_value;
+    secp256k1_gej f_result, result;
+    uint32_t index;
+
+    secp256k1_scalar_set_b32(&scalar_share_value, share->value, NULL);
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &f_result, &scalar_share_value);
+
+    secp256k1_scalar_set_int(&x, share->receiver_index);
+    secp256k1_scalar_set_int(&x_to_the_i, 1);
+    secp256k1_gej_clear(&result);
+    secp256k1_gej_mul_scalar(&result, &result, &x_to_the_i);
+
+    for (index = 0; index < commitment->num_coefficients; index++) {
+        secp256k1_gej current;
+        deserialize_point(&current, commitment->coefficient_commitments[index].data);
+        secp256k1_gej_mul_scalar(&current, &current, &x_to_the_i);
+        secp256k1_gej_add_var(&result, &result, &current, NULL);
+        secp256k1_scalar_mul(&x_to_the_i, &x_to_the_i, &x);
+    }
+    return secp256k1_gej_eq(&f_result, &result);
+}
+
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_finalize(
+        const secp256k1_context *ctx,
+        secp256k1_frost_keypair *keypair,
+        uint32_t index,
+        uint32_t num_participants,
+        const secp256k1_frost_keygen_secret_share *shares,
+        secp256k1_frost_vss_commitments **commitments) {
+    uint32_t s_idx, c_idx;
+    secp256k1_scalar scalar_unit, scalar_secret;
+    secp256k1_gej pubkey, group_pubkey;
+
+    if (ctx == NULL || keypair == NULL || shares == NULL || commitments == NULL) {
+        return 0;
+    }
+
+    keypair->public_keys.index = index;
+    for (s_idx = 0; s_idx < num_participants; s_idx++) {
+        for (c_idx = 0; c_idx < num_participants; c_idx++) {
+            if (shares[s_idx].generator_index == commitments[c_idx]->index) {
+                if (verify_secret_share(ctx, &shares[s_idx], commitments[c_idx]) == 0) {
+                    return 0;
+                }
+            }
+        }
+    }
+
+    secp256k1_scalar_set_int(&scalar_secret, 0);
+    for (s_idx = 0; s_idx < num_participants; s_idx++) {
+        secp256k1_scalar scalar_share_value;
+        secp256k1_scalar_set_b32(&scalar_share_value, shares[s_idx].value, NULL);
+        secp256k1_scalar_add(&scalar_secret, &scalar_secret, &scalar_share_value);
+    }
+    secp256k1_scalar_get_b32(keypair->secret, &scalar_secret);
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &pubkey, &scalar_secret);
+    serialize_point(&pubkey, keypair->public_keys.public_key);
+
+    secp256k1_gej_clear(&group_pubkey);
+    secp256k1_scalar_set_int(&scalar_unit, 1);
+    secp256k1_gej_mul_scalar(&group_pubkey,
+                             &group_pubkey, &scalar_unit);
+
+    for (c_idx = 0; c_idx < num_participants; c_idx++) {
+        secp256k1_gej secret_commitment;
+        deserialize_point(&secret_commitment, commitments[c_idx]->coefficient_commitments[0].data);
+        secp256k1_gej_add_var(&group_pubkey, &group_pubkey, &secret_commitment, NULL);
+    }
+    serialize_point(&group_pubkey, keypair->public_keys.group_public_key);
+    keypair->public_keys.max_participants = num_participants;
+    return 1;
+}
+
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_with_dealer(
+        const secp256k1_context *ctx,
+        secp256k1_frost_vss_commitments *share_commitment,
+        secp256k1_frost_keygen_secret_share *shares,
+        secp256k1_frost_keypair *keypairs,
+        uint32_t num_participants,
+        uint32_t threshold) {
+
+    secp256k1_scalar secret;
+    secp256k1_gej group_public_key;
+    uint32_t generator_index, index;
+
+    if (ctx == NULL || share_commitment == NULL || shares == NULL || keypairs == NULL) {
+        return 0;
+    }
+
+    /* We use generator_index=0 as we are generating shares with a dealer */
+    generator_index = 0;
+
+    /* Parameter checking */
+    if (threshold < 1 || num_participants < 1 || threshold > num_participants) {
+        return 0;
+    }
+
+    /* Initialization */
+    share_commitment->index = generator_index;
+    if (initialize_random_scalar(&secret) == 0) {
+        return 0;
+    }
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &group_public_key, &secret);
+
+    /* Generate shares */
+    if (generate_shares(ctx, share_commitment, shares, num_participants,
+                        threshold, generator_index, &secret) == 0) {
+        return 0;
+    }
+
+    /* Preparing output */
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_scalar share_value;
+        secp256k1_gej pubkey;
+
+        secp256k1_scalar_set_b32(&share_value, shares[index].value, NULL);
+        secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &pubkey, &share_value);
+        serialize_point(&pubkey, keypairs[index].public_keys.public_key);
+
+        memcpy(&keypairs[index].secret, &shares[index].value, SCALAR_SIZE);
+        serialize_point(&group_public_key, keypairs[index].public_keys.group_public_key);
+        keypairs[index].public_keys.index = shares[index].receiver_index;
+        keypairs[index].public_keys.max_participants = num_participants;
+    }
+    return 1;
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int signing_commitment_compare(secp256k1_frost_nonce_commitment *s1,
+                                                                   secp256k1_frost_nonce_commitment *s2) {
+    if (s1->index > s2->index) {
+        return 1;
+    }
+    if (s1->index < s2->index) {
+        return -1;
+    }
+    return 0;
+}
+
+static void signing_commitment_swap(secp256k1_frost_nonce_commitment *v1, secp256k1_frost_nonce_commitment *v2) {
+    uint32_t size;
+    secp256k1_frost_nonce_commitment buffer;
+
+    size = sizeof(secp256k1_frost_nonce_commitment);
+    memcpy(&buffer, v1, size);
+    memcpy(v1, v2, size);
+    memcpy(v2, &buffer, size);
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int signing_commitment_partition(secp256k1_frost_nonce_commitment *v, int p, int q) {
+    int i, j;
+    i = p;
+    j = q;
+    while (i <= j) {
+        while (signing_commitment_compare(&v[j], &v[p]) > 0) { j--; }
+        while (i <= j && signing_commitment_compare(&v[i], &v[p]) <= 0) { i++; }
+        if (i < j) {
+            signing_commitment_swap(&v[i], &v[j]);
+            i++;
+            j--;
+        }
+    }
+    signing_commitment_swap(&v[p], &v[j]);
+    return j;
+}
+
+static void signing_commitment_sort(secp256k1_frost_nonce_commitment *v, int p, int q) {
+    int l;
+    l = signing_commitment_partition(v, p, q);
+    if ((l - p) < (q - l)) {
+        if (p < (l - 1)) { signing_commitment_sort(v, p, l - 1); }
+        if ((l + 1) < q) { signing_commitment_sort(v, l + 1, q); }
+    } else {
+        if ((l + 1) < q) { signing_commitment_sort(v, l + 1, q); }
+        if (p < (l - 1)) { signing_commitment_sort(v, p, l - 1); }
+    }
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int compute_group_commitment(/* out */ secp256k1_gej *group_commitment,
+        /* out */ int *is_group_commitment_odd,
+                                              uint32_t num_signers,
+                                              const secp256k1_frost_binding_factors *binding_factors,
+                                              const secp256k1_frost_nonce_commitment *signing_commitments) {
+    secp256k1_scalar scalar_unit;
+    secp256k1_gej hiding_cmt, binding_cmt;
+    uint32_t index, inner_index;
+
+    secp256k1_scalar_set_int(&scalar_unit, 1);
+    secp256k1_gej_clear(group_commitment);
+    secp256k1_gej_mul_scalar(group_commitment, group_commitment, &scalar_unit);
+
+    for (index = 0; index < num_signers; index++) {
+        secp256k1_scalar *rho_i;
+        secp256k1_gej partial;
+        int found;
+        const secp256k1_frost_nonce_commitment *commitment;
+
+        commitment = &signing_commitments[index];
+        found = 0;
+        for (inner_index = 0; inner_index < binding_factors->num_binding_factors; inner_index++) {
+            if (binding_factors->participant_indexes[inner_index] == commitment->index) {
+                rho_i = &binding_factors->binding_factors[inner_index];
+                found = 1;
+                break;
+            }
+        }
+        if (found == 0) {
+            return 0;
+        }
+
+        secp256k1_gej_clear(&partial);
+        secp256k1_gej_mul_scalar(&partial, &partial, &scalar_unit);
+
+        /* group_commitment += commitment.d + (commitment.e * rho_i) */
+        deserialize_point(&hiding_cmt, commitment->hiding);
+        deserialize_point(&binding_cmt, commitment->binding);
+        secp256k1_gej_mul_scalar(&partial, &binding_cmt, rho_i);
+        secp256k1_gej_add_var(&partial, &hiding_cmt, &partial, NULL);
+
+        secp256k1_gej_add_var(group_commitment, group_commitment, &partial, NULL);
+    }
+
+    /*
+     * No matter if we tweaked the public key or not, the nonce commitment
+     * could potentially have an odd y-coordinate which is not acceptable,
+     * since as per BIP-340 the Y coordinate of P (public key) and R (nonce
+     * commitment) are implicitly chosen to be even.
+     * Hence, if nonce_commitment y-coordinate is odd we need to negate it
+    */
+    {
+        secp256k1_ge group_commitment_ge;
+        secp256k1_ge_set_gej_safe(&group_commitment_ge, group_commitment);
+        secp256k1_fe_normalize_var(&group_commitment_ge.y);
+        (*is_group_commitment_odd) = secp256k1_fe_is_odd(&group_commitment_ge.y);
+    };
+    return 1;
+}
+
+static void compute_challenge(secp256k1_scalar *challenge,
+                              const unsigned char *msg, uint32_t msg_len,
+                              const secp256k1_gej *group_public_key,
+                              const secp256k1_gej *group_commitment) {
+    unsigned char buf[SCALAR_SIZE];
+    unsigned char rx[SERIALIZED_PUBKEY_X_ONLY_SIZE];
+    unsigned char pk[SERIALIZED_PUBKEY_X_ONLY_SIZE];
+    secp256k1_sha256 sha;
+
+    serialize_point_xonly(group_commitment, rx);
+    serialize_point_xonly(group_public_key, pk);
+
+    secp256k1_sha256_initialize(&sha);
+    sha.s[0] = 0x9cecba11ul;
+    sha.s[1] = 0x23925381ul;
+    sha.s[2] = 0x11679112ul;
+    sha.s[3] = 0xd1627e0ful;
+    sha.s[4] = 0x97c87550ul;
+    sha.s[5] = 0x003cc765ul;
+    sha.s[6] = 0x90f61164ul;
+    sha.s[7] = 0x33e9b66aul;
+    sha.bytes = 64;
+
+    secp256k1_sha256_write(&sha, rx, SERIALIZED_PUBKEY_X_ONLY_SIZE);
+    secp256k1_sha256_write(&sha, pk, SERIALIZED_PUBKEY_X_ONLY_SIZE);
+    secp256k1_sha256_write(&sha, msg, msg_len);
+    secp256k1_sha256_finalize(&sha, buf);
+    secp256k1_scalar_set_b32(challenge, buf, NULL);
+}
+
+static void encode_group_commitments(
+        /* out */ unsigned char *buffer,
+                  uint32_t num_signers,
+                  const secp256k1_frost_nonce_commitment *signing_commitments) {
+    uint32_t index;
+    uint32_t item_size;
+    uint32_t identifier_idx, hiding_idx, binding_idx;
+    secp256k1_frost_nonce_commitment item;
+
+    index = 0;
+    item_size = (SCALAR_SIZE + SERIALIZED_PUBKEY_X_ONLY_SIZE + SERIALIZED_PUBKEY_X_ONLY_SIZE);
+
+    for (index = 0; index < num_signers; index++) {
+        secp256k1_gej hiding_cmt, binding_cmt;
+        item = signing_commitments[index];
+        identifier_idx = item_size * index;
+        hiding_idx = SCALAR_SIZE + item_size * index;
+        binding_idx = SCALAR_SIZE + SERIALIZED_PUBKEY_X_ONLY_SIZE + item_size * index;
+
+        serialize_scalar(item.index, &(buffer[identifier_idx]));
+        deserialize_point(&hiding_cmt, item.hiding);
+        serialize_point_xonly(&hiding_cmt, &(buffer[hiding_idx]));
+        deserialize_point(&binding_cmt, item.binding);
+        serialize_point_xonly(&binding_cmt, &(buffer[binding_idx]));
+    }
+}
+
+/* TODO: H4(msg) and H5(encoded_group_commitments) is the same for each participant; move in
+ * compute_binding_factors */
+static void compute_binding_factor(
+        /* out */ unsigned char *rho_input,
+        /* out */ secp256k1_scalar *binding_factor,
+                  uint32_t index,
+                  const unsigned char *msg, uint32_t msg_len,
+                  uint32_t num_signers,
+                  const secp256k1_frost_nonce_commitment *signing_commitments) {
+
+    /* Compute H4 of message */
+    unsigned char binding_factor_hash[SHA256_SIZE];
+    uint32_t encoded_group_commitments_size;
+    unsigned char *encoded_group_commitments;
+
+    /* unsigned char rho_input[SHA256_SIZE + SHA256_SIZE + SCALAR_SIZE]; */
+    compute_hash_h4(msg, msg_len, rho_input);
+
+    encoded_group_commitments_size = num_signers * (SCALAR_SIZE +
+                                                    SERIALIZED_PUBKEY_X_ONLY_SIZE + SERIALIZED_PUBKEY_X_ONLY_SIZE);
+    encoded_group_commitments = (unsigned char *) checked_malloc(&default_error_callback,
+                                                                 encoded_group_commitments_size);
+    encode_group_commitments(encoded_group_commitments, num_signers, signing_commitments);
+    compute_hash_h5(encoded_group_commitments, encoded_group_commitments_size, &(rho_input[SHA256_SIZE]));
+
+    /* rho_input = msg_hash || encoded_commitment_hash || serialize_scalar(identifier) */
+    serialize_scalar(index, &(rho_input[SHA256_SIZE + SHA256_SIZE]));
+
+    /* Compute binding factor for participant (index); binding_factor = H.H1(rho_input) */
+    compute_hash_h1(rho_input, SHA256_SIZE + SHA256_SIZE + SCALAR_SIZE, binding_factor_hash);
+
+    /* Convert to scalar (overflow ignored on purpose) */
+    convert_b32_to_scalar(binding_factor_hash, binding_factor);
+
+    free(encoded_group_commitments);
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int compute_binding_factors(/* out */ secp256k1_frost_binding_factors *binding_factors,
+                                             const unsigned char *msg32,
+                                             uint32_t msg_len,
+                                             uint32_t num_signers,
+                                             secp256k1_frost_nonce_commitment *signing_commitments) {
+    uint32_t index;
+    if (num_signers == 0) {
+        return 0;
+    }
+    binding_factors->num_binding_factors = num_signers;
+
+    /* Note: this sorting is performed in place; but this is acceptable. */
+    signing_commitment_sort(signing_commitments, 0, ((int32_t) num_signers) - 1);
+
+    for (index = 0; index < num_signers; index++) {
+        unsigned char rho_input[SHA256_SIZE + SHA256_SIZE + SCALAR_SIZE];
+        compute_binding_factor(rho_input, &(binding_factors->binding_factors[index]),
+                               signing_commitments[index].index, msg32, msg_len,
+                               num_signers, signing_commitments);
+
+        binding_factors->participant_indexes[index] = signing_commitments[index].index;
+        /*TODO: save rho_input in binding_factors; define an allocation strategy */
+    }
+
+    return 1;
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int derive_interpolating_value(/* out */ secp256k1_scalar *lambda_i,
+                                                const uint32_t signer_index,
+                                                uint32_t num_signers,
+                                                const uint32_t *all_signer_indices) {
+    secp256k1_scalar num, den, den_inverse;
+    uint32_t index;
+
+    secp256k1_scalar_set_int(lambda_i, 0);
+    secp256k1_scalar_set_int(&num, 1);
+    secp256k1_scalar_set_int(&den, 1);
+
+    for (index = 0; index < num_signers; ++index) {
+        secp256k1_scalar scalar_j;
+        secp256k1_scalar den_contribution;
+        secp256k1_scalar scalar_signer_index, scalar_signer_index_neg;
+
+        if (all_signer_indices[index] == signer_index) {
+            continue;
+        }
+
+        /* num *= x_j  */
+        secp256k1_scalar_set_int(&scalar_j, all_signer_indices[index]);
+        secp256k1_scalar_mul(&num, &num, &scalar_j);
+
+        /* den *= x_j - signer_index */
+        secp256k1_scalar_set_int(&scalar_j, all_signer_indices[index]);
+        secp256k1_scalar_set_int(&scalar_signer_index, signer_index);
+        secp256k1_scalar_negate(&scalar_signer_index_neg, &scalar_signer_index);
+        secp256k1_scalar_add(&den_contribution, &scalar_j, &scalar_signer_index_neg);
+        secp256k1_scalar_mul(&den, &den, &den_contribution);
+    }
+
+    if (secp256k1_scalar_is_zero(&den)) {
+        return 0;
+    }
+
+    secp256k1_scalar_inverse(&den_inverse, &den);
+    secp256k1_scalar_mul(lambda_i, &num, &den_inverse);
+
+    return 1;
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_sign_internal(/* out: */ secp256k1_frost_signature_share *response,
+                                                    const unsigned char *msg32,
+                                                    uint32_t num_signers,
+                                                    const secp256k1_frost_keypair *keypair,
+                                                    const secp256k1_frost_nonce *nonce,
+                                                    const secp256k1_frost_nonce_commitment *signing_commitments,
+                                                    const secp256k1_frost_binding_factors *bindings) {
+    secp256k1_gej group_commitment, group_pubkey;
+    secp256k1_scalar lambda_i, c, sig_share, term1, term2, secret, hiding, binding;
+    secp256k1_scalar *my_rho_i;
+    int is_group_commitment_odd;
+    uint32_t index;
+
+    /* Compute the group commitment */
+    if (compute_group_commitment(&group_commitment, &is_group_commitment_odd,
+                                 num_signers, bindings, signing_commitments) == 0) {
+        return 0;
+    }
+    /* Compute Lagrange coefficient */
+    if (derive_interpolating_value(&lambda_i, keypair->public_keys.index,
+                                   num_signers, bindings->participant_indexes) == 0) {
+        return 0;
+    }
+
+    /* Compute the per-message challenge */
+    deserialize_point(&group_pubkey, keypair->public_keys.group_public_key);
+    compute_challenge(&c, msg32, 32, &group_pubkey, &(group_commitment));
+
+    /* Compute the signature share */
+    my_rho_i = NULL;
+    for (index = 0; index < num_signers; index++) {
+        if (bindings->participant_indexes[index] == keypair->public_keys.index) {
+            my_rho_i = &(bindings->binding_factors[index]);
+            break;
+        }
+    }
+    if (my_rho_i == NULL) {
+        return 0;
+    }
+    secp256k1_scalar_set_int(&sig_share, 0);
+    secp256k1_scalar_set_b32(&secret, keypair->secret, NULL);
+    secp256k1_scalar_set_b32(&hiding, nonce->hiding, NULL);
+    secp256k1_scalar_set_b32(&binding, nonce->binding, NULL);
+
+    /* z_i = hiding_i + binding_i * rho_i + lambda_i * s_i * c */
+    secp256k1_scalar_mul(&term1, &binding, my_rho_i);
+    secp256k1_scalar_mul(&term2, &lambda_i, &secret);
+    secp256k1_scalar_mul(&term2, &term2, &c);
+    secp256k1_scalar_add(&sig_share, &hiding, &term1);
+    secp256k1_scalar_add(&sig_share, &sig_share, &term2);
+
+    if (is_group_commitment_odd) {
+        /* z_i' = -z_i + 2 * lambda_i * s_i * c */
+        secp256k1_scalar adj;
+        secp256k1_scalar_set_int(&adj, 2);
+        secp256k1_scalar_mul(&adj, &adj, &lambda_i);
+        secp256k1_scalar_mul(&adj, &adj, &secret);
+        secp256k1_scalar_mul(&adj, &adj, &c);
+        secp256k1_scalar_negate(&sig_share, &sig_share);
+        secp256k1_scalar_add(&sig_share, &sig_share, &adj);
+    }
+
+    secp256k1_scalar_get_b32(response->response, &sig_share);
+    response->index = keypair->public_keys.index;
+
+    return 1;
+}
+
+SECP256K1_API int secp256k1_frost_pubkey_from_keypair(secp256k1_frost_pubkey *pubkey,
+                                                      const secp256k1_frost_keypair *keypair) {
+    if (pubkey == NULL || keypair == NULL) {
+        return 0;
+    }
+    pubkey->index = keypair->public_keys.index;
+    pubkey->max_participants = keypair->public_keys.max_participants;
+    memcpy(&pubkey->public_key, &keypair->public_keys.public_key, 64);
+    memcpy(&pubkey->group_public_key, &keypair->public_keys.group_public_key, 64);
+    return 1;
+}
+
+SECP256K1_API int secp256k1_frost_sign(
+        secp256k1_frost_signature_share *signature_share,
+        const unsigned char *msg32,
+        uint32_t num_signers,
+        const secp256k1_frost_keypair *keypair,
+        secp256k1_frost_nonce *nonce,
+        secp256k1_frost_nonce_commitment *signing_commitments) {
+
+    secp256k1_frost_binding_factors binding_factors;
+
+    if (signature_share == NULL || msg32 == NULL || keypair == NULL || nonce == NULL || signing_commitments == NULL) {
+        return 0;
+    }
+    if (num_signers == 0 || num_signers > keypair->public_keys.max_participants) {
+        return 0;
+    }
+
+    if (nonce->used == 1) {
+        return 0;
+    }
+    binding_factors.num_binding_factors = num_signers;
+    binding_factors.binding_factors = (secp256k1_scalar *)
+            checked_malloc(&default_error_callback, num_signers * sizeof(secp256k1_scalar));
+    binding_factors.participant_indexes = (uint32_t *)
+            checked_malloc(&default_error_callback, num_signers * sizeof(uint32_t));
+    binding_factors.binding_factors_inputs =
+            (unsigned char **)
+                    checked_malloc(&default_error_callback, num_signers * sizeof(unsigned char *));
+
+    /* Compute the binding factor(s) */
+    if (compute_binding_factors(&binding_factors, msg32, 32, num_signers, signing_commitments) == 0) {
+        return 0;
+    }
+
+    /* Sign the message */
+    if (secp256k1_frost_sign_internal(signature_share, msg32, num_signers,
+                                      keypair, nonce, signing_commitments,
+                                      &binding_factors) == 0) {
+        return 0;
+    }
+
+    /* Mark nonce as used */
+    /* TODO: remove side effect on nonce */
+    nonce->used = 1;
+
+    /* Free all allocated vars */
+    free(binding_factors.binding_factors);
+    free(binding_factors.binding_factors_inputs); /*FIXME: also the allocated unsigned char *  to be freed */
+    free(binding_factors.participant_indexes);
+
+    return 1;
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int check_commitment_and_response_integrity(
+        const secp256k1_frost_nonce_commitment *commitments,
+                                                   const secp256k1_frost_signature_share *signature_shares,
+                                                   uint32_t num_signers) {
+    uint32_t cmt_index, shr_index, cmt_found;
+    cmt_found = 0;
+
+    for (shr_index = 0; shr_index < num_signers; shr_index++) {
+        cmt_found = 0;
+        for (cmt_index = 0; cmt_index < num_signers; cmt_index++) {
+            if (signature_shares[shr_index].index == commitments[cmt_index].index) {
+                cmt_found = 1;
+                break;
+            }
+        }
+        if (cmt_found == 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int is_signature_response_valid(const secp256k1_context *ctx,
+                                       const secp256k1_frost_signature_share *response,
+                                       const secp256k1_gej *pubkey,
+                                       const secp256k1_scalar *lambda_i,
+                                       const secp256k1_gej *commitment,
+                                       const secp256k1_scalar *challenge) {
+    secp256k1_gej lhs, rhs, partial;
+    secp256k1_scalar cl, resp;
+
+    secp256k1_scalar_set_b32(&resp, response->response, NULL);
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &lhs, &resp);
+    secp256k1_scalar_mul(&cl, challenge, lambda_i);
+    secp256k1_gej_mul_scalar(&partial, pubkey, &cl);
+
+    secp256k1_gej_add_var(&rhs, commitment, &partial, NULL);
+
+    return secp256k1_gej_eq(&lhs, &rhs);
+}
+
+static SECP256K1_WARN_UNUSED_RESULT int verify_signature_share(const secp256k1_context *ctx,
+        /* in */ const secp256k1_frost_signature_share *signature_share,
+                                  const secp256k1_scalar *challenge,
+                                  const secp256k1_frost_binding_factors *binding_factors,
+                                  const secp256k1_frost_nonce_commitment *commitments,
+                                  const secp256k1_frost_pubkey *public_keys,
+                                  int is_group_commitment_odd,
+                                  uint32_t num_signers) {
+    const secp256k1_frost_nonce_commitment *matching_commitment = NULL;
+    secp256k1_gej signer_pubkey;
+    secp256k1_gej partial, commitment_i, hiding_cmt, binding_cmt;
+    secp256k1_scalar lambda_i;
+    secp256k1_scalar *matching_rho_i;
+    uint32_t index;
+    int found;
+
+    /* Get the binding factor by participant index of the signature share */
+    found = 0;
+    for (index = 0; index < binding_factors->num_binding_factors; index++) {
+        if (binding_factors->participant_indexes[index] == signature_share->index) {
+            matching_rho_i = &(binding_factors->binding_factors[index]);
+            found = 1;
+            break;
+        }
+    }
+    if (found == 0) {
+        /* No matching binding factors for this response */
+        return 0;
+    }
+
+    /* Compute Lagrange coefficient */
+    if (derive_interpolating_value(&lambda_i,
+                                   signature_share->index, num_signers,
+                                   binding_factors->participant_indexes) == 0) {
+        return 0;
+    }
+
+    /* Retrieve signing commitment by participant index  */
+    found = 0;
+    for (index = 0; index < num_signers; index++) {
+        if (commitments[index].index == signature_share->index) {
+            matching_commitment = &(commitments[index]);
+            found = 1;
+            break;
+        }
+    }
+    if (found == 0) {
+        /* No matching commitment for response */
+        return 0;
+    }
+
+    /* Retrieve signer pubkey by participant index  */
+    found = 0;
+    for (index = 0; index < num_signers; index++) {
+        if (public_keys[index].index == matching_commitment->index) {
+            deserialize_point(&signer_pubkey, public_keys[index].public_key);
+            found = 1;
+            break;
+        }
+    }
+    if (found == 0) {
+        /* Commitment does not have a matching signer public key */
+        return 0;
+    }
+
+    /* Compute the commitment share */
+    deserialize_point(&hiding_cmt, matching_commitment->hiding);
+    deserialize_point(&binding_cmt, matching_commitment->binding);
+    secp256k1_gej_mul_scalar(&partial, &binding_cmt, matching_rho_i);
+    secp256k1_gej_add_var(&commitment_i, &hiding_cmt, &partial, NULL);
+
+    if (is_group_commitment_odd == 1) {
+        secp256k1_gej_neg(&commitment_i, &commitment_i);
+    }
+
+    if (is_signature_response_valid(ctx, signature_share, &signer_pubkey,
+                                    &lambda_i, &commitment_i, challenge) == 0) {
+        return 0;
+    }
+    return 1;
+}
+
+static void free_binding_factors(secp256k1_frost_binding_factors *binding_factors) {
+    /* Free all allocated vars */
+    free(binding_factors->binding_factors);
+    free(binding_factors->binding_factors_inputs);
+    free(binding_factors->participant_indexes);
+}
+
+SECP256K1_API int secp256k1_frost_aggregate(const secp256k1_context *ctx,
+        /* out: */ unsigned char *sig64,
+                                            const unsigned char *msg32,
+                                            const secp256k1_frost_keypair *keypair,
+                                            const secp256k1_frost_pubkey *public_keys,
+                                            secp256k1_frost_nonce_commitment *commitments,
+                                            const secp256k1_frost_signature_share *signature_shares,
+                                            uint32_t num_signers) {
+    secp256k1_frost_binding_factors binding_factors;
+    secp256k1_frost_signature aggregated_signature;
+    secp256k1_scalar challenge;
+    secp256k1_gej group_pubkey;
+    int is_group_commitment_odd;
+    uint32_t index;
+
+    if (ctx == NULL || sig64 == NULL || msg32 == NULL || keypair == NULL || public_keys == NULL ||
+        commitments == NULL || signature_shares == NULL) {
+        return 0;
+    }
+
+    if (num_signers > keypair->public_keys.max_participants) {
+        return 0;
+    }
+
+    if (check_commitment_and_response_integrity(commitments, signature_shares, num_signers) == 0) {
+        return 0;
+    }
+
+    binding_factors.num_binding_factors = num_signers;
+    binding_factors.binding_factors = (secp256k1_scalar *)
+            checked_malloc(&default_error_callback, num_signers * sizeof(secp256k1_scalar));
+    binding_factors.participant_indexes = (uint32_t *)
+            checked_malloc(&default_error_callback, num_signers * sizeof(uint32_t));
+    binding_factors.binding_factors_inputs =
+            (unsigned char **)
+                    checked_malloc(&default_error_callback, num_signers * sizeof(unsigned char *));
+
+    /* Compute the binding factor(s) */
+    if (compute_binding_factors(&binding_factors, msg32, 32, num_signers, commitments) == 0) {
+        return 0;
+    }
+
+    /* Compute the group commitment */
+    if (compute_group_commitment(&(aggregated_signature.r), &is_group_commitment_odd,
+                                 num_signers, &binding_factors, commitments) == 0) {
+        free_binding_factors(&binding_factors);
+        return 0;
+    }
+
+    /* Compute message-based challenge */
+    deserialize_point(&group_pubkey, keypair->public_keys.group_public_key);
+    compute_challenge(&challenge, msg32, 32, &group_pubkey, &(aggregated_signature.r));
+
+    /* check the validity of each participant's response */
+    for (index = 0; index < num_signers; index++) {
+        if (verify_signature_share(ctx,
+                                   &signature_shares[index],
+                                   &challenge,
+                                   &binding_factors,
+                                   commitments,
+                                   public_keys,
+                                   is_group_commitment_odd,
+                                   num_signers) == 0) {
+            free_binding_factors(&binding_factors);
+            return 0;
+        }
+
+    }
+
+    /* Aggregate signature shares */
+    secp256k1_scalar_set_int(&(aggregated_signature.z), 0);
+
+    for (index = 0; index < num_signers; index++) {
+        secp256k1_scalar part_response;
+        secp256k1_scalar_set_b32(&part_response, signature_shares[index].response, NULL);
+        secp256k1_scalar_add(&(aggregated_signature.z), &(aggregated_signature.z), &part_response);
+    }
+
+    if (is_group_commitment_odd) {
+        secp256k1_gej_neg(&(aggregated_signature.r), &(aggregated_signature.r));
+    }
+
+    /* Serialize aggregated signature */
+    serialize_frost_signature(sig64, &aggregated_signature);
+
+    /* Free all allocated vars */
+    free_binding_factors(&binding_factors);
+
+    return 1;
+}
+
+/* TODO: this function can be removed, because aggregated signatures can be
+ * already verified using Schnorr verification */
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_verify(
+        const secp256k1_context *ctx,
+        const unsigned char *sig64,
+        const unsigned char *msg32,
+        const secp256k1_frost_pubkey *pubkey) {
+
+    secp256k1_scalar challenge;
+    secp256k1_gej term1, rhs, term2, term2_neg, group_pubkey;
+    secp256k1_frost_signature aggregated_signature;
+
+    if (ctx == NULL || sig64 == NULL || msg32 == NULL || pubkey == NULL) {
+        return 0;
+    }
+
+    /* Deserialize frost signature */
+    if (deserialize_frost_signature(&aggregated_signature, sig64) == 0) {
+        return 0;
+    }
+
+    /* Compute message-based challenge */
+    deserialize_point(&group_pubkey, pubkey->group_public_key);
+    compute_challenge(&challenge, msg32, 32, &group_pubkey, &(aggregated_signature.r));
+
+    /* sig.r ?= (G * sig.z) - (pubkey * challenge) */
+    secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &term1, &(aggregated_signature.z));
+    secp256k1_gej_mul_scalar(&term2, &group_pubkey, &challenge);
+    secp256k1_gej_neg(&term2_neg, &term2);
+    secp256k1_gej_add_var(&rhs, &term1, &term2_neg, NULL);
+
+    return secp256k1_gej_eq(&(aggregated_signature.r), &rhs);
+}
+
+#endif /* SECP256K1_MODULE_FROST_MAIN_H */

--- a/src/modules/frost/tests_impl.h
+++ b/src/modules/frost/tests_impl.h
@@ -1,3 +1,9 @@
+/***********************************************************************
+ * Copyright (c) 2023 Bank of Italy                                    *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_MODULE_FROST_TESTS_H
 #define SECP256K1_MODULE_FROST_TESTS_H
 

--- a/src/modules/frost/tests_impl.h
+++ b/src/modules/frost/tests_impl.h
@@ -1,0 +1,3130 @@
+#ifndef SECP256K1_MODULE_FROST_TESTS_H
+#define SECP256K1_MODULE_FROST_TESTS_H
+
+#include "../../../include/secp256k1_frost.h"
+
+
+void test_secp256k1_gej_eq_case_1(void) {
+    secp256k1_gej a, b;
+    secp256k1_ge a_ge, b_ge;
+    secp256k1_fe x1_fe, y1_fe, x2_fe, y2_fe;
+    secp256k1_ge_clear(&a_ge);
+    secp256k1_ge_clear(&b_ge);
+    secp256k1_fe_set_int(&x1_fe, 1);
+    secp256k1_fe_set_int(&y1_fe, 1);
+    secp256k1_fe_set_int(&x2_fe, 1);
+    secp256k1_fe_set_int(&y2_fe, 1);
+    secp256k1_ge_set_xy(&a_ge, &x1_fe, &y1_fe);
+    secp256k1_ge_set_xy(&b_ge, &x2_fe, &y2_fe);
+    secp256k1_gej_set_ge(&a, &a_ge);
+    secp256k1_gej_set_ge(&b, &b_ge);
+    CHECK(secp256k1_gej_eq(&a, &b) == 1);
+}
+
+void test_secp256k1_gej_eq_case_2(void) {
+    secp256k1_gej a, b;
+    secp256k1_ge a_ge, b_ge;
+    secp256k1_fe x1_fe, y1_fe, x2_fe, y2_fe;
+    secp256k1_ge_clear(&a_ge);
+    secp256k1_ge_clear(&b_ge);
+    secp256k1_fe_set_int(&x1_fe, 1);
+    secp256k1_fe_set_int(&y1_fe, 1);
+    secp256k1_fe_set_int(&x2_fe, 1);
+    secp256k1_fe_set_int(&y2_fe, 2);
+    secp256k1_ge_set_xy(&a_ge, &x1_fe, &y1_fe);
+    secp256k1_ge_set_xy(&b_ge, &x2_fe, &y2_fe);
+    secp256k1_gej_set_ge(&a, &a_ge);
+    secp256k1_gej_set_ge(&b, &b_ge);
+    CHECK(secp256k1_gej_eq(&a, &b) == 0);
+}
+
+void test_secp256k1_gej_eq_case_3(void) {
+    secp256k1_gej a, b;
+    secp256k1_ge a_ge, b_ge;
+    secp256k1_fe x1_fe, y1_fe, x2_fe, y2_fe;
+    secp256k1_ge_clear(&a_ge);
+    secp256k1_ge_clear(&b_ge);
+    secp256k1_fe_set_int(&x1_fe, 1);
+    secp256k1_fe_set_int(&y1_fe, 1);
+    secp256k1_fe_set_int(&x2_fe, 2);
+    secp256k1_fe_set_int(&y2_fe, 1);
+    secp256k1_ge_set_xy(&a_ge, &x1_fe, &y1_fe);
+    secp256k1_ge_set_xy(&b_ge, &x2_fe, &y2_fe);
+    secp256k1_gej_set_ge(&a, &a_ge);
+    secp256k1_gej_set_ge(&b, &b_ge);
+    CHECK(secp256k1_gej_eq(&a, &b) == 0);
+}
+
+void test_secp256k1_gej_eq_case_4(void) {
+    secp256k1_gej a, b;
+    secp256k1_ge a_ge, b_ge;
+    secp256k1_fe x1_fe, y1_fe, x2_fe, y2_fe;
+    secp256k1_ge_clear(&a_ge);
+    secp256k1_ge_clear(&b_ge);
+    secp256k1_fe_set_int(&x1_fe, 1);
+    secp256k1_fe_set_int(&y1_fe, 1);
+    secp256k1_fe_set_int(&x2_fe, 2);
+    secp256k1_fe_set_int(&y2_fe, 2);
+    secp256k1_ge_set_xy(&a_ge, &x1_fe, &y1_fe);
+    secp256k1_ge_set_xy(&b_ge, &x2_fe, &y2_fe);
+    secp256k1_gej_set_ge(&a, &a_ge);
+    secp256k1_gej_set_ge(&b, &b_ge);
+    CHECK(secp256k1_gej_eq(&a, &b) == 0);
+}
+
+void test_nonce_generate_with_seed(void) {
+    unsigned char buffer[32] = {0};
+    unsigned char check[32] = {0};
+    unsigned char seed[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    uint32_t index;
+    int init;
+    secp256k1_frost_keypair keypair;
+    memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+    nonce_generate(buffer, &keypair, seed);
+    init = 0;
+    for (index = 0; index < 32; index++) {
+        if (buffer[index] != check[index]) {
+            init = 1;
+            break;
+        }
+    }
+    CHECK(init == 1);
+}
+
+void test_nonce_generate_with_no_seed(void) {
+    unsigned char buffer[32] = {0};
+    unsigned char check[32] = {0};
+    unsigned char *seed = NULL;
+    uint32_t index;
+    int init;
+    secp256k1_frost_keypair keypair;
+    memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+    nonce_generate(buffer, &keypair, seed);
+    init = 0;
+    for (index = 0; index < 32; index++) {
+        if (buffer[index] != check[index]) {
+            init = 1;
+            break;
+        }
+    }
+    CHECK(init == 1);
+}
+
+/*
+ * Try to create a new secp256k1_frost_nonce with null context.
+ */
+void test_secp256k1_frost_nonce_create_null_context(void) {
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_nonce *nonce;
+    secp256k1_frost_keypair keypair;
+
+    memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+    nonce = secp256k1_frost_nonce_create(NULL, &keypair, binding_seed, hiding_seed);
+    CHECK(nonce == NULL);
+}
+
+/*
+ * Try to create a new secp256k1_frost_nonce object with null keypair.
+ */
+void test_secp256k1_frost_nonce_create_null_keypair(void) {
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_nonce *nonce;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    nonce = secp256k1_frost_nonce_create(sign_ctx, NULL, binding_seed, hiding_seed);
+    CHECK(nonce == NULL);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to create a new secp256k1_frost_nonce object with null binding_seed.
+ */
+void test_secp256k1_frost_nonce_create_null_binding_seed(void) {
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_nonce *nonce;
+    secp256k1_frost_keypair keypair;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+    nonce = secp256k1_frost_nonce_create(sign_ctx, &keypair, NULL, hiding_seed);
+    CHECK(nonce == NULL);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to create a new secp256k1_frost_nonce object with null hiding_seed.
+ */
+void test_secp256k1_frost_nonce_create_null_hiding_seed(void) {
+    unsigned char binding_seed[32] = {0};
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_nonce *nonce;
+    secp256k1_frost_keypair keypair;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+    nonce = secp256k1_frost_nonce_create(sign_ctx, &keypair, binding_seed, NULL);
+    CHECK(nonce == NULL);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to destroy a null secp256k1_frost_nonce object.
+ */
+void test_secp256k1_frost_nonce_destroy_null_nonce(void) {
+    secp256k1_frost_nonce_destroy(NULL);
+}
+
+/*
+ * Try to create a new secp256k1_frost_nonce object.
+ * Nonce is computed using a random seed passed as argument; if the same seed is provided, the same nonce is
+ * generated.
+ */
+void test_secp256k1_frost_nonce_create_and_destroy(void) {
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_nonce *nonce;
+    secp256k1_frost_keypair keypair;
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    /* keypair initialized to 0, because it is not computed using keygen functions */
+    memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+    keypair.public_keys.index = 27;
+    nonce = secp256k1_frost_nonce_create(sign_ctx, &keypair, binding_seed, hiding_seed);
+
+    CHECK(nonce != NULL);
+    /* Check if index has been propagated to commitments */
+    CHECK(nonce->commitments.index == 27);
+    /* We use the same seed for binding and hiding: expected nonce to be the same */
+    CHECK(memcmp(nonce->binding, nonce->hiding, 32) == 0);
+    /* We use the same seed for binding and hiding: expected commitments to be the same */
+    CHECK(memcmp(nonce->commitments.binding, nonce->commitments.hiding, 64) == 0);
+
+    secp256k1_frost_nonce_destroy(nonce);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to create a new secp256k1_frost_nonce object.
+ * Nonce is computed using a random seed passed as argument;
+ * if different seeds are provided, different nonces are generated.
+ */
+void test_secp256k1_frost_nonce_create_with_different_nonce(void) {
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {1};
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_nonce *nonce;
+    secp256k1_frost_keypair keypair;
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    /* keypair initialized to 0, because it is not computed using keygen functions */
+    memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+    keypair.public_keys.index = 27;
+    nonce = secp256k1_frost_nonce_create(sign_ctx, &keypair, binding_seed, hiding_seed);
+
+    CHECK(nonce != NULL);
+    CHECK(nonce->commitments.index == 27);
+    /* We use the same seed for binding and hiding: expected nonce to be different */
+    CHECK(memcmp(nonce->binding, nonce->hiding, 32) != 0);
+    /* We use the same seed for binding and hiding: expected commitments to be different */
+    CHECK(memcmp(nonce->commitments.binding, nonce->commitments.hiding, 64) != 0);
+
+    secp256k1_frost_nonce_destroy(nonce);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to create a new secp256k1_frost_vss_commitments object.
+ * The object will not be initialized.
+ * The creation method only allocate memory for coefficient commitments.
+ */
+void test_secp256k1_frost_vss_commitments_create_and_destroy(void) {
+    secp256k1_frost_vss_commitments *vss;
+    const uint32_t threshold = 30;
+    vss = secp256k1_frost_vss_commitments_create(threshold);
+    CHECK(vss != NULL);
+    CHECK(vss->num_coefficients == threshold);
+    secp256k1_frost_vss_commitments_destroy(vss);
+}
+
+/*
+ * Do not create if threshold is less than 1.
+ */
+void test_secp256k1_frost_vss_commitments_create_null_when_threshold_lt_1(void) {
+    secp256k1_frost_vss_commitments *vss;
+    const uint32_t threshold = 0;
+    vss = secp256k1_frost_vss_commitments_create(threshold);
+    CHECK(vss == NULL);
+}
+
+/*
+ * Try to create a new secp256k1_frost_keypair object.
+ * The object will not be initialized (a keygen is needed for this purpose).
+ * The creation method only assigns the participant index.
+ */
+void test_secp256k1_frost_keypair_create_and_destroy(void) {
+    secp256k1_frost_keypair *keypair;
+    uint32_t participant_index = 30;
+
+    keypair = secp256k1_frost_keypair_create(participant_index);
+
+    CHECK(keypair != NULL);
+    CHECK(keypair->public_keys.index == participant_index);
+
+    secp256k1_frost_keypair_destroy(keypair);
+}
+
+/*
+ * Try to destroy a null secp256k1_frost_keypair object.
+ */
+void test_secp256k1_frost_keypair_destroy_null_keypair(void) {
+    secp256k1_frost_keypair_destroy(NULL);
+}
+
+/*
+ * Try to execute the first step of DKG.
+ * Expect error when participants < 1
+ */
+void test_secp256k1_frost_keygen_begin_invalid_participants(void) {
+    int result;
+    const unsigned char context[4] = "test";
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 0, /* threshold */ 2,
+                                              1, context, 4);
+
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to execute the first step of DKG.
+ * Expect error when threshold < 1
+ */
+void test_secp256k1_frost_keygen_begin_invalid_threshold(void) {
+    int result;
+    const unsigned char context[4] = "test";
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(1);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 2, /* threshold */ 0,
+                                              1, context, 4);
+
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to execute the first step of DKG.
+ * Expect error when threshold > participants
+ */
+void test_secp256k1_frost_keygen_begin_threshold_gt_participants(void) {
+    int result;
+    const unsigned char context[4] = "test";
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    const uint32_t threshold = 3;
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(threshold);
+
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 2, threshold,
+                                              1, context, 4);
+
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to execute the first step of DKG, with null context.
+ */
+void test_secp256k1_frost_keygen_begin_null_secp_context(void) {
+    secp256k1_context *sign_ctx = NULL;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+    const unsigned char context[4] = "test";
+
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to execute the first step of DKG, with null commitment.
+ */
+void test_secp256k1_frost_keygen_begin_null_commitment(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment = NULL;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+    const unsigned char context[4] = "test";
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 0);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to execute the first step of DKG, with null shares.
+ */
+void test_secp256k1_frost_keygen_begin_null_shares(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share *shares = NULL;
+    int result;
+    const unsigned char context[4] = "test";
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to execute the first step of DKG with null context.
+ */
+void test_secp256k1_frost_keygen_begin_null_context(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, NULL, 0);
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to execute the first step of DKG.
+ */
+void test_secp256k1_frost_keygen_begin(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+    const unsigned char context[4] = "test";
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 1);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to evaluate the commitments produced by the first step of DKG.
+ */
+void test_secp256k1_frost_keygen_validate(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+    const unsigned char context[4] = "test";
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 1);
+
+    result = secp256k1_frost_keygen_dkg_commitment_validate(
+            sign_ctx,
+            dkg_commitment,
+            context, 4);
+
+    CHECK(result == 1);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_keygen_validate_null_secp_context(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+    const unsigned char context[4] = "test";
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 1);
+
+    result = secp256k1_frost_keygen_dkg_commitment_validate(
+            NULL,
+            dkg_commitment,
+            context, 4);
+
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_keygen_validate_null_commitment(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+    const unsigned char context[4] = "test";
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 1);
+
+    result = secp256k1_frost_keygen_dkg_commitment_validate(
+            sign_ctx,
+            NULL,
+            context, 4);
+
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_keygen_validate_null_context(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+    const unsigned char context[4] = "test";
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 1);
+
+    result = secp256k1_frost_keygen_dkg_commitment_validate(
+            sign_ctx,
+            dkg_commitment,
+            NULL, 4);
+
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Check whether keygen_validate returns 0 on invalid commitments.
+ */
+void test_secp256k1_frost_keygen_validate_invalid_secret_commitment(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    secp256k1_gej _identityPoint;
+    int result;
+    const unsigned char context[4] = "test";
+    const uint32_t threshold = 2;
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(threshold);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ threshold,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 1);
+
+    /* now, set the first commitments to be invalid */
+    secp256k1_gej_clear(&_identityPoint);
+    serialize_point(&_identityPoint, dkg_commitment->coefficient_commitments[0].data);
+
+    /* now, ensure that this dkg commitment is marked as invalid */
+    result = secp256k1_frost_keygen_dkg_commitment_validate(
+            sign_ctx,
+            dkg_commitment,
+            context, 4);
+
+    CHECK(result == 0);
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Check whether keygen_validate returns 0 when a different context is used for validation.
+ */
+void test_secp256k1_frost_keygen_validate_invalid_context(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares[3];
+    int result;
+    const unsigned char context[4] = "test";
+    const unsigned char invalid_context[7] = "invalid";
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = secp256k1_frost_vss_commitments_create(2);
+    result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
+            /* num_participants */ 3,
+            /* threshold */ 2,
+            /* participant_index */ 1, context, 4);
+    CHECK(result == 1);
+
+    /* calling validate with a different context */
+    result = secp256k1_frost_keygen_dkg_commitment_validate(
+            sign_ctx,
+            dkg_commitment,
+            invalid_context, sizeof(invalid_context));
+    CHECK(result == 0);
+
+    secp256k1_frost_vss_commitments_destroy(dkg_commitment);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to finalize the DKG. If no error occurs, 1 is returned.
+ */
+void test_secp256k1_frost_keygen_finalize(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    secp256k1_frost_keygen_secret_share shares_per_participant[3][3];
+    int i_share_per_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypair;
+    uint32_t index;
+    const unsigned char context[4] = "test";
+    const uint32_t threshold = 2;
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    for (index = 0; index < num_participants; index++) {
+        i_share_per_participant[index] = 0;
+        dkg_commitment[index] = secp256k1_frost_vss_commitments_create(threshold);
+    }
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    /* Step 2. keygen begin and validate for each participant */
+    for (index = 0; index < num_participants; index++) {
+        uint32_t share_index;
+        result = secp256k1_frost_keygen_dkg_begin(sign_ctx,
+                                                  dkg_commitment[index],
+                                                  shares_by_participant,
+                /* num_participants */ 3, threshold,
+                                                  index + 1, context, 4);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_keygen_dkg_commitment_validate(sign_ctx, dkg_commitment[index], context, 4);
+        CHECK(result == 1);
+
+        /* Step 3. dispatching shares for single participant */
+        for (share_index = 0; share_index < 3; share_index++) {
+            uint32_t spi;
+            spi = shares_by_participant[share_index].receiver_index - 1;
+            shares_per_participant[spi][i_share_per_participant[spi]] =
+                    shares_by_participant[share_index];
+            i_share_per_participant[spi]++;
+        }
+    }
+
+    /* Step 4. keygen finalize for each participant */
+    for (index = 0; index < num_participants; index++) {
+        result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, &keypair, index + 1, 3,
+                                                     shares_per_participant[index],
+                                                     dkg_commitment);
+        CHECK(result == 1);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_vss_commitments_destroy(dkg_commitment[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+    free(dkg_commitment);
+}
+
+void test_secp256k1_frost_keygen_finalize_null_secp_context(void) {
+    const secp256k1_context *sign_ctx = NULL;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_per_participant;
+    int result;
+    secp256k1_frost_keypair keypair;
+    const uint32_t num_participants = 3;
+
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    memset(&shares_per_participant, 0, sizeof(secp256k1_frost_keygen_secret_share));
+    result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, &keypair, 1, num_participants,
+                                                 &shares_per_participant,
+                                                 dkg_commitment);
+    CHECK(result == 0);
+    free(dkg_commitment);
+}
+
+void test_secp256k1_frost_keygen_finalize_null_keypair(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_per_participant;
+    int result;
+    const uint32_t num_participants = 3;
+    secp256k1_frost_keypair *keypair = NULL;
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    memset(&shares_per_participant, 0, sizeof(secp256k1_frost_keygen_secret_share));
+    result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, keypair, 1, num_participants,
+                                                 &shares_per_participant,
+                                                 dkg_commitment);
+    CHECK(result == 0);
+    secp256k1_context_destroy(sign_ctx);
+    free(dkg_commitment);
+}
+
+void test_secp256k1_frost_keygen_finalize_null_shares(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share *shares_per_participant = NULL;
+    int result;
+    const uint32_t num_participants = 3;
+    secp256k1_frost_keypair keypair;
+
+    /* Step 1. initialization */
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, &keypair, 1, num_participants,
+                                                 shares_per_participant,
+                                                 dkg_commitment);
+    CHECK(result == 0);
+    secp256k1_context_destroy(sign_ctx);
+    free(dkg_commitment);
+}
+
+void test_secp256k1_frost_keygen_finalize_null_commitments(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment = NULL;
+    secp256k1_frost_keygen_secret_share shares_per_participant;
+    int result;
+    const uint32_t num_participants = 3;
+    secp256k1_frost_keypair keypair;
+
+    /* Step 1. initialization */
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    memset(&shares_per_participant, 0, sizeof(secp256k1_frost_keygen_secret_share));
+    result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, &keypair, 1, num_participants,
+                                                 &shares_per_participant,
+                                                 dkg_commitment);
+    CHECK(result == 0);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Verify that the keypairs can successfully reconstruct the group public key.
+ */
+void test_secp256k1_frost_keygen_finalize_is_valid(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    secp256k1_frost_keygen_secret_share shares_per_participant[3][3];
+    int i_share_per_participant[3];
+    uint32_t signer_indexes[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+    uint32_t index;
+    const unsigned char context[4] = "test";
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    for (index = 0; index < num_participants; index++) {
+        i_share_per_participant[index] = 0;
+        signer_indexes[index] = index + 1;
+        dkg_commitment[index] = secp256k1_frost_vss_commitments_create(2);
+    }
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    /* Step 2. keygen begin and validate for each participant */
+    for (index = 0; index < num_participants; index++) {
+        uint32_t share_index;
+        result = secp256k1_frost_keygen_dkg_begin(sign_ctx,
+                                                  dkg_commitment[index],
+                                                  shares_by_participant,
+                /* num_participants */ 3, /* threshold */ 2,
+                                                  index + 1, context, 4);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_keygen_dkg_commitment_validate(sign_ctx, dkg_commitment[index], context, 4);
+        CHECK(result == 1);
+
+        /* Step 3. dispatching shares for single participant */
+        for (share_index = 0; share_index < 3; share_index++) {
+            uint32_t spi;
+            spi = shares_by_participant[share_index].receiver_index - 1;
+            shares_per_participant[spi][i_share_per_participant[spi]] =
+                    shares_by_participant[share_index];
+            i_share_per_participant[spi]++;
+        }
+    }
+
+    /* Step 4. keygen finalize for each participant */
+    for (index = 0; index < num_participants; index++) {
+        result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, &(keypairs[index]), index + 1, 3,
+                                                     shares_per_participant[index],
+                                                     dkg_commitment);
+        CHECK(result == 1);
+    }
+
+    /* Ensure we can reconstruct the secret, given all the secret keys */
+    {
+        secp256k1_scalar output;
+        secp256k1_gej received_public, group_pubkey;
+        int is_equal;
+
+        secp256k1_scalar_set_int(&output, 0);
+        for (index = 0; index < num_participants; index++) {
+            secp256k1_scalar lambda, output_partial, secret;
+
+            result = derive_interpolating_value(&lambda, keypairs[index].public_keys.index,
+                                                num_participants, signer_indexes);
+            CHECK(result == 1);
+
+            secp256k1_scalar_set_b32(&secret, keypairs[index].secret, NULL);
+            secp256k1_scalar_mul(&output_partial, &secret, &lambda);
+            secp256k1_scalar_add(&output, &output, &output_partial);
+        }
+        secp256k1_ecmult_gen(&sign_ctx->ecmult_gen_ctx, &received_public, &output);
+
+        deserialize_point(&group_pubkey, keypairs[0].public_keys.group_public_key);
+        /* ensure that the secret terms interpolate to the correct public key */
+        is_equal = secp256k1_gej_eq(&received_public, &group_pubkey);
+        CHECK(is_equal == 1);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_vss_commitments_destroy(dkg_commitment[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+    free(dkg_commitment);
+}
+
+/*
+ * When a different participant index is provided to keygen_finalize,
+ * it should return no error, but the keygen index is modified accordingly.
+ */
+void test_secp256k1_frost_keygen_finalize_different_participant_index(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    secp256k1_frost_keygen_secret_share shares_per_participant[3][3];
+    int i_share_per_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypair;
+    uint32_t index;
+    const unsigned char context[4] = "test";
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    for (index = 0; index < num_participants; index++) {
+        i_share_per_participant[index] = 0;
+        dkg_commitment[index] = secp256k1_frost_vss_commitments_create(2);
+    }
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    /* Step 2. keygen begin and validate for each participant */
+    for (index = 0; index < num_participants; index++) {
+        uint32_t share_index;
+        result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment[index], shares_by_participant,
+                                                  3, 2, index + 1, context, 4);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_keygen_dkg_commitment_validate(sign_ctx, dkg_commitment[index], context, 4);
+        CHECK(result == 1);
+
+        /* Step 3. dispatching shares for single participant */
+        for (share_index = 0; share_index < 3; share_index++) {
+            uint32_t spi;
+            spi = shares_by_participant[share_index].receiver_index - 1;
+            shares_per_participant[spi][i_share_per_participant[spi]] = shares_by_participant[share_index];
+            i_share_per_participant[spi]++;
+        }
+    }
+
+    /* Step 4. keygen finalize for each participant */
+    for (index = 0; index < num_participants; index++) {
+        /* Testing the following line: when a different participant index, result == 0 is expected. */
+        result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, &keypair, ((index + 2) % num_participants),
+                                                     3, shares_per_participant[index], dkg_commitment);
+        CHECK(result == 1);
+        CHECK(keypair.public_keys.index == ((index + 2) % num_participants));
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_vss_commitments_destroy(dkg_commitment[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+    free(dkg_commitment);
+}
+
+/*
+ * Try to finalize the keygen with invalid commitments; expected 0 (error code).
+ */
+void test_secp256k1_frost_keygen_finalize_invalid_commitments(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    secp256k1_frost_keygen_secret_share shares_per_participant[3][3];
+    int i_share_per_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypair;
+    uint32_t index;
+    const unsigned char context[4] = "test";
+    secp256k1_gej _identityPoint;
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    for (index = 0; index < num_participants; index++) {
+        i_share_per_participant[index] = 0;
+        dkg_commitment[index] = secp256k1_frost_vss_commitments_create(2);
+    }
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    /* Step 2. keygen begin and validate for each participant */
+    for (index = 0; index < num_participants; index++) {
+        uint32_t share_index;
+        result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment[index], shares_by_participant,
+                                                  3, 2, index + 1, context, 4);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_keygen_dkg_commitment_validate(sign_ctx, dkg_commitment[index], context, 4);
+        CHECK(result == 1);
+
+        /* Step 3. dispatching shares for single participant */
+        for (share_index = 0; share_index < 3; share_index++) {
+            uint32_t spi;
+            spi = shares_by_participant[share_index].receiver_index - 1;
+            shares_per_participant[spi][i_share_per_participant[spi]] = shares_by_participant[share_index];
+            i_share_per_participant[spi]++;
+        }
+    }
+
+    /* now, set the first commitments to be invalid */
+    secp256k1_gej_clear(&_identityPoint);
+    serialize_point(&_identityPoint, dkg_commitment[0]->coefficient_commitments[0].data);
+
+    /* Step 4. keygen finalize for each participant */
+    for (index = 0; index < num_participants; index++) {
+        /* Testing the following line: invalidating the commitments. */
+        result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, &keypair, index + 1,
+                                                     3, shares_per_participant[index], dkg_commitment);
+        CHECK(result == 0);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_vss_commitments_destroy(dkg_commitment[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+    free(dkg_commitment);
+}
+
+/*
+ * Test the signing_commitment_sort (quicksort) on a randomly sorted array.
+ */
+void test_quicksort_on_signing_commitment(void) {
+    uint32_t i;
+    secp256k1_frost_nonce_commitment cmt[5];
+    for (i = 0; i < 5; i++) {
+        cmt[i].index = (i * 3) % 5;
+    }
+    signing_commitment_sort(cmt, 0, 4);
+    for (i = 0; i < 5; i++) {
+        CHECK(cmt[i].index == i);
+    }
+}
+
+/*
+ * Test the signing_commitment_sort (quicksort) on an array with duplicates.
+ */
+void test_quicksort_on_signing_commitment_with_duplicates(void) {
+    uint32_t i;
+    secp256k1_frost_nonce_commitment cmt[5];
+    for (i = 0; i < 5; i++) {
+        cmt[i].index = (i * 3) % 5;
+    }
+    cmt[3].index = 0;
+
+    signing_commitment_sort(cmt, 0, 4);
+
+    for (i = 0; i < 5; i++) {
+        uint32_t rhs;
+        rhs = (uint32_t)(i > 0 ? i - 1 : i);
+        CHECK(cmt[i].index == rhs);
+    }
+}
+
+/*
+ * Try to produce a signature_share. If no error occurs, 1 is returned.
+ * This test does not verify the signature secp256k1_frost_keygen_secret_share.
+ */
+void test_secp256k1_frost_dkg_and_sign(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    secp256k1_frost_keygen_secret_share shares_per_participant[3][3];
+    int i_share_per_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypair[3];
+    uint32_t index;
+    const unsigned char context[4] = "test";
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_share[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    for (index = 0; index < num_participants; index++) {
+        i_share_per_participant[index] = 0;
+        dkg_commitment[index] = secp256k1_frost_vss_commitments_create(2);
+    }
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    /* Step 2. keygen begin and validate for each participant */
+    for (index = 0; index < num_participants; index++) {
+        uint32_t share_index;
+        result = secp256k1_frost_keygen_dkg_begin(sign_ctx,
+                                                  dkg_commitment[index],
+                                                  shares_by_participant,
+                /*num_participants*/  3, /* threshold */ 2,
+                                                  index + 1, context, 4);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_keygen_dkg_commitment_validate(sign_ctx, dkg_commitment[index], context, 4);
+        CHECK(result == 1);
+
+        /* Step 3. dispatching shares for single participant */
+        for (share_index = 0; share_index < 3; share_index++) {
+            uint32_t spi;
+            spi = shares_by_participant[share_index].receiver_index - 1;
+            shares_per_participant[spi][i_share_per_participant[spi]] =
+                    shares_by_participant[share_index];
+            i_share_per_participant[spi]++;
+        }
+    }
+
+    /* Step 4. keygen finalize for each participant */
+    for (index = 0; index < num_participants; index++) {
+        result = secp256k1_frost_keygen_dkg_finalize(sign_ctx, &keypair[index], index + 1, 3,
+                                                     shares_per_participant[index],
+                                                     dkg_commitment);
+        CHECK(result == 1);
+    }
+
+    /* Step 5: prepare signature commitments */
+    for (index = 0; index < num_participants; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_ctx,
+                                                     &keypair[index], binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 6: compute signature shares */
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_sign(&(signature_share[index]),
+                             msg32, num_participants,
+                             &keypair[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_vss_commitments_destroy(dkg_commitment[index]);
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+    free(dkg_commitment);
+}
+
+void test_secp256k1_frost_keygen_with_single_dealer_null_secp_context(void) {
+    secp256k1_context *sign_ctx = NULL;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                2);
+    CHECK(result == 0);
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+}
+
+void test_secp256k1_frost_keygen_with_single_dealer_null_commitments(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments = NULL;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                2);
+    CHECK(result == 0);
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_keygen_with_single_dealer_null_shares(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share *shares_by_participant = NULL;
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                2);
+    CHECK(result == 0);
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_keygen_with_single_dealer_null_keypairs(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair *keypairs = NULL;
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                2);
+    CHECK(result == 0);
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Test whether a single dealer can produce keypairs.
+ * Keygen using a single dealer is alternative to DKG.
+ */
+void test_secp256k1_frost_keygen_with_single_dealer(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                2);
+    CHECK(result == 1);
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_keygen_with_single_dealer_invalid_participants(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    /* Step 1. initialization */
+    num_participants = 0;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                2);
+    CHECK(result == 0);
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_keygen_with_single_dealer_invalid_threshold(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                0);
+    CHECK(result == 0);
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_keygen_with_single_dealer_threshold_gt_participants(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                num_participants + 1);
+    CHECK(result == 0);
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Test whether a single dealer can produce valid keypairs.
+ */
+void test_secp256k1_frost_keygen_with_single_dealer_is_valid(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                2);
+    CHECK(result == 1);
+
+    /* Ensure we can reconstruct the secret, given all the secret keys */
+    {
+        secp256k1_scalar output;
+        secp256k1_gej received_public, group_pubkey;
+        int is_equal;
+        uint32_t index;
+        uint32_t signer_indexes[3];
+        for (index = 0; index < num_participants; index++) {
+            signer_indexes[index] = index + 1;
+        }
+
+        secp256k1_scalar_set_int(&output, 0);
+        for (index = 0; index < num_participants; index++) {
+            secp256k1_scalar lambda, output_partial, secret;
+
+            result = derive_interpolating_value(&lambda, keypairs[index].public_keys.index,
+                                                num_participants, signer_indexes);
+            CHECK(result == 1);
+
+            secp256k1_scalar_set_b32(&secret, keypairs[index].secret, NULL);
+            secp256k1_scalar_mul(&output_partial, &secret, &lambda);
+            secp256k1_scalar_add(&output, &output, &output_partial);
+        }
+        secp256k1_ecmult_gen(&sign_ctx->ecmult_gen_ctx, &received_public, &output);
+
+        deserialize_point(&group_pubkey, keypairs[0].public_keys.group_public_key);
+        /* ensure that the secret terms interpolate to the correct public key */
+        is_equal = secp256k1_gej_eq(&received_public, &group_pubkey);
+        CHECK(is_equal == 1);
+    }
+
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to produce a signature_share after keygen using single dealer.
+ */
+void test_secp256k1_frost_single_dealer_and_sign(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_share[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                2);
+    CHECK(result == 1);
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < num_participants; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_sign(&(signature_share[index]),
+                             msg32, num_participants,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_sign_null_signature_shares(void) {
+    int result;
+    uint32_t threshold_signers;
+    secp256k1_frost_signature_share *signature_shares = NULL;
+    secp256k1_frost_keypair keypairs;
+    secp256k1_frost_nonce nonces;
+    secp256k1_frost_nonce_commitment signing_commitments;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    threshold_signers = 2;
+
+    memset(&keypairs, 0, sizeof(secp256k1_frost_keypair));
+    memset(&nonces, 0, sizeof(secp256k1_frost_nonce));
+    memset(&signing_commitments, 0, sizeof(secp256k1_frost_nonce_commitment));
+
+    result = secp256k1_frost_sign(signature_shares,
+                                  msg32, threshold_signers,
+                                  &keypairs,
+                                  &nonces,
+                                  &signing_commitments);
+
+    CHECK(result == 0);
+}
+
+void test_secp256k1_frost_sign_null_msg32(void) {
+    int result;
+    uint32_t threshold_signers;
+    secp256k1_frost_signature_share signature_share;
+    secp256k1_frost_keypair keypairs;
+    secp256k1_frost_nonce nonces;
+    secp256k1_frost_nonce_commitment signing_commitments;
+    const unsigned char *msg32 = NULL;
+    threshold_signers = 2;
+
+    memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
+    memset(&keypairs, 0, sizeof(secp256k1_frost_keypair));
+    memset(&nonces, 0, sizeof(secp256k1_frost_nonce));
+    memset(&signing_commitments, 0, sizeof(secp256k1_frost_nonce_commitment));
+
+    result = secp256k1_frost_sign(&signature_share,
+                                  msg32, threshold_signers,
+                                  &keypairs,
+                                  &nonces,
+                                  &signing_commitments);
+
+    CHECK(result == 0);
+}
+
+
+void test_secp256k1_frost_sign_null_keypairs(void) {
+    int result;
+    uint32_t threshold_signers;
+    secp256k1_frost_signature_share signature_share;
+    secp256k1_frost_keypair *keypairs = NULL;
+    secp256k1_frost_nonce nonces;
+    secp256k1_frost_nonce_commitment signing_commitments;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    threshold_signers = 2;
+
+    memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
+    memset(&nonces, 0, sizeof(secp256k1_frost_nonce));
+    memset(&signing_commitments, 0, sizeof(secp256k1_frost_nonce_commitment));
+
+    result = secp256k1_frost_sign(&signature_share,
+                                  msg32, threshold_signers,
+                                  keypairs,
+                                  &nonces,
+                                  &signing_commitments);
+
+    CHECK(result == 0);
+}
+
+void test_secp256k1_frost_sign_null_nonces(void) {
+    int result;
+    uint32_t threshold_signers;
+    secp256k1_frost_signature_share signature_share;
+    secp256k1_frost_keypair keypairs;
+    secp256k1_frost_nonce *nonces = NULL;
+    secp256k1_frost_nonce_commitment signing_commitments;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    threshold_signers = 2;
+
+    memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
+    memset(&keypairs, 0, sizeof(secp256k1_frost_keypair));
+    memset(&signing_commitments, 0, sizeof(secp256k1_frost_nonce_commitment));
+
+    result = secp256k1_frost_sign(&signature_share,
+                                  msg32, threshold_signers,
+                                  &keypairs,
+                                  nonces,
+                                  &signing_commitments);
+
+    CHECK(result == 0);
+}
+
+void test_secp256k1_frost_sign_null_signing_commitments(void) {
+    int result;
+    uint32_t threshold_signers;
+    secp256k1_frost_signature_share signature_share;
+    secp256k1_frost_keypair keypairs;
+    secp256k1_frost_nonce nonces;
+    secp256k1_frost_nonce_commitment *signing_commitments = NULL;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    threshold_signers = 2;
+
+    memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
+    memset(&keypairs, 0, sizeof(secp256k1_frost_keypair));
+    memset(&nonces, 0, sizeof(secp256k1_frost_nonce));
+
+    result = secp256k1_frost_sign(&signature_share,
+                                  msg32, threshold_signers,
+                                  &keypairs,
+                                  &nonces,
+                                  signing_commitments);
+
+    CHECK(result == 0);
+}
+
+void test_secp256k1_frost_sign_num_signer_set_to_zero(void) {
+    int result;
+    uint32_t threshold_signers;
+    secp256k1_frost_signature_share signature_share;
+    secp256k1_frost_keypair keypairs;
+    secp256k1_frost_nonce nonces;
+    secp256k1_frost_nonce_commitment signing_commitments;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    threshold_signers = 0;
+
+    memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
+    memset(&keypairs, 0, sizeof(secp256k1_frost_keypair));
+    memset(&nonces, 0, sizeof(secp256k1_frost_nonce));
+    memset(&signing_commitments, 0, sizeof(secp256k1_frost_nonce_commitment));
+
+    result = secp256k1_frost_sign(&signature_share,
+                                  msg32, threshold_signers,
+                                  &keypairs,
+                                  &nonces,
+                                  &signing_commitments);
+
+    CHECK(result == 0);
+}
+
+void test_secp256k1_frost_sign_more_participants_than_max_to_be_invalid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_verify_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_pubkey_from_keypair(&public_keys[index], &keypairs[index]);
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        result = secp256k1_frost_sign(&(signature_shares[index]),
+                                      msg32, num_participants + 1,
+                                      &keypairs[index],
+                                      nonces[index],
+                                      signing_commitments);
+        CHECK(result == 0);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+}
+
+/*
+ * Try to produce a valid signature_share (keygen using single dealer).
+ * Signature shares are aggregated; the aggregated signature is then verified.
+ */
+void test_secp256k1_frost_sign_aggregate_verify_to_be_valid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(2);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_verify_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_pubkey_from_keypair(&public_keys[index], &keypairs[index]);
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, threshold_signers,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < threshold_signers; index++) {
+        unsigned char signature[64];
+        /* Step 4: aggregate signature shares */
+        result = secp256k1_frost_aggregate(sign_verify_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           threshold_signers);
+        CHECK(result == 1);
+
+        /* Step 5: verify aggregated signature */
+        result = secp256k1_frost_verify(sign_verify_ctx,
+                                        signature,
+                                        msg32,
+                                        &keypairs[index].public_keys);
+        CHECK(result == 1);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+}
+
+/*
+ * Try to produce a valid signature_share (keygen using single dealer).
+ * Signature shares are aggregated; the aggregated signature is then verified.
+ */
+void test_secp256k1_frost_sign_aggregate_verify_more_parts_to_be_valid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[10];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[10];
+    secp256k1_frost_pubkey public_keys[10];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[10];
+    secp256k1_frost_nonce *nonces[10];
+    secp256k1_frost_nonce_commitment signing_commitments[10];
+
+    /* Step 1. initialization */
+    num_participants = 10;
+    threshold_signers = 8;
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_verify_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        result = secp256k1_frost_pubkey_from_keypair(&public_keys[index], &keypairs[index]);
+        CHECK(result == 1);
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        result = secp256k1_frost_sign(&(signature_shares[index]),
+                                      msg32, threshold_signers,
+                                      &keypairs[index],
+                                      nonces[index],
+                                      signing_commitments);
+        CHECK(result == 1);
+    }
+
+    for (index = 0; index < threshold_signers; index++) {
+        unsigned char signature[64];
+        /* Step 4: aggregate signature shares */
+        result = secp256k1_frost_aggregate(sign_verify_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           threshold_signers);
+        CHECK(result == 1);
+
+        /* Step 5: verify aggregated signature */
+        result = secp256k1_frost_verify(sign_verify_ctx,
+                                        signature,
+                                        msg32,
+                                        &keypairs[index].public_keys);
+        CHECK(result == 1);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+}
+
+/*
+ * Do not sign when an already used nonce is provided.
+ */
+void test_secp256k1_frost_sign_with_used_nonce_to_not_sign(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+
+        /* Step 2.b: mark nonce as used */
+        nonces[index]->used = 1;
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        result = secp256k1_frost_sign(&(signature_shares[index]),
+                                      msg32, threshold_signers,
+                                      &keypairs[index],
+                                      nonces[index],
+                                      signing_commitments);
+        CHECK(result == 0);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to produce a valid signature_share.
+ * A larger number of participants and a higher threshold are considered.
+ */
+void test_secp256k1_frost_with_larger_params_to_be_valid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[10];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[10];
+    secp256k1_frost_pubkey public_keys[10];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[10];
+    secp256k1_frost_nonce *nonces[10];
+    secp256k1_frost_nonce_commitment signing_commitments[10];
+
+    /* Step 1. initialization */
+    num_participants = 10;
+    threshold_signers = 6;
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_verify_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, threshold_signers,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < threshold_signers; index++) {
+        unsigned char signature[64];
+        /* Step 4: aggregate signature shares */
+        result = secp256k1_frost_aggregate(sign_verify_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           threshold_signers);
+        CHECK(result == 1);
+
+        /* Step 5: verify aggregated signature */
+        result = secp256k1_frost_verify(sign_verify_ctx,
+                                        signature,
+                                        msg32,
+                                        &keypairs[index].public_keys);
+        CHECK(result == 1);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+}
+
+/*
+ * Evaluate aggregate (and verify) when all signers provide a signature share.
+ * Expected to return 1 (i.e., to be valid).
+ */
+void test_secp256k1_frost_aggregate_with_all_signers_to_be_valid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_verify_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < num_participants; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, num_participants,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        unsigned char signature[64];
+        /* Step 4: aggregate signature shares */
+        result = secp256k1_frost_aggregate(sign_verify_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           num_participants);
+        CHECK(result == 1);
+
+        /* Step 5: verify aggregated signature */
+        result = secp256k1_frost_verify(sign_verify_ctx,
+                                        signature,
+                                        msg32,
+                                        &keypairs[index].public_keys);
+        CHECK(result == 1);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+}
+
+void test_secp256k1_frost_aggregate_null_secp_context(void) {
+    secp256k1_context *sign_ctx = NULL;
+    unsigned char signature[64];
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    secp256k1_frost_keypair keypair;
+    secp256k1_frost_pubkey public_keys[3];
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+    int result;
+    const uint32_t num_participants = 3;
+    uint32_t index;
+    for (index = 0; index < num_participants; index++) {
+        memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+        memset(&signature_shares[index], 0, sizeof(secp256k1_frost_signature_share));
+        memset(&public_keys[index], 0, sizeof(secp256k1_frost_pubkey));
+        memset(&signing_commitments[index], 0, sizeof(secp256k1_frost_nonce_commitment));
+    }
+    result = secp256k1_frost_aggregate(sign_ctx,
+                                       signature,
+                                       msg32, &keypair,
+                                       public_keys, signing_commitments,
+                                       signature_shares,
+                                       num_participants);
+    CHECK(result == 0);
+}
+
+void test_secp256k1_frost_aggregate_null_signature(void) {
+    secp256k1_context *sign_ctx;
+    unsigned char *signature = NULL;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    secp256k1_frost_keypair keypair;
+    secp256k1_frost_pubkey public_keys[3];
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+    int result;
+    const uint32_t num_participants = 3;
+    uint32_t index;
+    for (index = 0; index < num_participants; index++) {
+        memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+        memset(&signature_shares[index], 0, sizeof(secp256k1_frost_signature_share));
+        memset(&public_keys[index], 0, sizeof(secp256k1_frost_pubkey));
+        memset(&signing_commitments[index], 0, sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    result = secp256k1_frost_aggregate(sign_ctx,
+                                       signature,
+                                       msg32, &keypair,
+                                       public_keys, signing_commitments,
+                                       signature_shares,
+                                       num_participants);
+    CHECK(result == 0);
+
+    /* Cleaning up */
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_aggregate_null_message(void) {
+    secp256k1_context *sign_ctx;
+    unsigned char signature[64];
+    const unsigned char *msg32 = NULL;
+    secp256k1_frost_keypair keypair;
+    secp256k1_frost_pubkey public_keys[3];
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+    int result;
+    const uint32_t num_participants = 3;
+    uint32_t index;
+    for (index = 0; index < num_participants; index++) {
+        memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+        memset(&signature_shares[index], 0, sizeof(secp256k1_frost_signature_share));
+        memset(&public_keys[index], 0, sizeof(secp256k1_frost_pubkey));
+        memset(&signing_commitments[index], 0, sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    result = secp256k1_frost_aggregate(sign_ctx,
+                                       signature,
+                                       msg32, &keypair,
+                                       public_keys, signing_commitments,
+                                       signature_shares,
+                                       num_participants);
+    CHECK(result == 0);
+
+    /* Cleaning up */
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_aggregate_null_keypair(void) {
+    secp256k1_context *sign_ctx;
+    unsigned char signature[64];
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    secp256k1_frost_keypair *keypair = NULL;
+    secp256k1_frost_pubkey public_keys[3];
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+    int result;
+    const uint32_t num_participants = 3;
+    uint32_t index;
+    for (index = 0; index < num_participants; index++) {
+        memset(&signature_shares[index], 0, sizeof(secp256k1_frost_signature_share));
+        memset(&public_keys[index], 0, sizeof(secp256k1_frost_pubkey));
+        memset(&signing_commitments[index], 0, sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    result = secp256k1_frost_aggregate(sign_ctx,
+                                       signature,
+                                       msg32, keypair,
+                                       public_keys, signing_commitments,
+                                       signature_shares,
+                                       num_participants);
+    CHECK(result == 0);
+
+    /* Cleaning up */
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_aggregate_null_pubkeys(void) {
+    secp256k1_context *sign_ctx;
+    unsigned char signature[64];
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    secp256k1_frost_keypair keypair;
+    secp256k1_frost_pubkey *public_keys = NULL;
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+    int result;
+    const uint32_t num_participants = 3;
+    uint32_t index;
+    for (index = 0; index < num_participants; index++) {
+        memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+        memset(&signature_shares[index], 0, sizeof(secp256k1_frost_signature_share));
+        memset(&signing_commitments[index], 0, sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    result = secp256k1_frost_aggregate(sign_ctx,
+                                       signature,
+                                       msg32, &keypair,
+                                       public_keys, signing_commitments,
+                                       signature_shares,
+                                       num_participants);
+    CHECK(result == 0);
+
+    /* Cleaning up */
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_aggregate_null_signing_commitments(void) {
+    secp256k1_context *sign_ctx;
+    unsigned char signature[64];
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    secp256k1_frost_keypair keypair;
+    secp256k1_frost_pubkey public_keys[3];
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce_commitment *signing_commitments = NULL;
+    int result;
+    const uint32_t num_participants = 3;
+    uint32_t index;
+    for (index = 0; index < num_participants; index++) {
+        memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+        memset(&signature_shares[index], 0, sizeof(secp256k1_frost_signature_share));
+        memset(&public_keys[index], 0, sizeof(secp256k1_frost_pubkey));
+    }
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    result = secp256k1_frost_aggregate(sign_ctx,
+                                       signature,
+                                       msg32, &keypair,
+                                       public_keys, signing_commitments,
+                                       signature_shares,
+                                       num_participants);
+    CHECK(result == 0);
+
+    /* Cleaning up */
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_aggregate_null_signature_shares(void) {
+    secp256k1_context *sign_ctx;
+    unsigned char signature[64];
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    secp256k1_frost_keypair keypair;
+    secp256k1_frost_pubkey public_keys[3];
+    secp256k1_frost_signature_share *signature_shares = NULL;
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+    int result;
+    const uint32_t num_participants = 3;
+    uint32_t index;
+    for (index = 0; index < num_participants; index++) {
+        memset(&keypair, 0, sizeof(secp256k1_frost_keypair));
+        memset(&public_keys[index], 0, sizeof(secp256k1_frost_pubkey));
+        memset(&signing_commitments[index], 0, sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    result = secp256k1_frost_aggregate(sign_ctx,
+                                       signature,
+                                       msg32, &keypair,
+                                       public_keys, signing_commitments,
+                                       signature_shares,
+                                       num_participants);
+    CHECK(result == 0);
+
+    /* Cleaning up */
+    secp256k1_context_destroy(sign_ctx);
+}
+
+void test_secp256k1_frost_aggregate_with_more_participants_than_max_to_be_invalid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_verify_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < num_participants; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, num_participants,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        unsigned char signature[64];
+        /* Step 4: aggregate signature shares */
+        result = secp256k1_frost_aggregate(sign_verify_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           num_participants + 1);
+        CHECK(result == 0);
+
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+}
+
+/*
+ * Try to aggregate with less signature_shares than the threshold.
+ * Expected to return 0 (invalid).
+ */
+void test_secp256k1_frost_aggregate_with_few_signature_share_to_be_invalid(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, threshold_signers,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    {
+        /* Step 4.pre: consider only a single signature_share for aggregation */
+        uint32_t num_signature_share_to_consider;
+        num_signature_share_to_consider = 1;
+
+        for (index = 0; index < threshold_signers; index++) {
+            unsigned char signature[64];
+            /* Step 4: aggregate signature shares */
+            result = secp256k1_frost_aggregate(sign_ctx,
+                                               signature,
+                                               msg32, &keypairs[index],
+                                               public_keys, signing_commitments,
+                                               signature_shares,
+                                               num_signature_share_to_consider);
+            CHECK(result == 0);
+        }
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to aggregate with an invalid signature_share.
+ * Expected to return 0 (invalid).
+ */
+void test_secp256k1_frost_aggregate_with_invalid_signature_share_to_be_invalid(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, threshold_signers,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    /* Step 3.b: invalidate single signature share */
+    memcpy(signature_shares[0].response, msg32, 32);
+
+    for (index = 0; index < threshold_signers; index++) {
+        unsigned char signature[64];
+        /* Step 4: aggregate signature shares */
+        result = secp256k1_frost_aggregate(sign_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           threshold_signers);
+        CHECK(result == 0);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Try to aggregate valid signature_share when a wrong group key is provided (keygen using single dealer).
+ * Expected to return 0 (invalid).
+ */
+void test_secp256k1_frost_aggregate_with_invalid_group_key_to_be_invalid(void) {
+    secp256k1_context *sign_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, threshold_signers,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < threshold_signers; index++) {
+        unsigned char signature[64];
+        /* Step 4: aggregate signature shares */
+        memset(keypairs[index].public_keys.group_public_key, 0, 64);
+        result = secp256k1_frost_aggregate(sign_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           threshold_signers);
+        CHECK(result == 0);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_ctx);
+}
+
+/*
+ * Produce a valid aggregated signature, but validate with wrong group pubkey.
+ * Expected to be invalid.
+ */
+void test_secp256k1_frost_verify_with_invalid_group_key_to_be_invalid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments *dealer_commitments;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    int result;
+    uint32_t num_participants;
+    uint32_t threshold_signers;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+
+    uint32_t index;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    threshold_signers = 2;
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    dealer_commitments = secp256k1_frost_vss_commitments_create(threshold_signers);
+
+    result = secp256k1_frost_keygen_with_dealer(sign_verify_ctx,
+                                                dealer_commitments,
+                                                shares_by_participant,
+                                                keypairs, num_participants,
+                                                threshold_signers);
+    CHECK(result == 1);
+
+    /* Step 1.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 2: prepare signature commitments */
+    for (index = 0; index < threshold_signers; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index],
+                                                     binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 3: compute signature shares */
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, threshold_signers,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < threshold_signers; index++) {
+        unsigned char signature[64];
+        /* Step 4: aggregate signature shares */
+        result = secp256k1_frost_aggregate(sign_verify_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           threshold_signers);
+        CHECK(result == 1);
+
+        /* Step 5: verify aggregated signature */
+        memset(keypairs[index].public_keys.group_public_key, 0, 64);
+        result = secp256k1_frost_verify(sign_verify_ctx,
+                                        signature,
+                                        msg32,
+                                        &keypairs[index].public_keys);
+        CHECK(result == 0);
+    }
+
+    /* Cleaning up */
+    secp256k1_frost_vss_commitments_destroy(dealer_commitments);
+    for (index = 0; index < threshold_signers; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+}
+
+/*
+ * Try to produce an aggregated signature and validate it.
+ * Keygen using DKG.
+ */
+void test_secp256k1_frost_dkg_sign_aggregate_verify_to_be_valid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_by_participant[3];
+    secp256k1_frost_keygen_secret_share shares_per_participant[3][3];
+    int i_share_per_participant[3];
+    int result;
+    uint32_t num_participants;
+    secp256k1_frost_keypair keypairs[3];
+    secp256k1_frost_pubkey public_keys[3];
+    uint32_t index;
+    const unsigned char context[4] = "test";
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[3];
+    secp256k1_frost_nonce *nonces[3];
+    secp256k1_frost_nonce_commitment signing_commitments[3];
+
+    /* Step 1. initialization */
+    num_participants = 3;
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    for (index = 0; index < num_participants; index++) {
+        i_share_per_participant[index] = 0;
+        dkg_commitment[index] = secp256k1_frost_vss_commitments_create(2);
+
+    }
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+
+    /* Step 2. keygen begin and validate for each participant */
+    for (index = 0; index < num_participants; index++) {
+        uint32_t share_index;
+        result = secp256k1_frost_keygen_dkg_begin(sign_verify_ctx,
+                                                  dkg_commitment[index],
+                                                  shares_by_participant,
+                /*num_participants*/  3, /* threshold */ 2,
+                                                  index + 1, context, 4);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_keygen_dkg_commitment_validate(sign_verify_ctx, dkg_commitment[index], context, 4);
+        CHECK(result == 1);
+
+        /* Step 3. dispatching shares for single participant */
+        for (share_index = 0; share_index < 3; share_index++) {
+            uint32_t spi;
+            spi = shares_by_participant[share_index].receiver_index - 1;
+            shares_per_participant[spi][i_share_per_participant[spi]] =
+                    shares_by_participant[share_index];
+            i_share_per_participant[spi]++;
+        }
+    }
+
+    /* Step 4. keygen finalize for each participant */
+    for (index = 0; index < num_participants; index++) {
+        result = secp256k1_frost_keygen_dkg_finalize(sign_verify_ctx, &keypairs[index], index + 1, 3,
+                                                     shares_per_participant[index],
+                                                     dkg_commitment);
+        CHECK(result == 1);
+    }
+
+    /* Step 4.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 5: prepare signature commitments */
+    for (index = 0; index < num_participants; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index], binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 6: compute signature shares */
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, num_participants,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        unsigned char signature[64];
+        result = secp256k1_frost_aggregate(sign_verify_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           num_participants);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_verify(sign_verify_ctx,
+                                        signature,
+                                        msg32,
+                                        &keypairs[index].public_keys);
+        CHECK(result == 1);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_vss_commitments_destroy(dkg_commitment[index]);
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+    free(dkg_commitment);
+}
+
+/*
+ * Try to produce an aggregated signature and validate it.
+ * Keygen using DKG.
+ */
+void test_secp256k1_frost_dkg_sign_aggregate_verify_more_parts_to_be_valid(void) {
+    secp256k1_context *sign_verify_ctx;
+    secp256k1_frost_vss_commitments **dkg_commitment;
+    secp256k1_frost_keygen_secret_share shares_by_participant[10];
+    secp256k1_frost_keygen_secret_share shares_per_participant[10][10];
+    int i_share_per_participant[10];
+    int result;
+    uint32_t num_participants, threshold;
+    secp256k1_frost_keypair keypairs[10];
+    secp256k1_frost_pubkey public_keys[10];
+    uint32_t index;
+    const unsigned char context[4] = "test";
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char binding_seed[32] = {0};
+    unsigned char hiding_seed[32] = {0};
+    secp256k1_frost_signature_share signature_shares[10];
+    secp256k1_frost_nonce *nonces[10];
+    secp256k1_frost_nonce_commitment signing_commitments[10];
+
+    /* Step 1. initialization */
+    num_participants = 10;
+    threshold = 8;
+    dkg_commitment = malloc(num_participants * sizeof(secp256k1_frost_vss_commitments *));
+    for (index = 0; index < num_participants; index++) {
+        i_share_per_participant[index] = 0;
+        dkg_commitment[index] = secp256k1_frost_vss_commitments_create(threshold);
+
+    }
+    sign_verify_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+
+    /* Step 2. keygen begin and validate for each participant */
+    for (index = 0; index < num_participants; index++) {
+        uint32_t share_index;
+        result = secp256k1_frost_keygen_dkg_begin(sign_verify_ctx,
+                                                  dkg_commitment[index],
+                                                  shares_by_participant,
+                                                  num_participants, threshold,
+                                                  index + 1, context, 4);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_keygen_dkg_commitment_validate(sign_verify_ctx, dkg_commitment[index], context, 4);
+        CHECK(result == 1);
+
+        /* Step 3. dispatching shares for single participant */
+        for (share_index = 0; share_index < num_participants; share_index++) {
+            uint32_t spi;
+            spi = shares_by_participant[share_index].receiver_index - 1;
+            shares_per_participant[spi][i_share_per_participant[spi]] =
+                    shares_by_participant[share_index];
+            i_share_per_participant[spi]++;
+        }
+    }
+
+    /* Step 4. keygen finalize for each participant */
+    for (index = 0; index < num_participants; index++) {
+        result = secp256k1_frost_keygen_dkg_finalize(sign_verify_ctx, &keypairs[index], index + 1,
+                                                     num_participants,
+                                                     shares_per_participant[index],
+                                                     dkg_commitment);
+        CHECK(result == 1);
+    }
+
+    /* Step 4.b: extract public_keys */
+    for (index = 0; index < num_participants; index++) {
+        memcpy(&public_keys[index], &keypairs[index].public_keys, sizeof(secp256k1_frost_pubkey));
+    }
+
+    /* Step 5: prepare signature commitments */
+    for (index = 0; index < threshold; index++) {
+        nonces[index] = secp256k1_frost_nonce_create(sign_verify_ctx,
+                                                     &keypairs[index], binding_seed, hiding_seed);
+        memcpy(&signing_commitments[index], &(nonces[index]->commitments), sizeof(secp256k1_frost_nonce_commitment));
+    }
+
+    /* Step 6: compute signature shares */
+    for (index = 0; index < threshold; index++) {
+        secp256k1_frost_sign(&(signature_shares[index]),
+                             msg32, threshold,
+                             &keypairs[index],
+                             nonces[index],
+                             signing_commitments);
+    }
+
+    for (index = 0; index < threshold; index++) {
+        unsigned char signature[64];
+        result = secp256k1_frost_aggregate(sign_verify_ctx,
+                                           signature,
+                                           msg32, &keypairs[index],
+                                           public_keys, signing_commitments,
+                                           signature_shares,
+                                           threshold);
+        CHECK(result == 1);
+
+        result = secp256k1_frost_verify(sign_verify_ctx,
+                                        signature,
+                                        msg32,
+                                        &keypairs[index].public_keys);
+        CHECK(result == 1);
+    }
+
+    for (index = 0; index < num_participants; index++) {
+        secp256k1_frost_vss_commitments_destroy(dkg_commitment[index]);
+    }
+    for (index = 0; index < threshold; index++) {
+        secp256k1_frost_nonce_destroy(nonces[index]);
+    }
+    secp256k1_context_destroy(sign_verify_ctx);
+    free(dkg_commitment);
+}
+
+/*
+ * Test serialize and deserialize point.
+ */
+void test_serialize_and_deserialize_point(void) {
+    unsigned char serialized64[64];
+    secp256k1_gej point, deserialized_point;
+    secp256k1_scalar seed;
+    secp256k1_context *test_ctx;
+    int is_equal;
+
+    /* Initialize signature */
+    test_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    secp256k1_scalar_set_int(&seed, 42);
+    secp256k1_ecmult_gen(&test_ctx->ecmult_gen_ctx, &point, &seed);
+
+    /* Serialize and deserialize */
+    serialize_point(&point, serialized64);
+    deserialize_point(&deserialized_point, serialized64);
+
+    is_equal = secp256k1_gej_eq(&point, &deserialized_point);
+    CHECK(is_equal == 1);
+
+    secp256k1_context_destroy(test_ctx);
+}
+
+/*
+ * Test serialize and deserialize functions for frost_signature.
+ */
+void test_serialize_and_deserialize_frost_signature(void) {
+    unsigned char serialized64[64];
+    secp256k1_frost_signature signature;
+    secp256k1_frost_signature deserialized_signature;
+    secp256k1_context *test_ctx;
+    int is_equal;
+
+    /* Initialize signature */
+    test_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    secp256k1_scalar_set_int(&(signature.z), 42);
+    secp256k1_ecmult_gen(&test_ctx->ecmult_gen_ctx, &(signature.r), &(signature.z));
+
+    /* Serialize and deserialize */
+    serialize_frost_signature(serialized64, &signature);
+    CHECK(deserialize_frost_signature(&deserialized_signature, serialized64) == 1);
+
+    is_equal = secp256k1_gej_eq(&(signature.r), &(deserialized_signature.r));
+    CHECK(is_equal == 1);
+
+    is_equal = secp256k1_scalar_eq(&(signature.z), &(deserialized_signature.z));
+    CHECK(is_equal == 1);
+
+    secp256k1_context_destroy(test_ctx);
+}
+
+/*
+ * Test verify function on a signature expected to be valid.
+ */
+void test_secp256k1_frost_verify_to_be_valid(void) {
+    secp256k1_scalar private_key, nonce, challenge;
+    secp256k1_gej pubkey;
+    secp256k1_context *test_ctx;
+    int result;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char serialized64[64];
+    secp256k1_frost_signature signature;
+    secp256k1_frost_keypair keypair;
+
+    test_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    secp256k1_scalar_set_int(&private_key, 42);
+    secp256k1_ecmult_gen(&test_ctx->ecmult_gen_ctx, &pubkey, &private_key);
+    secp256k1_scalar_set_int(&nonce, 5);
+    secp256k1_ecmult_gen(&test_ctx->ecmult_gen_ctx, &(signature.r), &nonce);
+    compute_challenge(&challenge, msg32, 32, &pubkey, &(signature.r));
+
+    secp256k1_scalar_mul(&(signature.z), &private_key, &challenge);
+    secp256k1_scalar_add(&(signature.z), &nonce, &(signature.z));
+
+    serialize_frost_signature(serialized64, &signature);
+    serialize_point(&pubkey, keypair.public_keys.group_public_key);
+
+    result = secp256k1_frost_verify(test_ctx,
+                                    serialized64,
+                                    msg32,
+                                    &keypair.public_keys);
+    CHECK(result == 1);
+
+    secp256k1_context_destroy(test_ctx);
+}
+
+void test_secp256k1_frost_verify_null_secp_context(void) {
+    secp256k1_context *test_ctx = NULL;
+    int result;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char serialized64[64] = {0};
+    secp256k1_frost_pubkey pubkey;
+
+    memset(&pubkey, 0, sizeof(secp256k1_frost_pubkey));
+    result = secp256k1_frost_verify(test_ctx,
+                                    serialized64,
+                                    msg32,
+                                    &pubkey);
+    CHECK(result == 0);
+}
+
+void test_secp256k1_frost_verify_null_signature(void) {
+    secp256k1_context *test_ctx;
+    int result;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char *serialized64 = NULL;
+    secp256k1_frost_pubkey pubkey;
+
+    test_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    memset(&pubkey, 0, sizeof(secp256k1_frost_pubkey));
+    result = secp256k1_frost_verify(test_ctx,
+                                    serialized64,
+                                    msg32,
+                                    &pubkey);
+    CHECK(result == 0);
+
+    secp256k1_context_destroy(test_ctx);
+}
+
+void test_secp256k1_frost_verify_null_message(void) {
+    secp256k1_context *test_ctx;
+    int result;
+    const unsigned char *msg32 = NULL;
+    unsigned char serialized64[64] = {0};
+    secp256k1_frost_pubkey pubkey;
+
+    test_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    memset(&pubkey, 0, sizeof(secp256k1_frost_pubkey));
+    result = secp256k1_frost_verify(test_ctx,
+                                    serialized64,
+                                    msg32,
+                                    &pubkey);
+    CHECK(result == 0);
+
+    secp256k1_context_destroy(test_ctx);
+}
+
+void test_secp256k1_frost_verify_null_pubkey(void) {
+    secp256k1_context *test_ctx;
+    int result;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char serialized64[64] = {0};
+    secp256k1_frost_pubkey *pubkey = NULL;
+
+    test_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    result = secp256k1_frost_verify(test_ctx,
+                                    serialized64,
+                                    msg32,
+                                    pubkey);
+    CHECK(result == 0);
+
+    secp256k1_context_destroy(test_ctx);
+}
+
+/*
+ * Test verify function on a signature expected to be invalid.
+ */
+void test_secp256k1_frost_verify_to_be_invalid(void) {
+    secp256k1_scalar private_key, nonce, invalid_nonce, challenge;
+    secp256k1_gej pubkey;
+    secp256k1_context *test_ctx;
+    int result;
+    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char serialized64[64];
+    secp256k1_frost_signature signature;
+    secp256k1_frost_keypair keypair;
+
+    test_ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    secp256k1_scalar_set_int(&private_key, 42);
+    secp256k1_ecmult_gen(&test_ctx->ecmult_gen_ctx, &pubkey, &private_key);
+    secp256k1_scalar_set_int(&nonce, 5);
+    secp256k1_ecmult_gen(&test_ctx->ecmult_gen_ctx, &(signature.r), &nonce);
+    compute_challenge(&challenge, msg32, 32, &pubkey, &(signature.r));
+
+    secp256k1_scalar_mul(&(signature.z), &private_key, &challenge);
+
+    secp256k1_scalar_set_int(&invalid_nonce, 100);
+    secp256k1_scalar_add(&(signature.z), &invalid_nonce, &(signature.z));
+
+    serialize_frost_signature(serialized64, &signature);
+    serialize_point(&pubkey, keypair.public_keys.group_public_key);
+
+    result = secp256k1_frost_verify(test_ctx,
+                                    serialized64,
+                                    msg32,
+                                    &keypair.public_keys);
+    CHECK(result == 0);
+
+    secp256k1_context_destroy(test_ctx);
+}
+
+void run_frost_tests(void) {
+
+    /* Test auxiliary internal functions */
+    test_secp256k1_gej_eq_case_1();
+    test_secp256k1_gej_eq_case_2();
+    test_secp256k1_gej_eq_case_3();
+    test_secp256k1_gej_eq_case_4();
+    test_nonce_generate_with_seed();
+    test_nonce_generate_with_no_seed();
+    test_serialize_and_deserialize_point();
+    test_quicksort_on_signing_commitment();
+    test_quicksort_on_signing_commitment_with_duplicates();
+    test_serialize_and_deserialize_frost_signature();
+
+    /* Test context creation and destroy functions */
+    test_secp256k1_frost_vss_commitments_create_and_destroy();
+    test_secp256k1_frost_vss_commitments_create_null_when_threshold_lt_1();
+    test_secp256k1_frost_nonce_create_and_destroy();
+    test_secp256k1_frost_nonce_create_with_different_nonce();
+    test_secp256k1_frost_nonce_create_null_context();
+    test_secp256k1_frost_nonce_create_null_keypair();
+    test_secp256k1_frost_nonce_create_null_binding_seed();
+    test_secp256k1_frost_nonce_create_null_hiding_seed();
+    test_secp256k1_frost_nonce_destroy_null_nonce();
+    test_secp256k1_frost_keypair_create_and_destroy();
+    test_secp256k1_frost_keypair_destroy_null_keypair();
+
+    /* Test key generation (DKG and based on a single dealer) */
+    test_secp256k1_frost_keygen_begin();
+    test_secp256k1_frost_keygen_begin_null_secp_context();
+    test_secp256k1_frost_keygen_begin_null_commitment();
+    test_secp256k1_frost_keygen_begin_null_shares();
+    test_secp256k1_frost_keygen_begin_null_context();
+    test_secp256k1_frost_keygen_begin_invalid_participants();
+    test_secp256k1_frost_keygen_begin_invalid_threshold();
+    test_secp256k1_frost_keygen_begin_threshold_gt_participants();
+    test_secp256k1_frost_keygen_validate();
+    test_secp256k1_frost_keygen_validate_null_secp_context();
+    test_secp256k1_frost_keygen_validate_null_commitment();
+    test_secp256k1_frost_keygen_validate_null_context();
+    test_secp256k1_frost_keygen_validate_invalid_secret_commitment();
+    test_secp256k1_frost_keygen_validate_invalid_context();
+    test_secp256k1_frost_keygen_finalize();
+    test_secp256k1_frost_keygen_finalize_null_secp_context();
+    test_secp256k1_frost_keygen_finalize_null_keypair();
+    test_secp256k1_frost_keygen_finalize_null_shares();
+    test_secp256k1_frost_keygen_finalize_null_commitments();
+    test_secp256k1_frost_keygen_finalize_is_valid();
+    test_secp256k1_frost_keygen_finalize_different_participant_index();
+    test_secp256k1_frost_keygen_finalize_invalid_commitments();
+    test_secp256k1_frost_keygen_with_single_dealer();
+    test_secp256k1_frost_keygen_with_single_dealer_null_secp_context();
+    test_secp256k1_frost_keygen_with_single_dealer_null_commitments();
+    test_secp256k1_frost_keygen_with_single_dealer_null_shares();
+    test_secp256k1_frost_keygen_with_single_dealer_null_keypairs();
+    test_secp256k1_frost_keygen_with_single_dealer_is_valid();
+    test_secp256k1_frost_keygen_with_single_dealer_invalid_participants();
+    test_secp256k1_frost_keygen_with_single_dealer_invalid_threshold();
+    test_secp256k1_frost_keygen_with_single_dealer_threshold_gt_participants();
+
+    /* Test sign function */
+    test_secp256k1_frost_dkg_and_sign();
+    test_secp256k1_frost_dkg_sign_aggregate_verify_to_be_valid();
+    test_secp256k1_frost_dkg_sign_aggregate_verify_more_parts_to_be_valid();
+    test_secp256k1_frost_single_dealer_and_sign();
+    test_secp256k1_frost_sign_aggregate_verify_to_be_valid();
+    test_secp256k1_frost_sign_null_signing_commitments();
+    test_secp256k1_frost_sign_null_msg32();
+    test_secp256k1_frost_sign_null_keypairs();
+    test_secp256k1_frost_sign_null_nonces();
+    test_secp256k1_frost_sign_null_signature_shares();
+    test_secp256k1_frost_sign_more_participants_than_max_to_be_invalid();
+    test_secp256k1_frost_sign_aggregate_verify_more_parts_to_be_valid();
+    test_secp256k1_frost_sign_with_used_nonce_to_not_sign();
+
+    /* Test aggregate function */
+    test_secp256k1_frost_aggregate_with_all_signers_to_be_valid();
+    test_secp256k1_frost_aggregate_null_secp_context();
+    test_secp256k1_frost_aggregate_null_signature();
+    test_secp256k1_frost_aggregate_null_message();
+    test_secp256k1_frost_aggregate_null_keypair();
+    test_secp256k1_frost_aggregate_null_pubkeys();
+    test_secp256k1_frost_aggregate_null_signing_commitments();
+    test_secp256k1_frost_aggregate_null_signature_shares();
+    test_secp256k1_frost_aggregate_with_invalid_group_key_to_be_invalid();
+    test_secp256k1_frost_aggregate_with_invalid_signature_share_to_be_invalid();
+    test_secp256k1_frost_aggregate_with_few_signature_share_to_be_invalid();
+    test_secp256k1_frost_aggregate_with_more_participants_than_max_to_be_invalid();
+
+    /* Test verify function */
+    test_secp256k1_frost_verify_to_be_valid();
+    test_secp256k1_frost_verify_to_be_invalid();
+    test_secp256k1_frost_verify_with_invalid_group_key_to_be_invalid();
+    test_secp256k1_frost_verify_null_secp_context();
+    test_secp256k1_frost_verify_null_signature();
+    test_secp256k1_frost_verify_null_message();
+    test_secp256k1_frost_verify_null_pubkey();
+
+    /* Test overall process with different parameters */
+    test_secp256k1_frost_with_larger_params_to_be_valid();
+
+}
+
+#endif /* SECP256K1_MODULE_FROST_TESTS_H */

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -761,3 +761,9 @@ int secp256k1_tagged_sha256(const secp256k1_context* ctx, unsigned char *hash32,
 #ifdef ENABLE_MODULE_SCHNORRSIG
 # include "modules/schnorrsig/main_impl.h"
 #endif
+
+/* FROST_SPECIFIC - START */
+#ifdef ENABLE_MODULE_FROST
+# include "modules/frost/main_impl.h"
+#endif
+/* FROST_SPECIFIC - END */

--- a/src/tests.c
+++ b/src/tests.c
@@ -6401,6 +6401,12 @@ void run_ecdsa_edge_cases(void) {
 # include "modules/schnorrsig/tests_impl.h"
 #endif
 
+/* FROST_SPECIFIC - START */
+#ifdef ENABLE_MODULE_FROST
+# include "modules/frost/tests_impl.h"
+#endif
+/* FROST_SPECIFIC - END */
+
 void run_secp256k1_memczero_test(void) {
     unsigned char buf1[6] = {1, 2, 3, 4, 5, 6};
     unsigned char buf2[sizeof(buf1)];
@@ -6684,6 +6690,12 @@ int main(int argc, char **argv) {
 #ifdef ENABLE_MODULE_SCHNORRSIG
     run_schnorrsig_tests();
 #endif
+
+/* FROST_SPECIFIC - START */
+#ifdef ENABLE_MODULE_FROST
+    run_frost_tests();
+#endif
+/* FROST_SPECIFIC - END */
 
     /* util tests */
     run_secp256k1_memczero_test();


### PR DESCRIPTION
This PR:

- adds a copyright header in the frost module, in line with what already exists - for example - for the `schnorrsig` module:
  https://github.com/bitcoin-core/secp256k1/blob/5b32602295ff7ad9e1973f96b8ee8344b82f4af0/src/modules/schnorrsig/main_impl.h#L1-L5
  This is the header that gets added:

  ```
  /***********************************************************************
   * Copyright (c) 2023 Bank of Italy                                    *
   * Distributed under the MIT software license, see the accompanying    *
   * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
   ***********************************************************************/
  ```

- modifies the READMEs to mention that the original author of the library is Bank of Italy.

