### PR TITLE
build: Disable benchmarks and examples when ext. callbacks are enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,11 +150,12 @@ if(SECP256K1_VALGRIND)
   endif()
 endif()
 
-option(SECP256K1_BUILD_BENCHMARK "Build benchmarks." ON)
+include(CMakeDependentOption)
+cmake_dependent_option(SECP256K1_BUILD_BENCHMARK "Build benchmarks." ON "NOT SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS" OFF)
 option(SECP256K1_BUILD_TESTS "Build tests." ON)
 option(SECP256K1_BUILD_EXHAUSTIVE_TESTS "Build exhaustive tests." ON)
 option(SECP256K1_BUILD_CTIME_TESTS "Build constant-time tests." ${SECP256K1_VALGRIND})
-option(SECP256K1_BUILD_EXAMPLES "Build examples." OFF)
+cmake_dependent_option(SECP256K1_BUILD_EXAMPLES "Build examples." ON "NOT SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS" OFF)
 
 # Redefine configuration flags.
 # We leave assertions on, because they are only used in the examples, and we want them always on there.

--- a/configure.ac
+++ b/configure.ac
@@ -189,6 +189,11 @@ AC_ARG_ENABLE(external_default_callbacks,
     AS_HELP_STRING([--enable-external-default-callbacks],[enable external default callback functions [default=no]]), [],
     [SECP_SET_DEFAULT([enable_external_default_callbacks], [no], [no])])
 
+if test x"$enable_external_default_callbacks" = x"yes"; then
+  enable_benchmark="no"
+  enable_examples="no"
+fi
+
 # Test-only override of the (autodetected by the C code) "widemul" setting.
 # Legal values are:
 #  * int64 (for [u]int64_t),


### PR DESCRIPTION
Closes https://github.com/bitcoin-core/secp256k1/issues/1308.