### PR TITLE
ci: Move wine prefix to /tmp to avoid error D8037 in cl.exe

### DIFF
--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -31,7 +31,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3 msvc-wine/vsdownload.py --accept-license --dest /opt/msvc Microsoft.VisualStudio.Workload.VCTools && \
     msvc-wine/install.sh /opt/msvc
 
-# Initialize the wine environment. Wait until the wineserver process has
+# Moving the wine prefix to /tmp avoids error D8037 when invoking cl.exe.
+ENV WINEPREFIX=/tmp/wineprefix
+# Initialize the wine prefix. Wait until the wineserver process has
 # exited before closing the session, to avoid corrupting the wine prefix.
 RUN wine64 wineboot --init && \
     while (ps -A | grep wineserver) > /dev/null; do sleep 1; done


### PR DESCRIPTION
Don't ask me why this makes a difference. It may be some permission problem even though everything in Cirrus CI runs as root anyway. In any case, I'll probably get mad if I investigate this further.

Fixes #1326.