### PR TITLE
cmake: Fix checking compiler flags like `-Wno-some-warning`

### DIFF
--- a/cmake/TryAppendCFlags.cmake
+++ b/cmake/TryAppendCFlags.cmake
@@ -10,7 +10,13 @@ function(secp256k1_check_c_flags_internal flags output)
 
   # This avoids running a linker.
   set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-  check_c_compiler_flag("${flags}" ${result})
+
+  # Some compilers (GCC) produce no diagnostic for -Wno-unknown-warning
+  # unless other diagnostics are being produced. Therefore, test the
+  # -Wsome-warning case instead of the -Wno-some-warning one.
+  string(REPLACE "-Wno-" "-W" non_negated_flags "${flags}")
+
+  check_c_compiler_flag("${non_negated_flags}" ${result})
 
   set(${output} ${${result}} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Some compilers ([GCC](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html)) produce no diagnostic for `-Wno-unknown-warning` unless other diagnostics are being produced:

```
$ git diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 240557f..f976824 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ if(MSVC)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()
   # Keep the following commands ordered lexicographically.
+  try_append_c_flags(-Wno-unknown-warning)
   try_append_c_flags(-pedantic)
   try_append_c_flags(-Wall) # GCC >= 2.95 and probably many other compilers.
   try_append_c_flags(-Wcast-align) # GCC >= 2.95.
$ cmake -B build -DCMAKE_C_COMPILER=gcc 2>&1 | grep -i unknown
-- Performing Test C_SUPPORTS__WNO_UNKNOWN_WARNING
-- Performing Test C_SUPPORTS__WNO_UNKNOWN_WARNING - Success
Compile options ....................... -Wno-unknown-warning -pedantic -Wall -Wcast-align -Wcast-align=strict -Wextra -Wnested-externs -Wno-long-long -Wno-overlength-strings -Wno-unused-function -Wshadow -Wstrict-prototypes -Wundef
```

This PR fixes compiler flag check in CMake-based build system.

Let me know, if the same fix is desirable in Autotools-based build system.
