### PR TITLE
test: Warn if both `VERIFY` and `COVERAGE` are defined

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -14,6 +14,9 @@
     #pragma message("Ignoring USE_EXTERNAL_CALLBACKS in tests.")
     #undef USE_EXTERNAL_DEFAULT_CALLBACKS
 #endif
+#if defined(VERIFY) && defined(COVERAGE)
+    #pragma message("Defining VERIFY for tests being built for coverage analysis support is meaningless.")
+#endif
 #include "secp256k1.c"
 
 #include "../include/secp256k1.h"


### PR DESCRIPTION
Solves one item in https://github.com/bitcoin-core/secp256k1/issues/1235.

Also see: https://github.com/bitcoin-core/secp256k1/pull/1113#discussion_r1127856040.