### PR TITLE
Use `__shiftright128` intrinsic in `secp256k1_u128_rshift` on MSVC

### DIFF
--- a/src/int128_struct_impl.h
+++ b/src/int128_struct_impl.h
@@ -80,7 +80,12 @@ static SECP256K1_INLINE void secp256k1_u128_rshift(secp256k1_uint128 *r, unsigne
      r->lo = r->hi >> (n-64);
      r->hi = 0;
    } else if (n > 0) {
+#if defined(_MSC_VER) && defined(_M_X64)
+     VERIFY_CHECK(n < 64);
+     r->lo = __shiftright128(r->lo, r->hi, n);
+#else
      r->lo = ((1U * r->hi) << (64-n)) | r->lo >> n;
+#endif
      r->hi >>= n;
    }
 }


### PR DESCRIPTION
Closes https://github.com/bitcoin-core/secp256k1/issues/1324.

As the `__shiftright128` [docs](https://learn.microsoft.com/en-us/cpp/intrinsics/shiftright128) state:
> The `Shift` value is always modulo 64...

it is not applicable for the `n >= 64` branch.