### PR TITLE
ci: Fix error D8037 in `cl.exe` (attempt 2)

### DIFF
--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -36,8 +36,7 @@ case "$WRAPPER_CMD" in
     *wine*)
         # Make sure to shutdown wineserver whenever we exit.
         trap "wineserver -k || true" EXIT INT HUP
-        # This is apparently only reliable when we run a dummy command such as "hh.exe" afterwards.
-        wineserver -p && wine hh.exe
+        wineserver -p
         ;;
 esac
 

--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -29,9 +29,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     git clone https://github.com/mstorsjo/msvc-wine && \
     mkdir /opt/msvc && \
     python3 msvc-wine/vsdownload.py --accept-license --dest /opt/msvc Microsoft.VisualStudio.Workload.VCTools && \
-    msvc-wine/install.sh /opt/msvc
-
-# Initialize the wine environment. Wait until the wineserver process has
-# exited before closing the session, to avoid corrupting the wine prefix.
-RUN wine64 wineboot --init && \
+# Since commit 2146cbfaf037e21de56c7157ec40bb6372860f51, the
+# msvc-wine effectively initializes the wine prefix when running
+# the install.sh script.
+    msvc-wine/install.sh /opt/msvc && \
+# Wait until the wineserver process has exited before closing the session,
+# to avoid corrupting the wine prefix.
     while (ps -A | grep wineserver) > /dev/null; do sleep 1; done

--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -31,9 +31,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3 msvc-wine/vsdownload.py --accept-license --dest /opt/msvc Microsoft.VisualStudio.Workload.VCTools && \
     msvc-wine/install.sh /opt/msvc
 
-# Moving the wine prefix to /tmp avoids error D8037 when invoking cl.exe.
-ENV WINEPREFIX=/tmp/wineprefix
-# Initialize the wine prefix. Wait until the wineserver process has
+# Initialize the wine environment. Wait until the wineserver process has
 # exited before closing the session, to avoid corrupting the wine prefix.
 RUN wine64 wineboot --init && \
     while (ps -A | grep wineserver) > /dev/null; do sleep 1; done


### PR DESCRIPTION
Since the https://github.com/mstorsjo/msvc-wine/commit/2146cbfaf037e21de56c7157ec40bb6372860f51, the `msvc-wine` effectively initializes the WINE prefix when running the `install.sh` script. See [`install.sh`#L143](https://github.com/mstorsjo/msvc-wine/blob/2146cbfaf037e21de56c7157ec40bb6372860f51/install.sh#L143): 
```sh
    WINEDEBUG=-all wine64 wineboot &>/dev/null
```

Our following `wine64 wineboot --init` just messes up with the prefix.

This PR fixes this issue.

Also https://github.com/bitcoin-core/secp256k1/pull/1327 has been reverted as apparently it does not work. And https://github.com/bitcoin-core/secp256k1/pull/1320 has been combined into this one.