### PR TITLE
build: Use `SECP256K1_STATICLIB` macro instead of warning suppressions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -153,7 +153,7 @@ endif
 if USE_EXAMPLES
 noinst_PROGRAMS += ecdsa_example
 ecdsa_example_SOURCES = examples/ecdsa.c
-ecdsa_example_CPPFLAGS = -I$(top_srcdir)/include
+ecdsa_example_CPPFLAGS = -I$(top_srcdir)/include -DSECP256K1_STATICLIB
 ecdsa_example_LDADD = libsecp256k1.la
 ecdsa_example_LDFLAGS = -static
 if BUILD_WINDOWS
@@ -163,7 +163,7 @@ TESTS += ecdsa_example
 if ENABLE_MODULE_ECDH
 noinst_PROGRAMS += ecdh_example
 ecdh_example_SOURCES = examples/ecdh.c
-ecdh_example_CPPFLAGS = -I$(top_srcdir)/include
+ecdh_example_CPPFLAGS = -I$(top_srcdir)/include -DSECP256K1_STATICLIB
 ecdh_example_LDADD = libsecp256k1.la
 ecdh_example_LDFLAGS = -static
 if BUILD_WINDOWS
@@ -174,7 +174,7 @@ endif
 if ENABLE_MODULE_SCHNORRSIG
 noinst_PROGRAMS += schnorr_example
 schnorr_example_SOURCES = examples/schnorr.c
-schnorr_example_CPPFLAGS = -I$(top_srcdir)/include
+schnorr_example_CPPFLAGS = -I$(top_srcdir)/include -DSECP256K1_STATICLIB
 schnorr_example_LDADD = libsecp256k1.la
 schnorr_example_LDFLAGS = -static
 if BUILD_WINDOWS

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,7 +7,7 @@ target_link_libraries(example INTERFACE
   $<$<PLATFORM_ID:Windows>:bcrypt>
 )
 if(NOT BUILD_SHARED_LIBS AND MSVC)
-  target_link_options(example INTERFACE /IGNORE:4217)
+  target_compile_definitions(example INTERFACE SECP256K1_STATICLIB)
 endif()
 
 add_executable(ecdsa_example ecdsa.c)

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -140,7 +140,7 @@ typedef int (*secp256k1_nonce_function)(
 #   define SECP256K1_API            __declspec (dllexport)
 #   define SECP256K1_API_VAR extern __declspec (dllexport)
 #  endif
-# elif defined _MSC_VER
+# elif defined(_MSC_VER) && !defined(SECP256K1_STATICLIB)
 #  define SECP256K1_API
 #  define SECP256K1_API_VAR  extern __declspec (dllimport)
 # elif defined DLL_EXPORT


### PR DESCRIPTION
The changes from https://github.com/bitcoin-core/secp256k1/pull/1209 has been [described](https://github.com/bitcoin-core/secp256k1/blob/master/CHANGELOG.md#030---2023-03-08) as:
> Fixed declarations of API variables for MSVC (`__declspec(dllimport)`). This fixes MSVC builds of programs which link against a libsecp256k1 DLL dynamically and use API variables (and not only API functions). Unfortunately, the MSVC linker now will emit warning `LNK4217` when trying to link against libsecp256k1 statically. Pass `/ignore:4217` to the linker to suppress this warning. 

Apparently, this description is not complete. When [building](https://cirrus-ci.com/task/4676409155649536) Bitcoin Core the other warning being raised as well:
```
LINK : warning LNK4217: symbol 'secp256k1_nonce_function_rfc6979' defined in 'libsecp256k1.lib(secp256k1.obj)' is imported by 'libbitcoin_common.lib(key.obj)' in function '"public: bool __cdecl CKey::Sign(class uint256 const &,class std::vector<unsigned char,class std::allocator<unsigned char> > &,bool,unsigned int)const " (?Sign@CKey@@QEBA_NAEBVuint256@@AEAV?$vector@EV?$allocator@E@std@@@std@@_NI@Z)' [C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\build_msvc\test_bitcoin\test_bitcoin.vcxproj]
```

This PR provides to the user of a static libsecp256k1 library an option to define the `SECP256K1_STATICLIB` macro instead of ignoring MSVC linker warnings LNK4217 and LNK4286.