### PR TITLE
Normalize ge produced from secp256k1_pubkey_load

### DIFF
--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -247,8 +247,8 @@ static int secp256k1_pubkey_load(const secp256k1_context* ctx, secp256k1_ge* ge,
     } else {
         /* Otherwise, fall back to 32-byte big endian for X and Y. */
         secp256k1_fe x, y;
-        secp256k1_fe_set_b32_mod(&x, pubkey->data);
-        secp256k1_fe_set_b32_mod(&y, pubkey->data + 32);
+        ARG_CHECK(secp256k1_fe_set_b32_limit(&x, pubkey->data));
+        ARG_CHECK(secp256k1_fe_set_b32_limit(&y, pubkey->data + 32));
         secp256k1_ge_set_xy(ge, &x, &y);
     }
     ARG_CHECK(!secp256k1_fe_is_zero(&ge->x));


### PR DESCRIPTION
The output `ge` in secp256k1_pubkey_load is normalized when `sizeof(secp256k1_ge_storage) = 64` but not when it's not 64. ARG_CHECK at the end of the function assumes normalization. So normalize ge in the other code path too.

context: [#1129(comment)](https://github.com/bitcoin-core/secp256k1/pull/1129/files#r1196167066)