### PR TITLE
scalar: introduce and use `secp256k1_{read,write}_be64` helpers

### DIFF
--- a/src/scalar_4x64_impl.h
+++ b/src/scalar_4x64_impl.h
@@ -133,10 +133,10 @@ static void secp256k1_scalar_cadd_bit(secp256k1_scalar *r, unsigned int bit, int
 
 static void secp256k1_scalar_set_b32(secp256k1_scalar *r, const unsigned char *b32, int *overflow) {
     int over;
-    r->d[0] = ((uint64_t)secp256k1_read_be32(&b32[24]) << 32) | (uint64_t)secp256k1_read_be32(&b32[28]);
-    r->d[1] = ((uint64_t)secp256k1_read_be32(&b32[16]) << 32) | (uint64_t)secp256k1_read_be32(&b32[20]);
-    r->d[2] = ((uint64_t)secp256k1_read_be32(&b32[8])  << 32) | (uint64_t)secp256k1_read_be32(&b32[12]);
-    r->d[3] = ((uint64_t)secp256k1_read_be32(&b32[0])  << 32) | (uint64_t)secp256k1_read_be32(&b32[4]);
+    r->d[0] = secp256k1_read_be64(&b32[24]);
+    r->d[1] = secp256k1_read_be64(&b32[16]);
+    r->d[2] = secp256k1_read_be64(&b32[8]);
+    r->d[3] = secp256k1_read_be64(&b32[0]);
     over = secp256k1_scalar_reduce(r, secp256k1_scalar_check_overflow(r));
     if (overflow) {
         *overflow = over;
@@ -144,10 +144,10 @@ static void secp256k1_scalar_set_b32(secp256k1_scalar *r, const unsigned char *b
 }
 
 static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar* a) {
-    secp256k1_write_be32(&bin[0],  a->d[3] >> 32); secp256k1_write_be32(&bin[4],  a->d[3]);
-    secp256k1_write_be32(&bin[8],  a->d[2] >> 32); secp256k1_write_be32(&bin[12], a->d[2]);
-    secp256k1_write_be32(&bin[16], a->d[1] >> 32); secp256k1_write_be32(&bin[20], a->d[1]);
-    secp256k1_write_be32(&bin[24], a->d[0] >> 32); secp256k1_write_be32(&bin[28], a->d[0]);
+    secp256k1_write_be64(&bin[0],  a->d[3]);
+    secp256k1_write_be64(&bin[8],  a->d[2]);
+    secp256k1_write_be64(&bin[16], a->d[1]);
+    secp256k1_write_be64(&bin[24], a->d[0]);
 }
 
 SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -7516,16 +7516,31 @@ static void run_secp256k1_memczero_test(void) {
 }
 
 static void run_secp256k1_byteorder_tests(void) {
-    const uint32_t x = 0xFF03AB45;
-    const unsigned char x_be[4] = {0xFF, 0x03, 0xAB, 0x45};
-    unsigned char buf[4];
-    uint32_t x_;
+    {
+        const uint32_t x = 0xFF03AB45;
+        const unsigned char x_be[4] = {0xFF, 0x03, 0xAB, 0x45};
+        unsigned char buf[4];
+        uint32_t x_;
 
-    secp256k1_write_be32(buf, x);
-    CHECK(secp256k1_memcmp_var(buf, x_be, sizeof(buf)) == 0);
+        secp256k1_write_be32(buf, x);
+        CHECK(secp256k1_memcmp_var(buf, x_be, sizeof(buf)) == 0);
 
-    x_ = secp256k1_read_be32(buf);
-    CHECK(x == x_);
+        x_ = secp256k1_read_be32(buf);
+        CHECK(x == x_);
+    }
+
+    {
+        const uint64_t x = 0xCAFE0123BEEF4567;
+        const unsigned char x_be[8] = {0xCA, 0xFE, 0x01, 0x23, 0xBE, 0xEF, 0x45, 0x67};
+        unsigned char buf[8];
+        uint64_t x_;
+
+        secp256k1_write_be64(buf, x);
+        CHECK(secp256k1_memcmp_var(buf, x_be, sizeof(buf)) == 0);
+
+        x_ = secp256k1_read_be64(buf);
+        CHECK(x == x_);
+    }
 }
 
 static void int_cmov_test(void) {

--- a/src/util.h
+++ b/src/util.h
@@ -353,4 +353,28 @@ SECP256K1_INLINE static void secp256k1_write_be32(unsigned char* p, uint32_t x) 
     p[0] = x >> 24;
 }
 
+/* Read a uint64_t in big endian */
+SECP256K1_INLINE static uint64_t secp256k1_read_be64(const unsigned char* p) {
+    return (uint64_t)p[0] << 56 |
+           (uint64_t)p[1] << 48 |
+           (uint64_t)p[2] << 40 |
+           (uint64_t)p[3] << 32 |
+           (uint64_t)p[4] << 24 |
+           (uint64_t)p[5] << 16 |
+           (uint64_t)p[6] << 8  |
+           (uint64_t)p[7];
+}
+
+/* Write a uint64_t in big endian */
+SECP256K1_INLINE static void secp256k1_write_be64(unsigned char* p, uint64_t x) {
+    p[7] = x;
+    p[6] = x >>  8;
+    p[5] = x >> 16;
+    p[4] = x >> 24;
+    p[3] = x >> 32;
+    p[2] = x >> 40;
+    p[1] = x >> 48;
+    p[0] = x >> 56;
+}
+
 #endif /* SECP256K1_UTIL_H */


### PR DESCRIPTION
This is a simple follow-up to #1339, as suggested in comment https://github.com/bitcoin-core/secp256k1/pull/1339#issuecomment-1587508040.