### PR TITLE
ci: Print commit in Windows container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -383,6 +383,9 @@ task:
     # Ignore MSBuild warning MSB8029.
     # See: https://learn.microsoft.com/en-us/visualstudio/msbuild/errors/msb8029?view=vs-2022
     IgnoreWarnIntDirInTempDetected: 'true'
+  git_show_script:
+    # Print commit to allow reproducing the job outside of CI.
+    - git show --no-patch
   configure_script:
     - '%x64_NATIVE_TOOLS%'
     - cmake -E env CFLAGS="/WX" cmake -G "Visual Studio 17 2022" -A x64 -S . -B build -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON


### PR DESCRIPTION
This PR is a follow-up to https://github.com/bitcoin-core/secp256k1/pull/1368 and adds the same functionality to Windows containers that is already available in Linux containers.

See: https://github.com/bitcoin-core/secp256k1/pull/1368#discussion_r1250454050.