### PR TITLE
refactor: Drop unused cast

### DIFF
--- a/src/hash_impl.h
+++ b/src/hash_impl.h
@@ -138,7 +138,7 @@ static void secp256k1_sha256_write(secp256k1_sha256 *hash, const unsigned char *
     }
     if (len) {
         /* Fill the buffer with what remains. */
-        memcpy(((unsigned char*)hash->buf) + bufsize, data, len);
+        memcpy(hash->buf + bufsize, data, len);
     }
 }
 


### PR DESCRIPTION
The resulted code treats `memcpy`'s arguments exactly the same way as it does a few lines above: https://github.com/bitcoin-core/secp256k1/blob/c545fdc374964424683d9dac31a828adedabe860/src/hash_impl.h#L133