### PR TITLE
util: remove unused checked_realloc

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -152,14 +152,6 @@ static SECP256K1_INLINE void *checked_malloc(const secp256k1_callback* cb, size_
     return ret;
 }
 
-static SECP256K1_INLINE void *checked_realloc(const secp256k1_callback* cb, void *ptr, size_t size) {
-    void *ret = realloc(ptr, size);
-    if (ret == NULL) {
-        secp256k1_callback_call(cb, "Out of memory");
-    }
-    return ret;
-}
-
 #if defined(__BIGGEST_ALIGNMENT__)
 #define ALIGNMENT __BIGGEST_ALIGNMENT__
 #else


### PR DESCRIPTION
Usage was removed in 6fe50439 . This should be a NOOP.

Noticed when analyzing for zenbleed exposure: stdlib calls that aren't optimized away.

In this case realloc isn't making it into the final binary, but as far as I can tell this is completely dead code and should be dropped.