### PR TITLE
ci: Run "Windows (VS 2022)" job on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+
+env:
+  SECP256K1_BENCH_ITERS: 2
+
+jobs:
+  win64-native:
+    name: "x86_64: Windows (VS 2022)"
+    # See: https://github.com/actions/runner-images#available-images.
+    runs-on: windows-2022
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_shared_libs: ['ON', 'OFF']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate buildsystem
+        run: cmake -E env CFLAGS="/WX" cmake -B build -A x64 -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libs }}
+
+      - name: Build
+        run: cmake --build build --config RelWithDebInfo -- /p:UseMultiToolTask=true /maxCpuCount
+
+      - name: Check
+        run: |
+          ctest -C RelWithDebInfo --test-dir build -j ([int]$env:NUMBER_OF_PROCESSORS + 1)
+          build\src\RelWithDebInfo\bench_ecmult.exe
+          build\src\RelWithDebInfo\bench_internal.exe
+          build\src\RelWithDebInfo\bench.exe


### PR DESCRIPTION
This PR solves one item in https://github.com/bitcoin-core/secp256k1/issues/1392.

In response to upcoming [limiting free usage of Cirrus CI](https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/), suggesting to move (partially?) CI tasks/jobs from Cirrus CI to [GitHub Actions](https://docs.github.com/actions) (GHA).

Here is example from my personal repo: https://github.com/hebasto/secp256k1/actions/runs/5806269046.

For security concerns, see:
- https://github.com/bitcoin/bitcoin/issues/28098#issuecomment-1651432106
- https://github.com/bitcoin/bitcoin/issues/28098#issuecomment-1651688197

I'm suggesting the repository "Actions permissions" as follows:

![image](https://github.com/bitcoin-core/secp256k1/assets/32963518/bd18d489-784f-48ba-b599-ed1c4dfc34fa)

![image](https://github.com/bitcoin-core/secp256k1/assets/32963518/632280e0-9c26-42eb-a0ed-24f9a8142faa)

---

See build logs in my personal repo: https://github.com/hebasto/secp256k1/actions/runs/5692587475.