### PR TITLE
refactor: take use of `secp256k1_scalar_{zero,one}` constants (part 2)

### DIFF
--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -244,7 +244,6 @@ static void generate_scalar(uint32_t num, secp256k1_scalar* scalar) {
 
 static void run_ecmult_multi_bench(bench_data* data, size_t count, int includes_g, int num_iters) {
     char str[32];
-    static const secp256k1_scalar zero = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
     size_t iters = 1 + num_iters / count;
     size_t iter;
 
@@ -262,7 +261,7 @@ static void run_ecmult_multi_bench(bench_data* data, size_t count, int includes_
             secp256k1_scalar_add(&total, &total, &tmp);
         }
         secp256k1_scalar_negate(&total, &total);
-        secp256k1_ecmult(&data->expected_output[iter], NULL, &zero, &total);
+        secp256k1_ecmult(&data->expected_output[iter], NULL, &secp256k1_scalar_zero, &total);
     }
 
     /* Run the benchmark. */


### PR DESCRIPTION
This is a follow-up to PR #1330, which replaced scalar variables that were set to zero and one via `secp256k1_scalar_set_int`, but missed instances which were directly initialized via SECP256K1_SCALAR_CONST (found via `git grep "SECP256K1_SCALAR_CONST(0,"`).