### PR TITLE
ci, gha: Run all MSVC tests on Windows natively

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -239,48 +239,6 @@ task:
     - ./ci/cirrus.sh
   << : *CAT_LOGS
 
-task:
-  << : *LINUX_CONTAINER
-  env:
-    WRAPPER_CMD: wine
-    WERROR_CFLAGS: -WX
-    WITH_VALGRIND: no
-    ECDH: yes
-    RECOVERY: yes
-    EXPERIMENTAL: yes
-    SCHNORRSIG: yes
-    ELLSWIFT: yes
-    CTIMETESTS: no
-    # Use a MinGW-w64 host to tell ./configure we're building for Windows.
-    # This will detect some MinGW-w64 tools but then make will need only
-    # the MSVC tools CC, AR and NM as specified below.
-    HOST: x86_64-w64-mingw32
-    CC: /opt/msvc/bin/x64/cl
-    AR: /opt/msvc/bin/x64/lib
-    NM: /opt/msvc/bin/x64/dumpbin -symbols -headers
-    # Set non-essential options that affect the CLI messages here.
-    # (They depend on the user's taste, so we don't want to set them automatically in configure.ac.)
-    CFLAGS: -nologo -diagnostics:caret
-    LDFLAGS: -Xlinker -Xlinker -Xlinker -nologo
-  matrix:
-    - name: "x86_64 (MSVC): Windows (Debian stable, Wine)"
-    - name: "x86_64 (MSVC): Windows (Debian stable, Wine, int128_struct)"
-      env:
-        WIDEMUL: int128_struct
-    - name: "x86_64 (MSVC): Windows (Debian stable, Wine, int128_struct with __(u)mulh)"
-      env:
-        WIDEMUL: int128_struct
-        CPPFLAGS: -DSECP256K1_MSVC_MULH_TEST_OVERRIDE
-    - name: "i686 (MSVC): Windows (Debian stable, Wine)"
-      env:
-        HOST: i686-w64-mingw32
-        CC: /opt/msvc/bin/x86/cl
-        AR: /opt/msvc/bin/x86/lib
-        NM: /opt/msvc/bin/x86/dumpbin -symbols -headers
-  test_script:
-    - ./ci/cirrus.sh
-  << : *CAT_LOGS
-
 # Sanitizers
 task:
   << : *LINUX_CONTAINER
@@ -374,4 +332,3 @@ task:
   test_script:
     - g++ -Werror include/*.h
     - clang -Werror -x c++-header include/*.h
-    - /opt/msvc/bin/x64/cl.exe -c -WX -TP include/*.h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,41 @@ env:
 
 jobs:
   win64-native:
-    name: "x86_64: Windows, VS 2022"
+    name: ${{ matrix.configuration.job_name }}
     # See: https://github.com/actions/runner-images#available-images.
     runs-on: windows-2022
 
     strategy:
       fail-fast: false
       matrix:
-        lib_type: ['shared', 'static']
+        configuration:
+          - job_name: 'x64 (MSVC): Windows (VS 2022, shared)'
+            cmake_options: '-A x64 -DBUILD_SHARED_LIBS=ON'
+          - job_name: 'x64 (MSVC): Windows (VS 2022, static)'
+            cmake_options: '-A x64 -DBUILD_SHARED_LIBS=OFF'
+          - job_name: 'x64 (MSVC): Windows (VS 2022, int128_struct)'
+            cmake_options: '-A x64 -DSECP256K1_TEST_OVERRIDE_WIDE_MULTIPLY=int128_struct'
+          - job_name: 'x64 (MSVC): Windows (VS 2022, int128_struct with __(u)mulh)'
+            cmake_options: '-A x64 -DSECP256K1_TEST_OVERRIDE_WIDE_MULTIPLY=int128_struct'
+            cpp_flags: '/DSECP256K1_MSVC_MULH_TEST_OVERRIDE'
+          - job_name: 'x86 (MSVC): Windows (VS 2022)'
+            cmake_options: '-A Win32'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Generate buildsystem
-        run: cmake -E env CFLAGS="/WX" cmake -B build -A x64 -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON -DBUILD_SHARED_LIBS=${{ matrix.lib_type == 'shared' && 'ON' || 'OFF' }}
+        run: cmake -E env CFLAGS="/WX ${{ matrix.configuration.cpp_flags }}" cmake -B build -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON ${{ matrix.configuration.cmake_options }}
 
       - name: Build
         run: cmake --build build --config RelWithDebInfo -- /p:UseMultiToolTask=true /maxCpuCount
+
+      - name: Binaries info
+        # Use the bash shell included with Git for Windows.
+        shell: bash
+        run: |
+          cd build/src/RelWithDebInfo && file *tests.exe bench*.exe libsecp256k1-*.dll || true
 
       - name: Check
         run: |
@@ -37,6 +54,22 @@ jobs:
           build\src\RelWithDebInfo\bench_ecmult.exe
           build\src\RelWithDebInfo\bench_internal.exe
           build\src\RelWithDebInfo\bench.exe
+
+  win64-native-headers:
+    name: "x64 (MSVC): C++ (public headers)"
+    # See: https://github.com/actions/runner-images#available-images.
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Add cl.exe to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: C++ (public headers)
+        run: |
+          cl.exe -c -WX -TP include/*.h
 
   sage:
     name: "SageMath prover"

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -31,16 +31,6 @@ print_environment() {
 }
 print_environment
 
-# Start persistent wineserver if necessary.
-# This speeds up jobs with many invocations of wine (e.g., ./configure with MSVC) tremendously.
-case "$WRAPPER_CMD" in
-    *wine*)
-        # Make sure to shutdown wineserver whenever we exit.
-        trap "wineserver -k || true" EXIT INT HUP
-        wineserver -p
-        ;;
-esac
-
 env >> test_env.log
 
 # If gcc is requested, assert that it's in fact gcc (and not some symlinked Apple clang).

--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         gcc-aarch64-linux-gnu libc6-dev-arm64-cross libc6-dbg:arm64 \
         gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross libc6-dbg:ppc64el \
         gcc-mingw-w64-x86-64-win32 wine64 wine \
-        gcc-mingw-w64-i686-win32 wine32
+        gcc-mingw-w64-i686-win32 wine32 \
+        python3
 
 WORKDIR /root
 
@@ -55,20 +56,3 @@ RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.
     # Create symlinks for them
     ln -s $(ls /usr/bin/clang-?? | sort | tail -1) /usr/bin/clang-snapshot && \
     ln -s $(ls /usr/bin/clang-?? | sort | head -1) /usr/bin/clang
-
-# The "wine" package provides a convenience wrapper that we need
-RUN apt-get update && apt-get install --no-install-recommends -y \
-        git ca-certificates wine64 wine python3-simplejson python3-six msitools winbind procps && \
-# Workaround for `wine` package failure to employ the Debian alternatives system properly.
-    ln -s /usr/lib/wine/wine64 /usr/bin/wine64 && \
-# Set of tools for using MSVC on Linux.
-    git clone https://github.com/mstorsjo/msvc-wine && \
-    mkdir /opt/msvc && \
-    python3 msvc-wine/vsdownload.py --accept-license --dest /opt/msvc Microsoft.VisualStudio.Workload.VCTools && \
-# Since commit 2146cbfaf037e21de56c7157ec40bb6372860f51, the
-# msvc-wine effectively initializes the wine prefix when running
-# the install.sh script.
-    msvc-wine/install.sh /opt/msvc && \
-# Wait until the wineserver process has exited before closing the session,
-# to avoid corrupting the wine prefix.
-    while (ps -A | grep wineserver) > /dev/null; do sleep 1; done


### PR DESCRIPTION
This PR addresses the https://github.com/bitcoin-core/secp256k1/pull/1398#discussion_r1294608154 and is an alternative to https://github.com/bitcoin-core/secp256k1/pull/1398 in some part.

From https://github.com/bitcoin-core/secp256k1/pull/1398#discussion_r1294608154:
> Advantages:
> 
>    * That would get us rid of the entire business of "installing MSVC" and it would make this Docker image much smaller.
> 
> 
> Disadvantages:
> 
>    * We won't have Dockerfile anymore that people can use locally, e.g., when working on problems that appear only with MSVC.
> 
>    * We'll probably need some separate CI script for Windows / CMake. Currently, we simply reuse the Linux / autotools script, which is neat.

I do prefer this approach because it is natural.