### PR TITLE
ci: Use Homebrew's gcc in native macOS task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -139,6 +139,7 @@ task:
     - env: {BUILD: distcheck}
   brew_script:
     - brew install automake libtool gcc
+    - ln -s /opt/homebrew/bin/gcc-?? /opt/homebrew/bin/gcc
   test_script:
     - ./ci/cirrus.sh
   << : *CAT_LOGS

--- a/ci/cirrus.sh
+++ b/ci/cirrus.sh
@@ -43,6 +43,13 @@ esac
 
 env >> test_env.log
 
+# If gcc is requested, assert that it's in fact gcc (and not some symlinked Apple clang).
+case "${CC:-undefined}" in
+    *gcc*)
+        $CC -v 2>&1 | grep -q "gcc version" || exit 1;
+        ;;
+esac
+
 if [ -n "${CC+x}" ]; then
     # The MSVC compiler "cl" doesn't understand "-v"
     $CC -v || true


### PR DESCRIPTION
Fixes an issue noticed in https://github.com/bitcoin-core/secp256k1/pull/1394#issuecomment-1680233151:

> This uses the wrong GCC, namely Clang

When `CC=gcc`:

- on the [master](https://api.cirrus-ci.com/v1/task/5074854529990656/logs/test.log) branch:
```
+ gcc -v
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.5.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

- with this [PR](https://api.cirrus-ci.com/v1/task/5460539170619392/logs/test.log):
```
+ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/opt/homebrew/Cellar/gcc/13.1.0/bin/../libexec/gcc/aarch64-apple-darwin22/13/lto-wrapper
Target: aarch64-apple-darwin22
Configured with: ../configure --prefix=/opt/homebrew/opt/gcc --libdir=/opt/homebrew/opt/gcc/lib/gcc/current --disable-nls --enable-checking=release --with-gcc-major-version-only --enable-languages=c,c++,objc,obj-c++,fortran --program-suffix=-13 --with-gmp=/opt/homebrew/opt/gmp --with-mpfr=/opt/homebrew/opt/mpfr --with-mpc=/opt/homebrew/opt/libmpc --with-isl=/opt/homebrew/opt/isl --with-zstd=/opt/homebrew/opt/zstd --with-pkgversion='Homebrew GCC 13.1.0' --with-bugurl=https://github.com/Homebrew/homebrew-core/issues --with-system-zlib --build=aarch64-apple-darwin22 --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 13.1.0 (Homebrew GCC 13.1.0) 
```