### PR TITLE
ci, gha: Ensure only a single workflow processes `github.ref` at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     tags-ignore:
       - '**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   ### compiler options
   HOST:


### PR DESCRIPTION
This PR ensures that only a single workflow processes any push or pull request at a time.

A new push will be queued (including the master branch).

For a new pull request update, the previous in-progress one will be cancelled.

Same as https://github.com/bitcoin/bitcoin/pull/28282.