### PR TITLE
ci: Drop no longer needed workaround

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,8 +128,6 @@ task:
     ELLSWIFT: yes
     CTIMETESTS: no
   test_script:
-    # https://sourceware.org/bugzilla/show_bug.cgi?id=27008
-    - rm /etc/ld.so.cache
     - ./ci/ci.sh
   << : *CAT_LOGS
 


### PR DESCRIPTION
The https://sourceware.org/bugzilla/show_bug.cgi?id=27008 bug has been resolved since libc 2.33.

Debian Bookworm has [libc](https://packages.debian.org/bookworm/libc6) 2.36.

I've separated this change from moving CI tasks to GitHub Actions intentionally.