### PR TITLE
ci, doc: Document required actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,10 @@
+# This workflow requires the following actions to be allowed
+# in the repository's "Actions permissions":
+#   actions/checkout@*,
+#   docker/build-push-action@*,
+#   docker/setup-buildx-action@*,
+#   ilammy/msvc-dev-cmd@*,
+
 name: CI
 on:
   pull_request:


### PR DESCRIPTION
Suggested in https://github.com/bitcoin/bitcoin/pull/28173#pullrequestreview-1587098202:

> I wonder if it makes sense to document the required permissions inside the file?