### PR TITLE
ci: Use concurrency for pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.event_name != 'pull_request' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   ### compiler options


### PR DESCRIPTION
This PR is an amendment for https://github.com/bitcoin-core/secp256k1/pull/1403.

It avoids skipping builds when some pushes were done consequentially.

From GitHub Actions [docs](https://docs.github.com/en/actions/using-jobs/using-concurrency):

> When a concurrent ... workflow is queued, if another ... workflow using the same concurrency group in the repository is in progress, the queued ... workflow will be pending. **Any previously pending ... workflow in the concurrency group will be canceled.**

No behavior change for pull requests.

Same as https://github.com/bitcoin/bitcoin/pull/28322.