### PR TITLE
ci: Make repetitive command the default one

### DIFF
--- a/.github/actions/run-in-docker-action/action.yml
+++ b/.github/actions/run-in-docker-action/action.yml
@@ -9,7 +9,8 @@ inputs:
     required: true
   command:
     description: 'A command to run in a container'
-    required: true
+    required: false
+    default: ./ci/ci.sh
 runs:
   using: "composite"
   steps:

--- a/.github/actions/run-in-docker-action/action.yml
+++ b/.github/actions/run-in-docker-action/action.yml
@@ -41,5 +41,8 @@ runs:
           $(echo '${{ toJSON(env) }}' | jq -r 'keys[] | "--env \(.) "') \
           --volume ${{ github.workspace }}:${{ github.workspace }} \
           --workdir ${{ github.workspace }} \
-          ${{ inputs.tag }} bash -c "${{ inputs.command }}"
+          ${{ inputs.tag }} bash -c "
+            git config --global --add safe.directory ${{ github.workspace }}
+            ${{ inputs.command }}
+          "
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -156,7 +155,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -203,7 +201,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -258,7 +255,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -305,7 +301,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -352,7 +347,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -409,7 +403,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -467,7 +460,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -526,7 +518,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -583,7 +574,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true
@@ -747,7 +737,6 @@ jobs:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
           command: >
-            git config --global --add safe.directory ${{ github.workspace }} &&
             ./ci/ci.sh
 
       - run: cat tests.log || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -154,8 +152,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -200,8 +196,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -254,8 +248,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -300,8 +292,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -346,8 +336,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -402,8 +390,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -459,8 +445,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -517,8 +501,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -573,8 +555,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}
@@ -736,8 +716,6 @@ jobs:
         with:
           dockerfile: ./ci/linux-debian.Dockerfile
           tag: linux-debian-image
-          command: >
-            ./ci/ci.sh
 
       - run: cat tests.log || true
         if: ${{ always() }}


### PR DESCRIPTION
This PR addresses the https://github.com/bitcoin-core/secp256k1/pull/1409#discussion_r1301767281:
> couldn't we add this to `run-in-docker-action` to avoid duplication?