### PR TITLE
ci: Switch macOS from Ventura to Monterey and add Valgrind

### DIFF
--- a/.github/actions/install-homebrew-valgrind/action.yml
+++ b/.github/actions/install-homebrew-valgrind/action.yml
@@ -1,0 +1,33 @@
+name: "Install Valgrind"
+description: "Install Homebrew's Valgrind package and cache it."
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        brew tap LouisBrunner/valgrind
+        brew fetch --HEAD LouisBrunner/valgrind/valgrind
+        echo "CI_HOMEBREW_CELLAR_VALGRIND=$(brew --cellar valgrind)" >> "$GITHUB_ENV"
+      shell: bash
+
+    - run: |
+        sw_vers > valgrind_fingerprint
+        brew --version >> valgrind_fingerprint
+        git -C "$(brew --cache)/valgrind--git" rev-parse HEAD >> valgrind_fingerprint
+        cat valgrind_fingerprint
+      shell: bash
+
+    - uses: actions/cache@v3
+      id: cache
+      with:
+        path: ${{ env.CI_HOMEBREW_CELLAR_VALGRIND }}
+        key: ${{ github.job }}-valgrind-${{ hashFiles('valgrind_fingerprint') }}
+
+    - if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        brew install --HEAD LouisBrunner/valgrind/valgrind
+      shell: bash
+
+    - if: steps.cache.outputs.cache-hit == 'true'
+      run: |
+        brew link valgrind
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,27 +575,28 @@ jobs:
         if: ${{ always() }}
 
   macos-native:
-    name: "x86_64: macOS Ventura"
+    name: "x86_64: macOS Monterey"
     # See: https://github.com/actions/runner-images#available-images.
-    runs-on: macos-13 # Use M1 once available https://github.com/github/roadmap/issues/528
+    runs-on: macos-12 # Use M1 once available https://github.com/github/roadmap/issues/528
 
     env:
-      ASM: 'no'
-      WITH_VALGRIND: 'no'
-      CTIMETESTS: 'no'
       CC: 'clang'
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
 
     strategy:
       fail-fast: false
       matrix:
         env_vars:
           - { WIDEMUL: 'int64',  RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes' }
-          - { WIDEMUL: 'int64',  RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CC: 'gcc' }
           - { WIDEMUL: 'int128_struct', ECMULTGENPRECISION: 2, ECMULTWINDOW: 4 }
           - { WIDEMUL: 'int128',                  ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes' }
-          - { WIDEMUL: 'int128', RECOVERY: 'yes',              SCHNORRSIG: 'yes' }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes' }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes' }
           - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CC: 'gcc' }
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CPPFLAGS: '-DVERIFY' }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes',            WRAPPER_CMD: 'valgrind --error-exitcode=42', SECP256K1_TEST_ITERS: 2 }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CC: 'gcc', WRAPPER_CMD: 'valgrind --error-exitcode=42', SECP256K1_TEST_ITERS: 2 }
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CPPFLAGS: '-DVERIFY', CTIMETESTS: 'no' }
           - BUILD: 'distcheck'
 
     steps:
@@ -603,12 +604,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Homebrew packages
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: 1
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
           brew install automake libtool gcc
           ln -s $(brew --prefix gcc)/bin/gcc-?? /usr/local/bin/gcc
+
+      - name: Install and cache Valgrind
+        uses: ./.github/actions/install-homebrew-valgrind
 
       - name: CI script
         env: ${{ matrix.env_vars }}


### PR DESCRIPTION
This PR switches the macOS native job from Ventura to Monterey, which allows to support Valgrind.

Both runners--`macos-12` and `macos-13`--have the same clang compilers installed:
- https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
- https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

But Valgrind works fine on macOS Monterey, but not on Ventura.

See: https://github.com/bitcoin-core/secp256k1/issues/1392#issuecomment-1693685610.

The Homebrew's Valgrind package is cached once it has been built (as it was before https://github.com/bitcoin-core/secp256k1/pull/1152). Therefore, the `actions/cache@*` action is needed to be added to the list of the allowed actions.

https://github.com/bitcoin-core/secp256k1/pull/1412#issuecomment-1695716350:
> By the way, this solves #1151.