### PR TITLE
ci/gha: Add ARM64 QEMU jobs for clang and clang-snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,11 +485,11 @@ jobs:
       matrix:
         configuration:
           - env_vars:
-              CFLAGS: '-fsanitize=memory -g'
+              CFLAGS: '-fsanitize=memory -fsanitize-recover=memory -g'
           - env_vars:
               ECMULTGENPRECISION: 2
               ECMULTWINDOW: 2
-              CFLAGS: '-fsanitize=memory -g -O3'
+              CFLAGS: '-fsanitize=memory -fsanitize-recover=memory -g -O3'
 
     env:
       ECDH: 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,11 +283,22 @@ jobs:
       ELLSWIFT: 'yes'
       CTIMETESTS: 'no'
 
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration:
+          - env_vars: { } # gcc
+          - env_vars: # clang
+              CC: 'clang --target=aarch64-linux-gnu'
+          - env_vars: # clang-snapshot
+              CC: 'clang-snapshot --target=aarch64-linux-gnu'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: CI script
+        env: ${{ matrix.configuration.env_vars }}
         uses: ./.github/actions/run-in-docker-action
         with:
           dockerfile: ./ci/linux-debian.Dockerfile


### PR DESCRIPTION
Solves one item in https://github.com/bitcoin-core/secp256k1/issues/1392.

This PR also has a few tweaks to the Dockerfile, see individual commits.

---

I'll follow up soon with a PR for ARM64/gcc. This will rely on Cirrus CI.