### PR TITLE
cmake: Install `libsecp256k1.pc` file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,7 @@ jobs:
 
       - name: Check installation with Autotools
         env:
-          CI_INSTALL: ${{ runner.temp }}/${{ github.run_id }}${{ github.action }}
+          CI_INSTALL: ${{ runner.temp }}/${{ github.run_id }}${{ github.action }}/install
         run: |
           ./autogen.sh && ./configure --prefix=${{ env.CI_INSTALL }} && make clean && make install && ls -RlAh ${{ env.CI_INSTALL }}
           gcc -o ecdsa examples/ecdsa.c $(PKG_CONFIG_PATH=${{ env.CI_INSTALL }}/lib/pkgconfig pkg-config --cflags --libs libsecp256k1) -Wl,-rpath,"${{ env.CI_INSTALL }}/lib" && ./ecdsa

--- a/cmake/GeneratePkgConfigFile.cmake
+++ b/cmake/GeneratePkgConfigFile.cmake
@@ -1,0 +1,8 @@
+function(generate_pkg_config_file in_file)
+  set(prefix ${CMAKE_INSTALL_PREFIX})
+  set(exec_prefix \${prefix})
+  set(libdir \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+  set(includedir \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
+  set(PACKAGE_VERSION ${PROJECT_VERSION})
+  configure_file(${in_file} ${PROJECT_NAME}.pc @ONLY)
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,5 +161,13 @@ if(SECP256K1_INSTALL)
       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-)
+  )
+
+  include(GeneratePkgConfigFile)
+  generate_pkg_config_file(${PROJECT_SOURCE_DIR}/libsecp256k1.pc.in)
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+  )
 endif()


### PR DESCRIPTION
This PR allows downstream projects to use pkg-config to search for the libsecp256k1 library that is built with CMake.

Addressed https://github.com/bitcoin-core/secp256k1/discussions/1419#discussioncomment-6922896:
> We could just ship the pkg-config file also in CMake builds.