### PR TITLE
POC: Self-contained headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -775,7 +775,7 @@ jobs:
 
       - name: Test script
         run: |
-          ./tools/check_header.sh src/field.h
+          ./tools/check_header.sh src/field.h src/field_5x52.h src/field_10x26.h
 
   sage:
     name: "SageMath prover"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,6 +765,18 @@ jobs:
             g++ -Werror include/*.h
             clang -Werror -x c++-header include/*.h
 
+  headers:
+    name: "Self-contained headers"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Test script
+        run: |
+          ./tools/check_header.sh src/field.h
+
   sage:
     name: "SageMath prover"
     runs-on: ubuntu-latest

--- a/src/field.h
+++ b/src/field.h
@@ -29,13 +29,6 @@
  * implementation also provides a secp256k1_fe_verify routine to verify that
  * these fields match the run-time value and perform internal consistency
  * checks. */
-#ifdef VERIFY
-#  define SECP256K1_FE_VERIFY_FIELDS \
-    int magnitude; \
-    int normalized;
-#else
-#  define SECP256K1_FE_VERIFY_FIELDS
-#endif
 
 #if defined(SECP256K1_WIDEMUL_INT128)
 #include "field_5x52.h"

--- a/src/field_10x26.h
+++ b/src/field_10x26.h
@@ -30,7 +30,10 @@ typedef struct {
      *     sum(i=0..9, n[i] << (i*26)) < p
      *     (together these imply n[9] <= 2^22 - 1)
      */
-    SECP256K1_FE_VERIFY_FIELDS
+#ifdef VERIFY
+    int magnitude;
+    int normalized;
+#endif
 } secp256k1_fe;
 
 /* Unpacks a constant into a overlapping multi-limbed FE element. */

--- a/src/field_5x52.h
+++ b/src/field_5x52.h
@@ -30,7 +30,10 @@ typedef struct {
      *     sum(i=0..4, n[i] << (i*52)) < p
      *     (together these imply n[4] <= 2^48 - 1)
      */
-    SECP256K1_FE_VERIFY_FIELDS
+#ifdef VERIFY
+    int magnitude;
+    int normalized;
+#endif
 } secp256k1_fe;
 
 /* Unpacks a constant into a overlapping multi-limbed FE element. */

--- a/tools/check_header.sh
+++ b/tools/check_header.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -u
+
+for header in "$@"; do
+    source_file=${header%.h}.c
+    object_file=${header%.h}.o
+    mv "$header" "$source_file"
+    gcc -c "$source_file" -o "$object_file"
+    exit_code=$?
+    mv "$source_file" "$header"
+    if [ $exit_code -ne 0 ]; then
+        exit $exit_code
+    fi
+    echo "$header... OK"
+done


### PR DESCRIPTION
This PR adds a tool that verifies every header whether it is self-contained.

As an example, the `field_5x52.h` and `field_10x26.h` headers have been refactored to get self-contained.