### PR TITLE
ci: Bump major versions for docker actions

### DIFF
--- a/.github/actions/run-in-docker-action/action.yml
+++ b/.github/actions/run-in-docker-action/action.yml
@@ -14,9 +14,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: docker/setup-buildx-action@v2
+    - uses: docker/setup-buildx-action@v3
 
-    - uses: docker/build-push-action@v4
+    - uses: docker/build-push-action@v5
       id: main_builder
       continue-on-error: true
       with:
@@ -26,7 +26,7 @@ runs:
         load: true
         cache-from: type=gha
 
-    - uses: docker/build-push-action@v4
+    - uses: docker/build-push-action@v5
       id: retry_builder
       if: steps.main_builder.outcome == 'failure'
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           # See: https://github.com/moby/buildkit/issues/3969.
           driver-opts: |
             network=host
 
       - name: Build container
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           file: ./ci/linux-debian.Dockerfile
           tags: linux-debian-image


### PR DESCRIPTION
See:
- https://github.com/docker/build-push-action/releases/tag/v5.0.0
- https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0