### PR TITLE
ci: Ignore internal errors of snapshot compilers

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -83,7 +83,21 @@ esac
     --host="$HOST" $EXTRAFLAGS
 
 # We have set "-j<n>" in MAKEFLAGS.
-make
+build_exit_code=0
+make > make.log 2>&1 || build_exit_code=$?
+cat make.log
+if [ $build_exit_code -ne 0 ]; then
+    case "${CC:-undefined}" in
+        *snapshot*)
+            # Ignore internal compiler errors in gcc-snapshot and clang-snapshot
+            grep -e "internal compiler error:" -e "PLEASE submit a bug report" make.log
+            return $?;
+            ;;
+        *)
+            return 1;
+            ;;
+    esac
+fi
 
 # Print information about binaries so that we can see that the architecture is correct
 file *tests* || true


### PR DESCRIPTION
It was discussed on today's IRC meeting.