### PR TITLE
correct assertion for secp256k1_fe_mul_inner

### DIFF
--- a/src/field_5x52_int128_impl.h
+++ b/src/field_5x52_int128_impl.h
@@ -89,11 +89,11 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint64_t *r, const uint64_t 
     secp256k1_u128_accum_mul(&d, a2, b[3]);
     secp256k1_u128_accum_mul(&d, a3, b[2]);
     secp256k1_u128_accum_mul(&d, a4, b[1]);
-    VERIFY_BITS_128(&d, 115);
+    VERIFY_BITS_128(&d, 114);
     /* [d t4+(tx<<48) t3 0 0 c] = [p8 0 0 p5 p4 p3 0 0 p0] */
     u0 = secp256k1_u128_to_u64(&d) & M; secp256k1_u128_rshift(&d, 52);
     VERIFY_BITS(u0, 52);
-    VERIFY_BITS_128(&d, 63);
+    VERIFY_BITS_128(&d, 62);
     /* [d u0 t4+(tx<<48) t3 0 0 c] = [p8 0 0 p5 p4 p3 0 0 p0] */
     /* [d 0 t4+(tx<<48)+(u0<<52) t3 0 0 c] = [p8 0 0 p5 p4 p3 0 0 p0] */
     u0 = (u0 << 4) | tx;

--- a/src/field_5x52_int128_impl.h
+++ b/src/field_5x52_int128_impl.h
@@ -100,7 +100,7 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint64_t *r, const uint64_t 
     VERIFY_BITS(u0, 56);
     /* [d 0 t4+(u0<<48) t3 0 0 c] = [p8 0 0 p5 p4 p3 0 0 p0] */
     secp256k1_u128_accum_mul(&c, u0, R >> 4);
-    VERIFY_BITS_128(&c, 115);
+    VERIFY_BITS_128(&c, 113);
     /* [d 0 t4 t3 0 0 c] = [p8 0 0 p5 p4 p3 0 0 p0] */
     r[0] = secp256k1_u128_to_u64(&c) & M; secp256k1_u128_rshift(&c, 52);
     VERIFY_BITS(r[0], 52);


### PR DESCRIPTION
Based on the surrounding asserts, 112 bits before this line, and 61 bits after this line, this assertion should be 113 bits.  Notably the commensurate line in secp256k1_fe_sqr_inner is correctly assert to be 113 bits.