### PR TITLE
asm: add .note.GNU-stack section for non-exec stack

### DIFF
--- a/src/asm/field_10x26_arm.s
+++ b/src/asm/field_10x26_arm.s
@@ -913,3 +913,4 @@ secp256k1_fe_sqr_inner:
 	ldmfd	sp!, {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.size	secp256k1_fe_sqr_inner, .-secp256k1_fe_sqr_inner
 
+	.section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
With this in place, we no-longer see warnings like the following:
```bash
/usr/lib/gcc-cross/arm-linux-gnueabihf/12/../../../../arm-linux-gnueabihf/bin/ld: warning: field_10x26_arm.o: missing .note.GNU-stack section implies executable stack
/usr/lib/gcc-cross/arm-linux-gnueabihf/12/../../../../arm-linux-gnueabihf/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```

Should close #1434.