### PR TITLE
Return temporaries to being unsigned in secp256k1_fe_sqr_inner

### DIFF
--- a/src/field_5x52_int128_impl.h
+++ b/src/field_5x52_int128_impl.h
@@ -159,7 +159,7 @@ SECP256K1_INLINE static void secp256k1_fe_mul_inner(uint64_t *r, const uint64_t 
 SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint64_t *r, const uint64_t *a) {
     secp256k1_uint128 c, d;
     uint64_t a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4];
-    int64_t t3, t4, tx, u0;
+    uint64_t t3, t4, tx, u0;
     const uint64_t M = 0xFFFFFFFFFFFFFULL, R = 0x1000003D10ULL;
 
     VERIFY_BITS(a[0], 56);


### PR DESCRIPTION
These temporaries seem to been inadvertently changed to signed during a refactoring.  Generally, bit shifting is frowned upon for signed values.