### PR TITLE
Add group.h ge/gej equality functions

### DIFF
--- a/src/group.h
+++ b/src/group.h
@@ -102,6 +102,9 @@ static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a
  */
 static void secp256k1_ge_table_set_globalz(size_t len, secp256k1_ge *a, const secp256k1_fe *zr);
 
+/** Check two group elements (affine) for equality in variable time. */
+static int secp256k1_ge_eq_var(const secp256k1_ge *a, const secp256k1_ge *b);
+
 /** Set a group element (affine) equal to the point at infinity. */
 static void secp256k1_ge_set_infinity(secp256k1_ge *r);
 
@@ -113,6 +116,9 @@ static void secp256k1_gej_set_ge(secp256k1_gej *r, const secp256k1_ge *a);
 
 /** Check two group elements (jacobian) for equality in variable time. */
 static int secp256k1_gej_eq_var(const secp256k1_gej *a, const secp256k1_gej *b);
+
+/** Check two group elements (jacobian and affine) for equality in variable time. */
+static int secp256k1_gej_eq_ge_var(const secp256k1_gej *a, const secp256k1_ge *b);
 
 /** Compare the X coordinate of a group element (jacobian).
   * The magnitude of the group element's X coordinate must not exceed 31. */

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -354,6 +354,35 @@ static int secp256k1_gej_eq_var(const secp256k1_gej *a, const secp256k1_gej *b) 
     return secp256k1_gej_is_infinity(&tmp);
 }
 
+static int secp256k1_gej_eq_ge_var(const secp256k1_gej *a, const secp256k1_ge *b) {
+    secp256k1_gej tmp;
+    SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GE_VERIFY(b);
+
+    secp256k1_gej_neg(&tmp, a);
+    secp256k1_gej_add_ge_var(&tmp, &tmp, b, NULL);
+    return secp256k1_gej_is_infinity(&tmp);
+}
+
+static int secp256k1_ge_eq_var(const secp256k1_ge *a, const secp256k1_ge *b) {
+    secp256k1_fe tmp;
+    SECP256K1_GE_VERIFY(a);
+    SECP256K1_GE_VERIFY(b);
+
+    if (a->infinity != b->infinity) return 0;
+    if (a->infinity) return 1;
+
+    tmp = a->x;
+    secp256k1_fe_normalize_weak(&tmp);
+    if (!secp256k1_fe_equal(&tmp, &b->x)) return 0;
+
+    tmp = a->y;
+    secp256k1_fe_normalize_weak(&tmp);
+    if (!secp256k1_fe_equal(&tmp, &b->y)) return 0;
+
+    return 1;
+}
+
 static int secp256k1_gej_eq_x_var(const secp256k1_fe *x, const secp256k1_gej *a) {
     secp256k1_fe r;
     SECP256K1_FE_VERIFY(x);

--- a/src/modules/ellswift/tests_exhaustive_impl.h
+++ b/src/modules/ellswift/tests_exhaustive_impl.h
@@ -32,7 +32,7 @@ static void test_exhaustive_ellswift(const secp256k1_context *ctx, const secp256
         /* Decode ellswift pubkey and check that it matches the precomputed group element. */
         secp256k1_ellswift_decode(ctx, &pub_decoded, ell64);
         secp256k1_pubkey_load(ctx, &ge_decoded, &pub_decoded);
-        ge_equals_ge(&ge_decoded, &group[i]);
+        CHECK(secp256k1_ge_eq_var(&ge_decoded, &group[i]));
     }
 }
 

--- a/src/modules/ellswift/tests_impl.h
+++ b/src/modules/ellswift/tests_impl.h
@@ -237,7 +237,7 @@ void run_ellswift_tests(void) {
         secp256k1_ellswift_decode(CTX, &pubkey2, ell64);
         secp256k1_pubkey_load(CTX, &g2, &pubkey2);
         /* Compare with original. */
-        ge_equals_ge(&g, &g2);
+        CHECK(secp256k1_ge_eq_var(&g, &g2));
     }
     /* Verify the behavior of secp256k1_ellswift_create */
     for (i = 0; i < 400 * COUNT; i++) {
@@ -259,7 +259,7 @@ void run_ellswift_tests(void) {
         secp256k1_ellswift_decode(CTX, &pub, ell64);
         secp256k1_pubkey_load(CTX, &dec, &pub);
         secp256k1_ecmult(&res, NULL, &secp256k1_scalar_zero, &sec);
-        ge_equals_gej(&dec, &res);
+        CHECK(secp256k1_gej_eq_ge_var(&res, &dec));
     }
     /* Verify that secp256k1_ellswift_xdh computes the right shared X coordinate. */
     for (i = 0; i < 800 * COUNT; i++) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -3706,11 +3706,12 @@ static void test_ge(void) {
     secp256k1_ge_clear(&ge[0]);
     secp256k1_ge_set_gej_var(&ge[0], &gej[0]);
     for (i = 0; i < runs; i++) {
-        int j;
+        int j, k;
         secp256k1_ge g;
         random_group_element_test(&g);
         if (i >= runs - 2) {
             secp256k1_ge_mul_lambda(&g, &ge[1]);
+            CHECK(!secp256k1_ge_eq_var(&g, &ge[1]));
         }
         if (i >= runs - 1) {
             secp256k1_ge_mul_lambda(&g, &g);
@@ -3729,6 +3730,16 @@ static void test_ge(void) {
             random_gej_x_magnitude(&gej[1 + j + 4 * i]);
             random_gej_y_magnitude(&gej[1 + j + 4 * i]);
             random_gej_z_magnitude(&gej[1 + j + 4 * i]);
+        }
+
+        for (j = 0; j < 4; ++j) {
+            for (k = 0; k < 4; ++k) {
+                int expect_equal = (j >> 1) == (k >> 1);
+                CHECK(secp256k1_ge_eq_var(&ge[1 + j + 4 * i], &ge[1 + k + 4 * i]) == expect_equal);
+                CHECK(secp256k1_gej_eq_var(&gej[1 + j + 4 * i], &gej[1 + k + 4 * i]) == expect_equal);
+                CHECK(secp256k1_gej_eq_ge_var(&gej[1 + j + 4 * i], &ge[1 + k + 4 * i]) == expect_equal);
+                CHECK(secp256k1_gej_eq_ge_var(&gej[1 + k + 4 * i], &ge[1 + j + 4 * i]) == expect_equal);
+            }
         }
     }
 

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -67,7 +67,7 @@ static void test_exhaustive_endomorphism(const secp256k1_ge *group) {
     for (i = 0; i < EXHAUSTIVE_TEST_ORDER; i++) {
         secp256k1_ge res;
         secp256k1_ge_mul_lambda(&res, &group[i]);
-        ge_equals_ge(&group[i * EXHAUSTIVE_TEST_LAMBDA % EXHAUSTIVE_TEST_ORDER], &res);
+        CHECK(secp256k1_ge_eq_var(&group[i * EXHAUSTIVE_TEST_LAMBDA % EXHAUSTIVE_TEST_ORDER], &res));
     }
 }
 
@@ -93,21 +93,21 @@ static void test_exhaustive_addition(const secp256k1_ge *group, const secp256k1_
             secp256k1_gej tmp;
             /* add_var */
             secp256k1_gej_add_var(&tmp, &groupj[i], &groupj[j], NULL);
-            ge_equals_gej(&group[(i + j) % EXHAUSTIVE_TEST_ORDER], &tmp);
+            CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(i + j) % EXHAUSTIVE_TEST_ORDER]));
             /* add_ge */
             if (j > 0) {
                 secp256k1_gej_add_ge(&tmp, &groupj[i], &group[j]);
-                ge_equals_gej(&group[(i + j) % EXHAUSTIVE_TEST_ORDER], &tmp);
+                CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(i + j) % EXHAUSTIVE_TEST_ORDER]));
             }
             /* add_ge_var */
             secp256k1_gej_add_ge_var(&tmp, &groupj[i], &group[j], NULL);
-            ge_equals_gej(&group[(i + j) % EXHAUSTIVE_TEST_ORDER], &tmp);
+            CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(i + j) % EXHAUSTIVE_TEST_ORDER]));
             /* add_zinv_var */
             zless_gej.infinity = groupj[j].infinity;
             zless_gej.x = groupj[j].x;
             zless_gej.y = groupj[j].y;
             secp256k1_gej_add_zinv_var(&tmp, &groupj[i], &zless_gej, &fe_inv);
-            ge_equals_gej(&group[(i + j) % EXHAUSTIVE_TEST_ORDER], &tmp);
+            CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(i + j) % EXHAUSTIVE_TEST_ORDER]));
         }
     }
 
@@ -115,9 +115,9 @@ static void test_exhaustive_addition(const secp256k1_ge *group, const secp256k1_
     for (i = 0; i < EXHAUSTIVE_TEST_ORDER; i++) {
         secp256k1_gej tmp;
         secp256k1_gej_double(&tmp, &groupj[i]);
-        ge_equals_gej(&group[(2 * i) % EXHAUSTIVE_TEST_ORDER], &tmp);
+        CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(2 * i) % EXHAUSTIVE_TEST_ORDER]));
         secp256k1_gej_double_var(&tmp, &groupj[i], NULL);
-        ge_equals_gej(&group[(2 * i) % EXHAUSTIVE_TEST_ORDER], &tmp);
+        CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(2 * i) % EXHAUSTIVE_TEST_ORDER]));
     }
 
     /* Check negation */
@@ -125,9 +125,9 @@ static void test_exhaustive_addition(const secp256k1_ge *group, const secp256k1_
         secp256k1_ge tmp;
         secp256k1_gej tmpj;
         secp256k1_ge_neg(&tmp, &group[i]);
-        ge_equals_ge(&group[EXHAUSTIVE_TEST_ORDER - i], &tmp);
+        CHECK(secp256k1_ge_eq_var(&tmp, &group[EXHAUSTIVE_TEST_ORDER - i]));
         secp256k1_gej_neg(&tmpj, &groupj[i]);
-        ge_equals_gej(&group[EXHAUSTIVE_TEST_ORDER - i], &tmpj);
+        CHECK(secp256k1_gej_eq_ge_var(&tmpj, &group[EXHAUSTIVE_TEST_ORDER - i]));
     }
 }
 
@@ -144,8 +144,7 @@ static void test_exhaustive_ecmult(const secp256k1_ge *group, const secp256k1_ge
                 secp256k1_scalar_set_int(&ng, j);
 
                 secp256k1_ecmult(&tmp, &groupj[r_log], &na, &ng);
-                ge_equals_gej(&group[(i * r_log + j) % EXHAUSTIVE_TEST_ORDER], &tmp);
-
+                CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(i * r_log + j) % EXHAUSTIVE_TEST_ORDER]));
             }
         }
     }
@@ -163,7 +162,7 @@ static void test_exhaustive_ecmult(const secp256k1_ge *group, const secp256k1_ge
 
             /* Test secp256k1_ecmult_const. */
             secp256k1_ecmult_const(&tmp, &group[i], &ng);
-            ge_equals_gej(&group[(i * j) % EXHAUSTIVE_TEST_ORDER], &tmp);
+            CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(i * j) % EXHAUSTIVE_TEST_ORDER]));
 
             if (i != 0 && j != 0) {
                 /* Test secp256k1_ecmult_const_xonly with all curve X coordinates, and xd=NULL. */
@@ -215,7 +214,7 @@ static void test_exhaustive_ecmult_multi(const secp256k1_context *ctx, const sec
                         data.pt[1] = group[y];
 
                         secp256k1_ecmult_multi_var(&ctx->error_callback, scratch, &tmp, &g_sc, ecmult_multi_callback, &data, 2);
-                        ge_equals_gej(&group[(i * x + j * y + k) % EXHAUSTIVE_TEST_ORDER], &tmp);
+                        CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(i * x + j * y + k) % EXHAUSTIVE_TEST_ORDER]));
                     }
                 }
             }

--- a/src/testutil.h
+++ b/src/testutil.h
@@ -7,6 +7,7 @@
 #define SECP256K1_TESTUTIL_H
 
 #include "field.h"
+#include "group.h"
 #include "testrand.h"
 #include "util.h"
 
@@ -27,29 +28,11 @@ static void random_fe_non_zero(secp256k1_fe *nz) {
 }
 
 static void ge_equals_ge(const secp256k1_ge *a, const secp256k1_ge *b) {
-    CHECK(a->infinity == b->infinity);
-    if (a->infinity) {
-        return;
-    }
-    CHECK(secp256k1_fe_equal(&a->x, &b->x));
-    CHECK(secp256k1_fe_equal(&a->y, &b->y));
+    CHECK(secp256k1_ge_eq_var(a, b));
 }
 
 static void ge_equals_gej(const secp256k1_ge *a, const secp256k1_gej *b) {
-    secp256k1_fe z2s;
-    secp256k1_fe u1, u2, s1, s2;
-    CHECK(a->infinity == b->infinity);
-    if (a->infinity) {
-        return;
-    }
-    /* Check a.x * b.z^2 == b.x && a.y * b.z^3 == b.y, to avoid inverses. */
-    secp256k1_fe_sqr(&z2s, &b->z);
-    secp256k1_fe_mul(&u1, &a->x, &z2s);
-    u2 = b->x;
-    secp256k1_fe_mul(&s1, &a->y, &z2s); secp256k1_fe_mul(&s1, &s1, &b->z);
-    s2 = b->y;
-    CHECK(secp256k1_fe_equal(&u1, &u2));
-    CHECK(secp256k1_fe_equal(&s1, &s2));
+    CHECK(secp256k1_gej_eq_ge_var(b, a));
 }
 
 #endif /* SECP256K1_TESTUTIL_H */

--- a/src/testutil.h
+++ b/src/testutil.h
@@ -7,7 +7,6 @@
 #define SECP256K1_TESTUTIL_H
 
 #include "field.h"
-#include "group.h"
 #include "testrand.h"
 #include "util.h"
 
@@ -25,14 +24,6 @@ static void random_fe_non_zero(secp256k1_fe *nz) {
     do {
         random_fe(nz);
     } while (secp256k1_fe_is_zero(nz));
-}
-
-static void ge_equals_ge(const secp256k1_ge *a, const secp256k1_ge *b) {
-    CHECK(secp256k1_ge_eq_var(a, b));
-}
-
-static void ge_equals_gej(const secp256k1_ge *a, const secp256k1_gej *b) {
-    CHECK(secp256k1_gej_eq_ge_var(b, a));
 }
 
 #endif /* SECP256K1_TESTUTIL_H */


### PR DESCRIPTION
This pull requests removes the test-only functions `ge_equals_ge` and `ge_equals_gej`, and replaces them with proper group.h functions `secp256k1_ge_eq_var` and `secp256k1_gej_eq_ge_var` (mimicking the existing `secp256k1_gej_eq_var` function).

This drops some of the arbitrary and undocumented magnitude restristrictions these functions have, makes them properly tested on their own, and makes their semantics cleaner (I'm always left checking whether `ge_equals_ge` does a `CHECK` internally or whether it returns a value...).