### PR TITLE
tests: Make CHECK enforce 1 instead of just "!= 0"

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -86,8 +86,8 @@ static void bench_verify(void* arg, int iters) {
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
-        CHECK(secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->pubkey, data->pubkeylen) == 1);
-        CHECK(secp256k1_ecdsa_signature_parse_der(data->ctx, &sig, data->sig, data->siglen) == 1);
+        CHECK(secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->pubkey, data->pubkeylen));
+        CHECK(secp256k1_ecdsa_signature_parse_der(data->ctx, &sig, data->sig, data->siglen));
         CHECK(secp256k1_ecdsa_verify(data->ctx, &sig, data->msg, &pubkey) == (i == 0));
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
@@ -245,7 +245,7 @@ int main(int argc, char** argv) {
     CHECK(secp256k1_ecdsa_signature_serialize_der(data.ctx, data.sig, &data.siglen, &sig));
     CHECK(secp256k1_ec_pubkey_create(data.ctx, &pubkey, data.key));
     data.pubkeylen = 33;
-    CHECK(secp256k1_ec_pubkey_serialize(data.ctx, data.pubkey, &data.pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(secp256k1_ec_pubkey_serialize(data.ctx, data.pubkey, &data.pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
 
     print_output_table_header_row();
     if (d || have_flag(argc, argv, "ecdsa") || have_flag(argc, argv, "verify") || have_flag(argc, argv, "ecdsa_verify")) run_benchmark("ecdsa_verify", bench_verify, NULL, NULL, &data, 10, iters);

--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -99,7 +99,7 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
     SECP256K1_CHECKMEM_DEFINE(&pubkey, sizeof(secp256k1_pubkey));
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret);
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, spubkey, &outputlen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(secp256k1_ec_pubkey_serialize(ctx, spubkey, &outputlen, &pubkey, SECP256K1_EC_COMPRESSED));
 
     /* Test signing. */
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
@@ -114,7 +114,7 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ecdh(ctx, msg, &pubkey, key, NULL, NULL);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 #endif
 
 #ifdef ENABLE_MODULE_RECOVERY
@@ -131,78 +131,78 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ec_seckey_verify(ctx, key);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ec_seckey_negate(ctx, key);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     SECP256K1_CHECKMEM_UNDEFINE(msg, 32);
     ret = secp256k1_ec_seckey_tweak_add(ctx, key, msg);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     SECP256K1_CHECKMEM_UNDEFINE(msg, 32);
     ret = secp256k1_ec_seckey_tweak_mul(ctx, key, msg);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 
     /* Test keypair_create and keypair_xonly_tweak_add. */
 #ifdef ENABLE_MODULE_EXTRAKEYS
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_keypair_create(ctx, &keypair, key);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 
     /* The tweak is not treated as a secret in keypair_tweak_add */
     SECP256K1_CHECKMEM_DEFINE(msg, 32);
     ret = secp256k1_keypair_xonly_tweak_add(ctx, &keypair, msg);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
     ret = secp256k1_keypair_sec(ctx, key, &keypair);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 #endif
 
 #ifdef ENABLE_MODULE_SCHNORRSIG
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_keypair_create(ctx, &keypair, key);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
     ret = secp256k1_schnorrsig_sign32(ctx, sig, msg, &keypair, NULL);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 #endif
 
 #ifdef ENABLE_MODULE_ELLSWIFT
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ellswift_create(ctx, ellswift, key, NULL);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_ellswift_create(ctx, ellswift, key, ellswift);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-    CHECK(ret == 1);
+    CHECK(ret);
 
     for (i = 0; i < 2; i++) {
         SECP256K1_CHECKMEM_UNDEFINE(key, 32);
         SECP256K1_CHECKMEM_DEFINE(&ellswift, sizeof(ellswift));
         ret = secp256k1_ellswift_xdh(ctx, msg, ellswift, ellswift, key, i, secp256k1_ellswift_xdh_hash_function_bip324, NULL);
         SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-        CHECK(ret == 1);
+        CHECK(ret);
 
         SECP256K1_CHECKMEM_UNDEFINE(key, 32);
         SECP256K1_CHECKMEM_DEFINE(&ellswift, sizeof(ellswift));
         ret = secp256k1_ellswift_xdh(ctx, msg, ellswift, ellswift, key, i, secp256k1_ellswift_xdh_hash_function_prefix, (void *)prefix);
         SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
-        CHECK(ret == 1);
+        CHECK(ret);
     }
 
 #endif

--- a/src/modules/ecdh/bench_impl.h
+++ b/src/modules/ecdh/bench_impl.h
@@ -29,7 +29,7 @@ static void bench_ecdh_setup(void* arg) {
     for (i = 0; i < 32; i++) {
         data->scalar[i] = i + 1;
     }
-    CHECK(secp256k1_ec_pubkey_parse(data->ctx, &data->point, point, sizeof(point)) == 1);
+    CHECK(secp256k1_ec_pubkey_parse(data->ctx, &data->point, point, sizeof(point)));
 }
 
 static void bench_ecdh(void* arg, int iters) {
@@ -38,7 +38,7 @@ static void bench_ecdh(void* arg, int iters) {
     bench_ecdh_data *data = (bench_ecdh_data*)arg;
 
     for (i = 0; i < iters; i++) {
-        CHECK(secp256k1_ecdh(data->ctx, res, &data->point, data->scalar, NULL, NULL) == 1);
+        CHECK(secp256k1_ecdh(data->ctx, res, &data->point, data->scalar, NULL, NULL));
     }
 }
 

--- a/src/modules/ecdh/tests_impl.h
+++ b/src/modules/ecdh/tests_impl.h
@@ -30,14 +30,14 @@ static void test_ecdh_api(void) {
     unsigned char s_one[32] = { 0 };
     s_one[31] = 1;
 
-    CHECK(secp256k1_ec_pubkey_create(CTX, &point, s_one) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &point, s_one));
 
     /* Check all NULLs are detected */
-    CHECK(secp256k1_ecdh(CTX, res, &point, s_one, NULL, NULL) == 1);
+    CHECK(secp256k1_ecdh(CTX, res, &point, s_one, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdh(CTX, NULL, &point, s_one, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdh(CTX, res, NULL, s_one, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdh(CTX, res, &point, NULL, NULL, NULL));
-    CHECK(secp256k1_ecdh(CTX, res, &point, s_one, NULL, NULL) == 1);
+    CHECK(secp256k1_ecdh(CTX, res, &point, s_one, NULL, NULL));
 }
 
 static void test_ecdh_generator_basepoint(void) {
@@ -59,20 +59,20 @@ static void test_ecdh_generator_basepoint(void) {
         random_scalar_order(&s);
         secp256k1_scalar_get_b32(s_b32, &s);
 
-        CHECK(secp256k1_ec_pubkey_create(CTX, &point[0], s_one) == 1);
-        CHECK(secp256k1_ec_pubkey_create(CTX, &point[1], s_b32) == 1);
+        CHECK(secp256k1_ec_pubkey_create(CTX, &point[0], s_one));
+        CHECK(secp256k1_ec_pubkey_create(CTX, &point[1], s_b32));
 
         /* compute using ECDH function with custom hash function */
-        CHECK(secp256k1_ecdh(CTX, output_ecdh, &point[0], s_b32, ecdh_hash_function_custom, NULL) == 1);
+        CHECK(secp256k1_ecdh(CTX, output_ecdh, &point[0], s_b32, ecdh_hash_function_custom, NULL));
         /* compute "explicitly" */
-        CHECK(secp256k1_ec_pubkey_serialize(CTX, point_ser, &point_ser_len, &point[1], SECP256K1_EC_UNCOMPRESSED) == 1);
+        CHECK(secp256k1_ec_pubkey_serialize(CTX, point_ser, &point_ser_len, &point[1], SECP256K1_EC_UNCOMPRESSED));
         /* compare */
         CHECK(secp256k1_memcmp_var(output_ecdh, point_ser, 65) == 0);
 
         /* compute using ECDH function with default hash function */
-        CHECK(secp256k1_ecdh(CTX, output_ecdh, &point[0], s_b32, NULL, NULL) == 1);
+        CHECK(secp256k1_ecdh(CTX, output_ecdh, &point[0], s_b32, NULL, NULL));
         /* compute "explicitly" */
-        CHECK(secp256k1_ec_pubkey_serialize(CTX, point_ser, &point_ser_len, &point[1], SECP256K1_EC_COMPRESSED) == 1);
+        CHECK(secp256k1_ec_pubkey_serialize(CTX, point_ser, &point_ser_len, &point[1], SECP256K1_EC_COMPRESSED));
         secp256k1_sha256_initialize(&sha);
         secp256k1_sha256_write(&sha, point_ser, point_ser_len);
         secp256k1_sha256_finalize(&sha, output_ser);
@@ -97,14 +97,14 @@ static void test_bad_scalar(void) {
     /* Create random point */
     random_scalar_order(&rand);
     secp256k1_scalar_get_b32(s_rand, &rand);
-    CHECK(secp256k1_ec_pubkey_create(CTX, &point, s_rand) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &point, s_rand));
 
     /* Try to multiply it by bad values */
     CHECK(secp256k1_ecdh(CTX, output, &point, s_zero, NULL, NULL) == 0);
     CHECK(secp256k1_ecdh(CTX, output, &point, s_overflow, NULL, NULL) == 0);
     /* ...and a good one */
     s_overflow[31] -= 1;
-    CHECK(secp256k1_ecdh(CTX, output, &point, s_overflow, NULL, NULL) == 1);
+    CHECK(secp256k1_ecdh(CTX, output, &point, s_overflow, NULL, NULL));
 
     /* Hash function failure results in ecdh failure */
     CHECK(secp256k1_ecdh(CTX, output, &point, s_overflow, ecdh_hash_function_test_fail, NULL) == 0);
@@ -123,8 +123,8 @@ static void test_result_basepoint(void) {
 
     unsigned char s_one[32] = { 0 };
     s_one[31] = 1;
-    CHECK(secp256k1_ec_pubkey_create(CTX, &point, s_one) == 1);
-    CHECK(secp256k1_ecdh(CTX, out_base, &point, s_one, NULL, NULL) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &point, s_one));
+    CHECK(secp256k1_ecdh(CTX, out_base, &point, s_one, NULL, NULL));
 
     for (i = 0; i < 2 * COUNT; i++) {
         random_scalar_order(&rand);
@@ -132,12 +132,12 @@ static void test_result_basepoint(void) {
         secp256k1_scalar_inverse(&rand, &rand);
         secp256k1_scalar_get_b32(s_inv, &rand);
 
-        CHECK(secp256k1_ec_pubkey_create(CTX, &point, s) == 1);
-        CHECK(secp256k1_ecdh(CTX, out, &point, s_inv, NULL, NULL) == 1);
+        CHECK(secp256k1_ec_pubkey_create(CTX, &point, s));
+        CHECK(secp256k1_ecdh(CTX, out, &point, s_inv, NULL, NULL));
         CHECK(secp256k1_memcmp_var(out, out_base, 32) == 0);
 
-        CHECK(secp256k1_ec_pubkey_create(CTX, &point, s_inv) == 1);
-        CHECK(secp256k1_ecdh(CTX, out_inv, &point, s, NULL, NULL) == 1);
+        CHECK(secp256k1_ec_pubkey_create(CTX, &point, s_inv));
+        CHECK(secp256k1_ecdh(CTX, out_inv, &point, s, NULL, NULL));
         CHECK(secp256k1_memcmp_var(out_inv, out_base, 32) == 0);
     }
 }

--- a/src/modules/ellswift/bench_impl.h
+++ b/src/modules/ellswift/bench_impl.h
@@ -65,7 +65,7 @@ static void bench_ellswift_decode(void *arg, int iters) {
     bench_ellswift_data *data = (bench_ellswift_data*)arg;
 
     for (i = 0; i < iters; i++) {
-        CHECK(secp256k1_ellswift_decode(data->ctx, &out, data->rnd64) == 1);
+        CHECK(secp256k1_ellswift_decode(data->ctx, &out, data->rnd64));
         len = 33;
         CHECK(secp256k1_ec_pubkey_serialize(data->ctx, data->rnd64 + (i % 32), &len, &out, SECP256K1_EC_COMPRESSED));
     }
@@ -84,7 +84,7 @@ static void bench_ellswift_xdh(void *arg, int iters) {
                                      data->rnd64 + ((i + 16) % 33),
                                      party,
                                      secp256k1_ellswift_xdh_hash_function_bip324,
-                                     NULL) == 1);
+                                     NULL));
     }
 }
 

--- a/src/modules/extrakeys/tests_impl.h
+++ b/src/modules/extrakeys/tests_impl.h
@@ -26,13 +26,13 @@ static void test_xonly_pubkey(void) {
     secp256k1_testrand256(sk);
     memset(ones32, 0xFF, 32);
     secp256k1_testrand256(xy_sk);
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk) == 1);
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk));
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk));
 
     /* Test xonly_pubkey_from_pubkey */
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk) == 1);
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk));
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_from_pubkey(CTX, NULL, &pk_parity, &pk));
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, NULL, &pk) == 1);
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, NULL, &pk));
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, NULL));
     memset(&pk, 0, sizeof(pk));
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk));
@@ -40,23 +40,23 @@ static void test_xonly_pubkey(void) {
     /* Choose a secret key such that the resulting pubkey and xonly_pubkey match. */
     memset(sk, 0, sizeof(sk));
     sk[0] = 1;
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk) == 1);
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk));
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk));
     CHECK(secp256k1_memcmp_var(&pk, &xonly_pk, sizeof(pk)) == 0);
     CHECK(pk_parity == 0);
 
     /* Choose a secret key such that pubkey and xonly_pubkey are each others
      * negation. */
     sk[0] = 2;
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk) == 1);
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk));
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk));
     CHECK(secp256k1_memcmp_var(&xonly_pk, &pk, sizeof(xonly_pk)) != 0);
     CHECK(pk_parity == 1);
     secp256k1_pubkey_load(CTX, &pk1, &pk);
     secp256k1_pubkey_load(CTX, &pk2, (secp256k1_pubkey *) &xonly_pk);
-    CHECK(secp256k1_fe_equal(&pk1.x, &pk2.x) == 1);
+    CHECK(secp256k1_fe_equal(&pk1.x, &pk2.x));
     secp256k1_fe_negate(&y, &pk2.y, 1);
-    CHECK(secp256k1_fe_equal(&pk1.y, &y) == 1);
+    CHECK(secp256k1_fe_equal(&pk1.y, &y));
 
     /* Test xonly_pubkey_serialize and xonly_pubkey_parse */
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_serialize(CTX, NULL, &xonly_pk));
@@ -71,14 +71,14 @@ static void test_xonly_pubkey(void) {
         CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_serialize(CTX, buf32, &pk_tmp));
     }
 
-    CHECK(secp256k1_xonly_pubkey_serialize(CTX, buf32, &xonly_pk) == 1);
+    CHECK(secp256k1_xonly_pubkey_serialize(CTX, buf32, &xonly_pk));
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_parse(CTX, NULL, buf32));
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_parse(CTX, &xonly_pk, NULL));
 
     /* Serialization and parse roundtrip */
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, NULL, &pk) == 1);
-    CHECK(secp256k1_xonly_pubkey_serialize(CTX, buf32, &xonly_pk) == 1);
-    CHECK(secp256k1_xonly_pubkey_parse(CTX, &xonly_pk_tmp, buf32) == 1);
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, NULL, &pk));
+    CHECK(secp256k1_xonly_pubkey_serialize(CTX, buf32, &xonly_pk));
+    CHECK(secp256k1_xonly_pubkey_parse(CTX, &xonly_pk_tmp, buf32));
     CHECK(secp256k1_memcmp_var(&xonly_pk, &xonly_pk_tmp, sizeof(xonly_pk)) == 0);
 
     /* Test parsing invalid field elements */
@@ -102,7 +102,7 @@ static void test_xonly_pubkey(void) {
             CHECK(secp256k1_xonly_pubkey_parse(CTX, &xonly_pk, &rand33[1]) == 0);
             CHECK(secp256k1_memcmp_var(&xonly_pk, zeros64, sizeof(xonly_pk)) == 0);
         } else {
-            CHECK(secp256k1_xonly_pubkey_parse(CTX, &xonly_pk, &rand33[1]) == 1);
+            CHECK(secp256k1_xonly_pubkey_parse(CTX, &xonly_pk, &rand33[1]));
         }
     }
 }
@@ -119,8 +119,8 @@ static void test_xonly_pubkey_comparison(void) {
     secp256k1_xonly_pubkey pk1;
     secp256k1_xonly_pubkey pk2;
 
-    CHECK(secp256k1_xonly_pubkey_parse(CTX, &pk1, pk1_ser) == 1);
-    CHECK(secp256k1_xonly_pubkey_parse(CTX, &pk2, pk2_ser) == 1);
+    CHECK(secp256k1_xonly_pubkey_parse(CTX, &pk1, pk1_ser));
+    CHECK(secp256k1_xonly_pubkey_parse(CTX, &pk2, pk2_ser));
 
     CHECK_ILLEGAL_VOID(CTX, CHECK(secp256k1_xonly_pubkey_cmp(CTX, NULL, &pk2) < 0));
     CHECK_ILLEGAL_VOID(CTX, CHECK(secp256k1_xonly_pubkey_cmp(CTX, &pk1, NULL) > 0));
@@ -154,12 +154,12 @@ static void test_xonly_pubkey_tweak(void) {
     memset(overflows, 0xff, sizeof(overflows));
     secp256k1_testrand256(tweak);
     secp256k1_testrand256(sk);
-    CHECK(secp256k1_ec_pubkey_create(CTX, &internal_pk, sk) == 1);
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &internal_xonly_pk, &pk_parity, &internal_pk) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &internal_pk, sk));
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &internal_xonly_pk, &pk_parity, &internal_pk));
 
-    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak) == 1);
-    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak) == 1);
-    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak) == 1);
+    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak));
+    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak));
+    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak));
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_tweak_add(CTX, NULL, &internal_xonly_pk, tweak));
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, NULL, tweak));
     /* NULL internal_xonly_pk zeroes the output_pk */
@@ -173,7 +173,7 @@ static void test_xonly_pubkey_tweak(void) {
     CHECK(secp256k1_memcmp_var(&output_pk, zeros64, sizeof(output_pk))  == 0);
 
     /* A zero tweak is fine */
-    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, zeros64) == 1);
+    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, zeros64));
 
     /* Fails if the resulting key was infinity */
     for (i = 0; i < COUNT; i++) {
@@ -211,15 +211,15 @@ static void test_xonly_pubkey_tweak_check(void) {
     memset(overflows, 0xff, sizeof(overflows));
     secp256k1_testrand256(tweak);
     secp256k1_testrand256(sk);
-    CHECK(secp256k1_ec_pubkey_create(CTX, &internal_pk, sk) == 1);
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &internal_xonly_pk, &pk_parity, &internal_pk) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &internal_pk, sk));
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &internal_xonly_pk, &pk_parity, &internal_pk));
 
-    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak) == 1);
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &output_xonly_pk, &pk_parity, &output_pk) == 1);
-    CHECK(secp256k1_xonly_pubkey_serialize(CTX, buf32, &output_xonly_pk) == 1);
-    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, pk_parity, &internal_xonly_pk, tweak) == 1);
-    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, pk_parity, &internal_xonly_pk, tweak) == 1);
-    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, pk_parity, &internal_xonly_pk, tweak) == 1);
+    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak));
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &output_xonly_pk, &pk_parity, &output_pk));
+    CHECK(secp256k1_xonly_pubkey_serialize(CTX, buf32, &output_xonly_pk));
+    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, pk_parity, &internal_xonly_pk, tweak));
+    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, pk_parity, &internal_xonly_pk, tweak));
+    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, pk_parity, &internal_xonly_pk, tweak));
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_tweak_add_check(CTX, NULL, pk_parity, &internal_xonly_pk, tweak));
     /* invalid pk_parity value */
     CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, 2, &internal_xonly_pk, tweak) == 0);
@@ -227,16 +227,16 @@ static void test_xonly_pubkey_tweak_check(void) {
     CHECK_ILLEGAL(CTX, secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, pk_parity, &internal_xonly_pk, NULL));
 
     memset(tweak, 1, sizeof(tweak));
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &internal_xonly_pk, NULL, &internal_pk) == 1);
-    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak) == 1);
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &output_xonly_pk, &pk_parity, &output_pk) == 1);
-    CHECK(secp256k1_xonly_pubkey_serialize(CTX, output_pk32, &output_xonly_pk) == 1);
-    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, output_pk32, pk_parity, &internal_xonly_pk, tweak) == 1);
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &internal_xonly_pk, NULL, &internal_pk));
+    CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk, &internal_xonly_pk, tweak));
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &output_xonly_pk, &pk_parity, &output_pk));
+    CHECK(secp256k1_xonly_pubkey_serialize(CTX, output_pk32, &output_xonly_pk));
+    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, output_pk32, pk_parity, &internal_xonly_pk, tweak));
 
     /* Wrong pk_parity */
     CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, output_pk32, !pk_parity, &internal_xonly_pk, tweak) == 0);
     /* Wrong public key */
-    CHECK(secp256k1_xonly_pubkey_serialize(CTX, buf32, &internal_xonly_pk) == 1);
+    CHECK(secp256k1_xonly_pubkey_serialize(CTX, buf32, &internal_xonly_pk));
     CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, buf32, pk_parity, &internal_xonly_pk, tweak) == 0);
 
     /* Overflowing tweak not allowed */
@@ -257,23 +257,23 @@ static void test_xonly_pubkey_tweak_recursive(void) {
     int i;
 
     secp256k1_testrand256(sk);
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pk[0], sk) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pk[0], sk));
     /* Add tweaks */
     for (i = 0; i < N_PUBKEYS - 1; i++) {
         secp256k1_xonly_pubkey xonly_pk;
         memset(tweak[i], i + 1, sizeof(tweak[i]));
-        CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, NULL, &pk[i]) == 1);
-        CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &pk[i + 1], &xonly_pk, tweak[i]) == 1);
+        CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, NULL, &pk[i]));
+        CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &pk[i + 1], &xonly_pk, tweak[i]));
     }
 
     /* Verify tweaks */
     for (i = N_PUBKEYS - 1; i > 0; i--) {
         secp256k1_xonly_pubkey xonly_pk;
         int pk_parity;
-        CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk[i]) == 1);
-        CHECK(secp256k1_xonly_pubkey_serialize(CTX, pk_serialized, &xonly_pk) == 1);
-        CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, NULL, &pk[i - 1]) == 1);
-        CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, pk_serialized, pk_parity, &xonly_pk, tweak[i - 1]) == 1);
+        CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk[i]));
+        CHECK(secp256k1_xonly_pubkey_serialize(CTX, pk_serialized, &xonly_pk));
+        CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, NULL, &pk[i - 1]));
+        CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, pk_serialized, pk_parity, &xonly_pk, tweak[i - 1]));
     }
 }
 #undef N_PUBKEYS
@@ -293,14 +293,14 @@ static void test_keypair(void) {
 
     /* Test keypair_create */
     secp256k1_testrand256(sk);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
     CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) != 0);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
     CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) != 0);
     CHECK_ILLEGAL(CTX, secp256k1_keypair_create(CTX, NULL, sk));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_create(CTX, &keypair, NULL));
     CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) == 0);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
     CHECK_ILLEGAL(STATIC_CTX, secp256k1_keypair_create(STATIC_CTX, &keypair, sk));
     CHECK(secp256k1_memcmp_var(zeros96, &keypair, sizeof(keypair)) == 0);
 
@@ -312,63 +312,63 @@ static void test_keypair(void) {
 
     /* Test keypair_pub */
     secp256k1_testrand256(sk);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
-    CHECK(secp256k1_keypair_pub(CTX, &pk, &keypair) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+    CHECK(secp256k1_keypair_pub(CTX, &pk, &keypair));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_pub(CTX, NULL, &keypair));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_pub(CTX, &pk, NULL));
     CHECK(secp256k1_memcmp_var(zeros96, &pk, sizeof(pk)) == 0);
 
     /* Using an invalid keypair is fine for keypair_pub */
     memset(&keypair, 0, sizeof(keypair));
-    CHECK(secp256k1_keypair_pub(CTX, &pk, &keypair) == 1);
+    CHECK(secp256k1_keypair_pub(CTX, &pk, &keypair));
     CHECK(secp256k1_memcmp_var(zeros96, &pk, sizeof(pk)) == 0);
 
     /* keypair holds the same pubkey as pubkey_create */
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk) == 1);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
-    CHECK(secp256k1_keypair_pub(CTX, &pk_tmp, &keypair) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk));
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+    CHECK(secp256k1_keypair_pub(CTX, &pk_tmp, &keypair));
     CHECK(secp256k1_memcmp_var(&pk, &pk_tmp, sizeof(pk)) == 0);
 
     /** Test keypair_xonly_pub **/
     secp256k1_testrand256(sk);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &xonly_pk, &pk_parity, &keypair) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &xonly_pk, &pk_parity, &keypair));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_xonly_pub(CTX, NULL, &pk_parity, &keypair));
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &xonly_pk, NULL, &keypair) == 1);
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &xonly_pk, NULL, &keypair));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_xonly_pub(CTX, &xonly_pk, &pk_parity, NULL));
     CHECK(secp256k1_memcmp_var(zeros96, &xonly_pk, sizeof(xonly_pk)) == 0);
     /* Using an invalid keypair will set the xonly_pk to 0 (first reset
      * xonly_pk). */
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &xonly_pk, &pk_parity, &keypair) == 1);
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &xonly_pk, &pk_parity, &keypair));
     memset(&keypair, 0, sizeof(keypair));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_xonly_pub(CTX, &xonly_pk, &pk_parity, &keypair));
     CHECK(secp256k1_memcmp_var(zeros96, &xonly_pk, sizeof(xonly_pk)) == 0);
 
     /** keypair holds the same xonly pubkey as pubkey_create **/
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk) == 1);
-    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk) == 1);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &xonly_pk_tmp, &pk_parity_tmp, &keypair) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pk, sk));
+    CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk));
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &xonly_pk_tmp, &pk_parity_tmp, &keypair));
     CHECK(secp256k1_memcmp_var(&xonly_pk, &xonly_pk_tmp, sizeof(pk)) == 0);
     CHECK(pk_parity == pk_parity_tmp);
 
     /* Test keypair_seckey */
     secp256k1_testrand256(sk);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
-    CHECK(secp256k1_keypair_sec(CTX, sk_tmp, &keypair) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+    CHECK(secp256k1_keypair_sec(CTX, sk_tmp, &keypair));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_sec(CTX, NULL, &keypair));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_sec(CTX, sk_tmp, NULL));
     CHECK(secp256k1_memcmp_var(zeros96, sk_tmp, sizeof(sk_tmp)) == 0);
 
     /* keypair returns the same seckey it got */
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
-    CHECK(secp256k1_keypair_sec(CTX, sk_tmp, &keypair) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+    CHECK(secp256k1_keypair_sec(CTX, sk_tmp, &keypair));
     CHECK(secp256k1_memcmp_var(sk, sk_tmp, sizeof(sk_tmp)) == 0);
 
 
     /* Using an invalid keypair is fine for keypair_seckey */
     memset(&keypair, 0, sizeof(keypair));
-    CHECK(secp256k1_keypair_sec(CTX, sk_tmp, &keypair) == 1);
+    CHECK(secp256k1_keypair_sec(CTX, sk_tmp, &keypair));
     CHECK(secp256k1_memcmp_var(zeros96, sk_tmp, sizeof(sk_tmp)) == 0);
 }
 
@@ -384,31 +384,31 @@ static void test_keypair_add(void) {
     secp256k1_testrand256(sk);
     secp256k1_testrand256(tweak);
     memset(overflows, 0xFF, 32);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
 
-    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak) == 1);
-    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak) == 1);
-    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak) == 1);
+    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak));
+    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak));
+    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_xonly_tweak_add(CTX, NULL, tweak));
     CHECK_ILLEGAL(CTX, secp256k1_keypair_xonly_tweak_add(CTX, &keypair, NULL));
     /* This does not set the keypair to zeroes */
     CHECK(secp256k1_memcmp_var(&keypair, zeros96, sizeof(keypair)) != 0);
 
     /* Invalid tweak zeroes the keypair */
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
     CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, overflows) == 0);
     CHECK(secp256k1_memcmp_var(&keypair, zeros96, sizeof(keypair))  == 0);
 
     /* A zero tweak is fine */
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
-    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, zeros96) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, zeros96));
 
     /* Fails if the resulting keypair was (sk=0, pk=infinity) */
     for (i = 0; i < COUNT; i++) {
         secp256k1_scalar scalar_tweak;
         secp256k1_keypair keypair_tmp;
         secp256k1_testrand256(sk);
-        CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+        CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
         memcpy(&keypair_tmp, &keypair, sizeof(keypair));
         /* Because sk may be negated before adding, we need to try with tweak =
          * sk as well as tweak = -sk. */
@@ -427,16 +427,16 @@ static void test_keypair_add(void) {
     CHECK_ILLEGAL(CTX, secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak));
     CHECK(secp256k1_memcmp_var(&keypair, zeros96, sizeof(keypair))  == 0);
     /* Only seckey part of keypair invalid */
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
     memset(&keypair, 0, 32);
     CHECK_ILLEGAL(CTX, secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak));
     /* Only pubkey part of keypair invalid */
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
     memset(&keypair.data[32], 0, 64);
     CHECK_ILLEGAL(CTX, secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak));
 
     /* Check that the keypair_tweak_add implementation is correct */
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
     for (i = 0; i < COUNT; i++) {
         secp256k1_xonly_pubkey internal_pk;
         secp256k1_xonly_pubkey output_pk;
@@ -447,22 +447,22 @@ static void test_keypair_add(void) {
         int pk_parity;
 
         secp256k1_testrand256(tweak);
-        CHECK(secp256k1_keypair_xonly_pub(CTX, &internal_pk, NULL, &keypair) == 1);
-        CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak) == 1);
-        CHECK(secp256k1_keypair_xonly_pub(CTX, &output_pk, &pk_parity, &keypair) == 1);
+        CHECK(secp256k1_keypair_xonly_pub(CTX, &internal_pk, NULL, &keypair));
+        CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak));
+        CHECK(secp256k1_keypair_xonly_pub(CTX, &output_pk, &pk_parity, &keypair));
 
         /* Check that it passes xonly_pubkey_tweak_add_check */
-        CHECK(secp256k1_xonly_pubkey_serialize(CTX, pk32, &output_pk) == 1);
-        CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, pk32, pk_parity, &internal_pk, tweak) == 1);
+        CHECK(secp256k1_xonly_pubkey_serialize(CTX, pk32, &output_pk));
+        CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, pk32, pk_parity, &internal_pk, tweak));
 
         /* Check that the resulting pubkey matches xonly_pubkey_tweak_add */
-        CHECK(secp256k1_keypair_pub(CTX, &output_pk_xy, &keypair) == 1);
-        CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk_expected, &internal_pk, tweak) == 1);
+        CHECK(secp256k1_keypair_pub(CTX, &output_pk_xy, &keypair));
+        CHECK(secp256k1_xonly_pubkey_tweak_add(CTX, &output_pk_expected, &internal_pk, tweak));
         CHECK(secp256k1_memcmp_var(&output_pk_xy, &output_pk_expected, sizeof(output_pk_xy)) == 0);
 
         /* Check that the secret key in the keypair is tweaked correctly */
-        CHECK(secp256k1_keypair_sec(CTX, sk32, &keypair) == 1);
-        CHECK(secp256k1_ec_pubkey_create(CTX, &output_pk_expected, sk32) == 1);
+        CHECK(secp256k1_keypair_sec(CTX, sk32, &keypair));
+        CHECK(secp256k1_ec_pubkey_create(CTX, &output_pk_expected, sk32));
         CHECK(secp256k1_memcmp_var(&output_pk_xy, &output_pk_expected, sizeof(output_pk_xy)) == 0);
     }
 }

--- a/src/modules/recovery/tests_impl.h
+++ b/src/modules/recovery/tests_impl.h
@@ -45,11 +45,11 @@ static void test_ecdsa_recovery_api(void) {
                                        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 
     /* Construct and verify corresponding public key. */
-    CHECK(secp256k1_ec_seckey_verify(CTX, privkey) == 1);
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, privkey) == 1);
+    CHECK(secp256k1_ec_seckey_verify(CTX, privkey));
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, privkey));
 
     /* Check bad contexts and NULLs for signing */
-    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, privkey, NULL, NULL) == 1);
+    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, privkey, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_sign_recoverable(CTX, NULL, message, privkey, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_sign_recoverable(CTX, &recsig, NULL, privkey, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, NULL, NULL, NULL));
@@ -60,28 +60,28 @@ static void test_ecdsa_recovery_api(void) {
     CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, zero_privkey, NULL, NULL) == 0);
     CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, over_privkey, NULL, NULL) == 0);
     /* This one will succeed. */
-    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, privkey, NULL, NULL) == 1);
+    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, privkey, NULL, NULL));
 
     /* Check signing with a goofy nonce function */
 
     /* Check bad contexts and NULLs for recovery */
-    CHECK(secp256k1_ecdsa_recover(CTX, &recpubkey, &recsig, message) == 1);
+    CHECK(secp256k1_ecdsa_recover(CTX, &recpubkey, &recsig, message));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recover(CTX, NULL, &recsig, message));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recover(CTX, &recpubkey, NULL, message));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recover(CTX, &recpubkey, &recsig, NULL));
 
     /* Check NULLs for conversion */
-    CHECK(secp256k1_ecdsa_sign(CTX, &normal_sig, message, privkey, NULL, NULL) == 1);
+    CHECK(secp256k1_ecdsa_sign(CTX, &normal_sig, message, privkey, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recoverable_signature_convert(CTX, NULL, &recsig));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recoverable_signature_convert(CTX, &normal_sig, NULL));
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(CTX, &normal_sig, &recsig) == 1);
+    CHECK(secp256k1_ecdsa_recoverable_signature_convert(CTX, &normal_sig, &recsig));
 
     /* Check NULLs for de/serialization */
-    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, privkey, NULL, NULL) == 1);
+    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &recsig, message, privkey, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, NULL, &recid, &recsig));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, sig, NULL, &recsig));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, sig, &recid, NULL));
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, sig, &recid, &recsig) == 1);
+    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, sig, &recid, &recsig));
 
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, NULL, sig, recid));
     CHECK_ILLEGAL(CTX, secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &recsig, NULL, recid));
@@ -113,37 +113,37 @@ static void test_ecdsa_recovery_end_to_end(void) {
     }
 
     /* Construct and verify corresponding public key. */
-    CHECK(secp256k1_ec_seckey_verify(CTX, privkey) == 1);
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, privkey) == 1);
+    CHECK(secp256k1_ec_seckey_verify(CTX, privkey));
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, privkey));
 
     /* Serialize/parse compact and verify/recover. */
     extra[0] = 0;
-    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[0], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign(CTX, &signature[0], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[4], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[1], message, privkey, NULL, extra) == 1);
+    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[0], message, privkey, NULL, NULL));
+    CHECK(secp256k1_ecdsa_sign(CTX, &signature[0], message, privkey, NULL, NULL));
+    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[4], message, privkey, NULL, NULL));
+    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[1], message, privkey, NULL, extra));
     extra[31] = 1;
-    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[2], message, privkey, NULL, extra) == 1);
+    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[2], message, privkey, NULL, extra));
     extra[31] = 0;
     extra[0] = 1;
-    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[3], message, privkey, NULL, extra) == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, sig, &recid, &rsignature[4]) == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(CTX, &signature[4], &rsignature[4]) == 1);
+    CHECK(secp256k1_ecdsa_sign_recoverable(CTX, &rsignature[3], message, privkey, NULL, extra));
+    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, sig, &recid, &rsignature[4]));
+    CHECK(secp256k1_ecdsa_recoverable_signature_convert(CTX, &signature[4], &rsignature[4]));
     CHECK(secp256k1_memcmp_var(&signature[4], &signature[0], 64) == 0);
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[4], message, &pubkey) == 1);
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[4], message, &pubkey));
     memset(&rsignature[4], 0, sizeof(rsignature[4]));
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsignature[4], sig, recid) == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(CTX, &signature[4], &rsignature[4]) == 1);
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[4], message, &pubkey) == 1);
+    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsignature[4], sig, recid));
+    CHECK(secp256k1_ecdsa_recoverable_signature_convert(CTX, &signature[4], &rsignature[4]));
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[4], message, &pubkey));
     /* Parse compact (with recovery id) and recover. */
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsignature[4], sig, recid) == 1);
-    CHECK(secp256k1_ecdsa_recover(CTX, &recpubkey, &rsignature[4], message) == 1);
+    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsignature[4], sig, recid));
+    CHECK(secp256k1_ecdsa_recover(CTX, &recpubkey, &rsignature[4], message));
     CHECK(secp256k1_memcmp_var(&pubkey, &recpubkey, sizeof(pubkey)) == 0);
     /* Serialize/destroy/parse signature and verify again. */
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, sig, &recid, &rsignature[4]) == 1);
+    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(CTX, sig, &recid, &rsignature[4]));
     sig[secp256k1_testrand_bits(6)] += 1 + secp256k1_testrand_int(255);
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsignature[4], sig, recid) == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(CTX, &signature[4], &rsignature[4]) == 1);
+    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsignature[4], sig, recid));
+    CHECK(secp256k1_ecdsa_recoverable_signature_convert(CTX, &signature[4], &rsignature[4]));
     CHECK(secp256k1_ecdsa_verify(CTX, &signature[4], message, &pubkey) == 0);
     /* Recover again */
     CHECK(secp256k1_ecdsa_recover(CTX, &recpubkey, &rsignature[4], message) == 0 ||
@@ -239,16 +239,16 @@ static void test_ecdsa_recovery_edge_cases(void) {
             0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E,
             0x8C, 0xD0, 0x36, 0x41, 0x45, 0x02, 0x01, 0x04
         };
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigb64, recid) == 1);
-        CHECK(secp256k1_ecdsa_recover(CTX, &pubkeyb, &rsig, msg32) == 1);
-        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbder, sizeof(sigbder)) == 1);
-        CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyb) == 1);
+        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigb64, recid));
+        CHECK(secp256k1_ecdsa_recover(CTX, &pubkeyb, &rsig, msg32));
+        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbder, sizeof(sigbder)));
+        CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyb));
         for (recid2 = 0; recid2 < 4; recid2++) {
             secp256k1_pubkey pubkey2b;
-            CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigb64, recid2) == 1);
-            CHECK(secp256k1_ecdsa_recover(CTX, &pubkey2b, &rsig, msg32) == 1);
+            CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigb64, recid2));
+            CHECK(secp256k1_ecdsa_recover(CTX, &pubkey2b, &rsig, msg32));
             /* Verifying with (order + r,4) should always fail. */
-            CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbderlong, sizeof(sigbderlong)) == 1);
+            CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbderlong, sizeof(sigbderlong)));
             CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyb) == 0);
         }
         /* DER parsing tests. */
@@ -261,14 +261,14 @@ static void test_ecdsa_recovery_edge_cases(void) {
         CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbderalt3, sizeof(sigbderalt3)) == 0);
         CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbderalt4, sizeof(sigbderalt4)) == 0);
         sigbderalt3[4] = 1;
-        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbderalt3, sizeof(sigbderalt3)) == 1);
+        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbderalt3, sizeof(sigbderalt3)));
         CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyb) == 0);
         sigbderalt4[7] = 1;
-        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbderalt4, sizeof(sigbderalt4)) == 1);
+        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbderalt4, sizeof(sigbderalt4)));
         CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyb) == 0);
         /* Damage signature. */
         sigbder[7]++;
-        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbder, sizeof(sigbder)) == 1);
+        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbder, sizeof(sigbder)));
         CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyb) == 0);
         sigbder[7]--;
         CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigbder, 6) == 0);
@@ -303,23 +303,23 @@ static void test_ecdsa_recovery_edge_cases(void) {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         };
         secp256k1_pubkey pubkeyc;
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigc64, 0) == 1);
-        CHECK(secp256k1_ecdsa_recover(CTX, &pubkeyc, &rsig, msg32) == 1);
-        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigcder, sizeof(sigcder)) == 1);
-        CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyc) == 1);
+        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigc64, 0));
+        CHECK(secp256k1_ecdsa_recover(CTX, &pubkeyc, &rsig, msg32));
+        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigcder, sizeof(sigcder)));
+        CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyc));
         sigcder[4] = 0;
         sigc64[31] = 0;
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigc64, 0) == 1);
+        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigc64, 0));
         CHECK(secp256k1_ecdsa_recover(CTX, &pubkeyb, &rsig, msg32) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigcder, sizeof(sigcder)) == 1);
+        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigcder, sizeof(sigcder)));
         CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyc) == 0);
         sigcder[4] = 1;
         sigcder[7] = 0;
         sigc64[31] = 1;
         sigc64[63] = 0;
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigc64, 0) == 1);
+        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(CTX, &rsig, sigc64, 0));
         CHECK(secp256k1_ecdsa_recover(CTX, &pubkeyb, &rsig, msg32) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigcder, sizeof(sigcder)) == 1);
+        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, sigcder, sizeof(sigcder)));
         CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg32, &pubkeyc) == 0);
     }
 }

--- a/src/modules/schnorrsig/bench_impl.h
+++ b/src/modules/schnorrsig/bench_impl.h
@@ -40,7 +40,7 @@ static void bench_schnorrsig_verify(void* arg, int iters) {
 
     for (i = 0; i < iters; i++) {
         secp256k1_xonly_pubkey pk;
-        CHECK(secp256k1_xonly_pubkey_parse(data->ctx, &pk, data->pk[i]) == 1);
+        CHECK(secp256k1_xonly_pubkey_parse(data->ctx, &pk, data->pk[i]));
         CHECK(secp256k1_schnorrsig_verify(data->ctx, data->sigs[i], data->msgs[i], MSGLEN, &pk));
     }
 }
@@ -79,7 +79,7 @@ static void run_schnorrsig_bench(int iters, int argc, char** argv) {
         CHECK(secp256k1_keypair_create(data.ctx, keypair, sk));
         CHECK(secp256k1_schnorrsig_sign_custom(data.ctx, sig, msg, MSGLEN, keypair, NULL));
         CHECK(secp256k1_keypair_xonly_pub(data.ctx, &pk, NULL, keypair));
-        CHECK(secp256k1_xonly_pubkey_serialize(data.ctx, pk_char, &pk) == 1);
+        CHECK(secp256k1_xonly_pubkey_serialize(data.ctx, pk_char, &pk));
     }
 
     if (d || have_flag(argc, argv, "schnorrsig") || have_flag(argc, argv, "sign") || have_flag(argc, argv, "schnorrsig_sign")) run_benchmark("schnorrsig_sign", bench_schnorrsig_sign, NULL, NULL, (void *) &data, 10, iters);

--- a/src/modules/schnorrsig/tests_impl.h
+++ b/src/modules/schnorrsig/tests_impl.h
@@ -14,9 +14,9 @@
  */
 static void nonce_function_bip340_bitflip(unsigned char **args, size_t n_flip, size_t n_bytes, size_t msglen, size_t algolen) {
     unsigned char nonces[2][32];
-    CHECK(nonce_function_bip340(nonces[0], args[0], msglen, args[1], args[2], args[3], algolen, args[4]) == 1);
+    CHECK(nonce_function_bip340(nonces[0], args[0], msglen, args[1], args[2], args[3], algolen, args[4]));
     secp256k1_testrand_flip(args[n_flip], n_bytes);
-    CHECK(nonce_function_bip340(nonces[1], args[0], msglen, args[1], args[2], args[3], algolen, args[4]) == 1);
+    CHECK(nonce_function_bip340(nonces[1], args[0], msglen, args[1], args[2], args[3], algolen, args[4]));
     CHECK(secp256k1_memcmp_var(nonces[0], nonces[1], 32) != 0);
 }
 
@@ -74,10 +74,10 @@ static void run_nonce_function_bip340_tests(void) {
 
     /* NULL algo is disallowed */
     CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, NULL, 0, NULL) == 0);
-    CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, algo, algolen, NULL) == 1);
+    CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, algo, algolen, NULL));
     /* Other algo is fine */
     secp256k1_testrand_bytes_test(algo, algolen);
-    CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, algo, algolen, NULL) == 1);
+    CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, algo, algolen, NULL));
 
     for (i = 0; i < COUNT; i++) {
         unsigned char nonce2[32];
@@ -86,20 +86,20 @@ static void run_nonce_function_bip340_tests(void) {
         size_t algolen_tmp;
 
         /* Different msglen gives different nonce */
-        CHECK(nonce_function_bip340(nonce2, msg, msglen_tmp, key, pk, algo, algolen, NULL) == 1);
+        CHECK(nonce_function_bip340(nonce2, msg, msglen_tmp, key, pk, algo, algolen, NULL));
         CHECK(secp256k1_memcmp_var(nonce, nonce2, 32) != 0);
 
         /* Different algolen gives different nonce */
         offset = secp256k1_testrand_int(algolen - 1);
         algolen_tmp = (algolen + offset) % algolen;
-        CHECK(nonce_function_bip340(nonce2, msg, msglen, key, pk, algo, algolen_tmp, NULL) == 1);
+        CHECK(nonce_function_bip340(nonce2, msg, msglen, key, pk, algo, algolen_tmp, NULL));
         CHECK(secp256k1_memcmp_var(nonce, nonce2, 32) != 0);
     }
 
     /* NULL aux_rand argument is allowed, and identical to passing all zero aux_rand. */
     memset(aux_rand, 0, 32);
-    CHECK(nonce_function_bip340(nonce_z, msg, msglen, key, pk, algo, algolen, &aux_rand) == 1);
-    CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, algo, algolen, NULL) == 1);
+    CHECK(nonce_function_bip340(nonce_z, msg, msglen, key, pk, algo, algolen, &aux_rand));
+    CHECK(nonce_function_bip340(nonce, msg, msglen, key, pk, algo, algolen, NULL));
     CHECK(secp256k1_memcmp_var(nonce_z, nonce, 32) == 0);
 }
 
@@ -120,34 +120,34 @@ static void test_schnorrsig_api(void) {
     secp256k1_testrand256(sk2);
     secp256k1_testrand256(sk3);
     secp256k1_testrand256(msg);
-    CHECK(secp256k1_keypair_create(CTX, &keypairs[0], sk1) == 1);
-    CHECK(secp256k1_keypair_create(CTX, &keypairs[1], sk2) == 1);
-    CHECK(secp256k1_keypair_create(CTX, &keypairs[2], sk3) == 1);
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &pk[0], NULL, &keypairs[0]) == 1);
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &pk[1], NULL, &keypairs[1]) == 1);
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &pk[2], NULL, &keypairs[2]) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypairs[0], sk1));
+    CHECK(secp256k1_keypair_create(CTX, &keypairs[1], sk2));
+    CHECK(secp256k1_keypair_create(CTX, &keypairs[2], sk3));
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &pk[0], NULL, &keypairs[0]));
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &pk[1], NULL, &keypairs[1]));
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &pk[2], NULL, &keypairs[2]));
     memset(&zero_pk, 0, sizeof(zero_pk));
 
     /** main test body **/
-    CHECK(secp256k1_schnorrsig_sign32(CTX, sig, msg, &keypairs[0], NULL) == 1);
+    CHECK(secp256k1_schnorrsig_sign32(CTX, sig, msg, &keypairs[0], NULL));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign32(CTX, NULL, msg, &keypairs[0], NULL));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign32(CTX, sig, NULL, &keypairs[0], NULL));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign32(CTX, sig, msg, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign32(CTX, sig, msg, &invalid_keypair, NULL));
     CHECK_ILLEGAL(STATIC_CTX, secp256k1_schnorrsig_sign32(STATIC_CTX, sig, msg, &keypairs[0], NULL));
 
-    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypairs[0], &extraparams) == 1);
+    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypairs[0], &extraparams));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign_custom(CTX, NULL, msg, sizeof(msg), &keypairs[0], &extraparams));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign_custom(CTX, sig, NULL, sizeof(msg), &keypairs[0], &extraparams));
-    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, NULL, 0, &keypairs[0], &extraparams) == 1);
+    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, NULL, 0, &keypairs[0], &extraparams));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), NULL, &extraparams));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &invalid_keypair, &extraparams));
-    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypairs[0], NULL) == 1);
+    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypairs[0], NULL));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypairs[0], &invalid_extraparams));
     CHECK_ILLEGAL(STATIC_CTX, secp256k1_schnorrsig_sign_custom(STATIC_CTX, sig, msg, sizeof(msg), &keypairs[0], &extraparams));
 
-    CHECK(secp256k1_schnorrsig_sign32(CTX, sig, msg, &keypairs[0], NULL) == 1);
-    CHECK(secp256k1_schnorrsig_verify(CTX, sig, msg, sizeof(msg), &pk[0]) == 1);
+    CHECK(secp256k1_schnorrsig_sign32(CTX, sig, msg, &keypairs[0], NULL));
+    CHECK(secp256k1_schnorrsig_verify(CTX, sig, msg, sizeof(msg), &pk[0]));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_verify(CTX, NULL, msg, sizeof(msg), &pk[0]));
     CHECK_ILLEGAL(CTX, secp256k1_schnorrsig_verify(CTX, sig, NULL, sizeof(msg), &pk[0]));
     CHECK(secp256k1_schnorrsig_verify(CTX, sig, NULL, 0, &pk[0]) == 0);
@@ -817,14 +817,14 @@ static void test_schnorrsig_sign(void) {
     secp256k1_testrand256(aux_rand);
     CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
     CHECK(secp256k1_keypair_xonly_pub(CTX, &pk, NULL, &keypair));
-    CHECK(secp256k1_schnorrsig_sign32(CTX, sig, msg, &keypair, NULL) == 1);
+    CHECK(secp256k1_schnorrsig_sign32(CTX, sig, msg, &keypair, NULL));
     CHECK(secp256k1_schnorrsig_verify(CTX, sig, msg, sizeof(msg), &pk));
     /* Check that deprecated alias gives the same result */
-    CHECK(secp256k1_schnorrsig_sign(CTX, sig2, msg, &keypair, NULL) == 1);
+    CHECK(secp256k1_schnorrsig_sign(CTX, sig2, msg, &keypair, NULL));
     CHECK(secp256k1_memcmp_var(sig, sig2, sizeof(sig)) == 0);
 
     /* Test different nonce functions */
-    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypair, &extraparams) == 1);
+    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypair, &extraparams));
     CHECK(secp256k1_schnorrsig_verify(CTX, sig, msg, sizeof(msg), &pk));
     memset(sig, 1, sizeof(sig));
     extraparams.noncefp = nonce_function_failing;
@@ -836,15 +836,15 @@ static void test_schnorrsig_sign(void) {
     CHECK(secp256k1_memcmp_var(sig, zeros64, sizeof(sig)) == 0);
     memset(&sig, 1, sizeof(sig));
     extraparams.noncefp = nonce_function_overflowing;
-    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypair, &extraparams) == 1);
+    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypair, &extraparams));
     CHECK(secp256k1_schnorrsig_verify(CTX, sig, msg, sizeof(msg), &pk));
 
     /* When using the default nonce function, schnorrsig_sign_custom produces
      * the same result as schnorrsig_sign with aux_rand = extraparams.ndata */
     extraparams.noncefp = NULL;
     extraparams.ndata = aux_rand;
-    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypair, &extraparams) == 1);
-    CHECK(secp256k1_schnorrsig_sign32(CTX, sig2, msg, &keypair, extraparams.ndata) == 1);
+    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig, msg, sizeof(msg), &keypair, &extraparams));
+    CHECK(secp256k1_schnorrsig_sign32(CTX, sig2, msg, &keypair, extraparams.ndata));
     CHECK(secp256k1_memcmp_var(sig, sig2, sizeof(sig)) == 0);
 }
 
@@ -910,8 +910,8 @@ static void test_schnorrsig_sign_verify(void) {
     CHECK(!secp256k1_schnorrsig_verify(CTX, sig[0], msg[0], sizeof(msg[0]), &pk));
 
     /* The empty message can be signed & verified */
-    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig[0], NULL, 0, &keypair, NULL) == 1);
-    CHECK(secp256k1_schnorrsig_verify(CTX, sig[0], NULL, 0, &pk) == 1);
+    CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig[0], NULL, 0, &keypair, NULL));
+    CHECK(secp256k1_schnorrsig_verify(CTX, sig[0], NULL, 0, &pk));
 
     {
         /* Test varying message lengths */
@@ -920,8 +920,8 @@ static void test_schnorrsig_sign_verify(void) {
         for (i = 0; i < sizeof(msg_large); i += 32) {
             secp256k1_testrand256(&msg_large[i]);
         }
-        CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig[0], msg_large, msglen, &keypair, NULL) == 1);
-        CHECK(secp256k1_schnorrsig_verify(CTX, sig[0], msg_large, msglen, &pk) == 1);
+        CHECK(secp256k1_schnorrsig_sign_custom(CTX, sig[0], msg_large, msglen, &keypair, NULL));
+        CHECK(secp256k1_schnorrsig_verify(CTX, sig[0], msg_large, msglen, &pk));
         /* Verification for a random wrong message length fails */
         msglen = (msglen + (sizeof(msg_large) - 1)) % sizeof(msg_large);
         CHECK(secp256k1_schnorrsig_verify(CTX, sig[0], msg_large, msglen, &pk) == 0);
@@ -943,26 +943,26 @@ static void test_schnorrsig_taproot(void) {
 
     /* Create output key */
     secp256k1_testrand256(sk);
-    CHECK(secp256k1_keypair_create(CTX, &keypair, sk) == 1);
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &internal_pk, NULL, &keypair) == 1);
+    CHECK(secp256k1_keypair_create(CTX, &keypair, sk));
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &internal_pk, NULL, &keypair));
     /* In actual taproot the tweak would be hash of internal_pk */
-    CHECK(secp256k1_xonly_pubkey_serialize(CTX, tweak, &internal_pk) == 1);
-    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak) == 1);
-    CHECK(secp256k1_keypair_xonly_pub(CTX, &output_pk, &pk_parity, &keypair) == 1);
-    CHECK(secp256k1_xonly_pubkey_serialize(CTX, output_pk_bytes, &output_pk) == 1);
+    CHECK(secp256k1_xonly_pubkey_serialize(CTX, tweak, &internal_pk));
+    CHECK(secp256k1_keypair_xonly_tweak_add(CTX, &keypair, tweak));
+    CHECK(secp256k1_keypair_xonly_pub(CTX, &output_pk, &pk_parity, &keypair));
+    CHECK(secp256k1_xonly_pubkey_serialize(CTX, output_pk_bytes, &output_pk));
 
     /* Key spend */
     secp256k1_testrand256(msg);
-    CHECK(secp256k1_schnorrsig_sign32(CTX, sig, msg, &keypair, NULL) == 1);
+    CHECK(secp256k1_schnorrsig_sign32(CTX, sig, msg, &keypair, NULL));
     /* Verify key spend */
-    CHECK(secp256k1_xonly_pubkey_parse(CTX, &output_pk, output_pk_bytes) == 1);
-    CHECK(secp256k1_schnorrsig_verify(CTX, sig, msg, sizeof(msg), &output_pk) == 1);
+    CHECK(secp256k1_xonly_pubkey_parse(CTX, &output_pk, output_pk_bytes));
+    CHECK(secp256k1_schnorrsig_verify(CTX, sig, msg, sizeof(msg), &output_pk));
 
     /* Script spend */
-    CHECK(secp256k1_xonly_pubkey_serialize(CTX, internal_pk_bytes, &internal_pk) == 1);
+    CHECK(secp256k1_xonly_pubkey_serialize(CTX, internal_pk_bytes, &internal_pk));
     /* Verify script spend */
-    CHECK(secp256k1_xonly_pubkey_parse(CTX, &internal_pk, internal_pk_bytes) == 1);
-    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, output_pk_bytes, pk_parity, &internal_pk, tweak) == 1);
+    CHECK(secp256k1_xonly_pubkey_parse(CTX, &internal_pk, internal_pk_bytes));
+    CHECK(secp256k1_xonly_pubkey_tweak_add_check(CTX, output_pk_bytes, pk_parity, &internal_pk, tweak));
 }
 
 static void run_schnorrsig_tests(void) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -292,22 +292,22 @@ static void run_ec_illegal_argument_tests(void) {
     /* Verify context-type checking illegal-argument errors. */
     CHECK_ILLEGAL(STATIC_CTX, secp256k1_ec_pubkey_create(STATIC_CTX, &pubkey, ctmp));
     SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, ctmp) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, ctmp));
     SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(pubkey));
     CHECK_ILLEGAL(STATIC_CTX, secp256k1_ecdsa_sign(STATIC_CTX, &sig, ctmp, ctmp, NULL, NULL));
     SECP256K1_CHECKMEM_UNDEFINE(&sig, sizeof(sig));
-    CHECK(secp256k1_ecdsa_sign(CTX, &sig, ctmp, ctmp, NULL, NULL) == 1);
+    CHECK(secp256k1_ecdsa_sign(CTX, &sig, ctmp, ctmp, NULL, NULL));
     SECP256K1_CHECKMEM_CHECK(&sig, sizeof(sig));
-    CHECK(secp256k1_ecdsa_verify(CTX, &sig, ctmp, &pubkey) == 1);
-    CHECK(secp256k1_ecdsa_verify(STATIC_CTX, &sig, ctmp, &pubkey) == 1);
-    CHECK(secp256k1_ec_pubkey_tweak_add(CTX, &pubkey, ctmp) == 1);
-    CHECK(secp256k1_ec_pubkey_tweak_add(STATIC_CTX, &pubkey, ctmp) == 1);
-    CHECK(secp256k1_ec_pubkey_tweak_mul(CTX, &pubkey, ctmp) == 1);
-    CHECK(secp256k1_ec_pubkey_negate(STATIC_CTX, &pubkey) == 1);
-    CHECK(secp256k1_ec_pubkey_negate(CTX, &pubkey) == 1);
+    CHECK(secp256k1_ecdsa_verify(CTX, &sig, ctmp, &pubkey));
+    CHECK(secp256k1_ecdsa_verify(STATIC_CTX, &sig, ctmp, &pubkey));
+    CHECK(secp256k1_ec_pubkey_tweak_add(CTX, &pubkey, ctmp));
+    CHECK(secp256k1_ec_pubkey_tweak_add(STATIC_CTX, &pubkey, ctmp));
+    CHECK(secp256k1_ec_pubkey_tweak_mul(CTX, &pubkey, ctmp));
+    CHECK(secp256k1_ec_pubkey_negate(STATIC_CTX, &pubkey));
+    CHECK(secp256k1_ec_pubkey_negate(CTX, &pubkey));
     CHECK_ILLEGAL(STATIC_CTX, secp256k1_ec_pubkey_negate(STATIC_CTX, &zero_pubkey));
     CHECK_ILLEGAL(CTX, secp256k1_ec_pubkey_negate(CTX, NULL));
-    CHECK(secp256k1_ec_pubkey_tweak_mul(STATIC_CTX, &pubkey, ctmp) == 1);
+    CHECK(secp256k1_ec_pubkey_tweak_mul(STATIC_CTX, &pubkey, ctmp));
 }
 
 static void run_static_context_tests(int use_prealloc) {
@@ -375,9 +375,9 @@ static void run_proper_context_tests(int use_prealloc) {
 
     /* Randomize and reset randomization */
     CHECK(context_eq(my_ctx, my_ctx_fresh));
-    CHECK(secp256k1_context_randomize(my_ctx, seed) == 1);
+    CHECK(secp256k1_context_randomize(my_ctx, seed));
     CHECK(!context_eq(my_ctx, my_ctx_fresh));
-    CHECK(secp256k1_context_randomize(my_ctx, NULL) == 1);
+    CHECK(secp256k1_context_randomize(my_ctx, NULL));
     CHECK(context_eq(my_ctx, my_ctx_fresh));
 
     /* set error callback (to a function that still aborts in case malloc() fails in secp256k1_context_clone() below) */
@@ -831,7 +831,7 @@ static void run_tagged_sha256_tests(void) {
     };
 
     /* API test */
-    CHECK(secp256k1_tagged_sha256(CTX, hash32, tag, sizeof(tag), msg, sizeof(msg)) == 1);
+    CHECK(secp256k1_tagged_sha256(CTX, hash32, tag, sizeof(tag), msg, sizeof(msg)));
     CHECK_ILLEGAL(CTX, secp256k1_tagged_sha256(CTX, NULL, tag, sizeof(tag), msg, sizeof(msg)));
     CHECK_ILLEGAL(CTX, secp256k1_tagged_sha256(CTX, hash32, NULL, 0, msg, sizeof(msg)));
     CHECK_ILLEGAL(CTX, secp256k1_tagged_sha256(CTX, hash32, tag, sizeof(tag), NULL, 0));
@@ -839,7 +839,7 @@ static void run_tagged_sha256_tests(void) {
     /* Static test vector */
     memcpy(tag, "tag", 3);
     memcpy(msg, "msg", 3);
-    CHECK(secp256k1_tagged_sha256(CTX, hash32, tag, 3, msg, 3) == 1);
+    CHECK(secp256k1_tagged_sha256(CTX, hash32, tag, 3, msg, 3));
     CHECK(secp256k1_memcmp_var(hash32, hash_expected, sizeof(hash32)) == 0);
 }
 
@@ -2288,8 +2288,8 @@ static void run_scalar_set_b32_seckey_tests(void) {
     /* Usually set_b32 and set_b32_seckey give the same result */
     random_scalar_order_b32(b32);
     secp256k1_scalar_set_b32(&s1, b32, NULL);
-    CHECK(secp256k1_scalar_set_b32_seckey(&s2, b32) == 1);
-    CHECK(secp256k1_scalar_eq(&s1, &s2) == 1);
+    CHECK(secp256k1_scalar_set_b32_seckey(&s2, b32));
+    CHECK(secp256k1_scalar_eq(&s1, &s2));
 
     memset(b32, 0, sizeof(b32));
     CHECK(secp256k1_scalar_set_b32_seckey(&s2, b32) == 0);
@@ -3007,9 +3007,9 @@ static void run_field_be32_overflow(void) {
         secp256k1_fe fe;
         CHECK(secp256k1_fe_set_b32_limit(&fe, zero_overflow) == 0);
         secp256k1_fe_set_b32_mod(&fe, zero_overflow);
-        CHECK(secp256k1_fe_normalizes_to_zero(&fe) == 1);
+        CHECK(secp256k1_fe_normalizes_to_zero(&fe));
         secp256k1_fe_normalize(&fe);
-        CHECK(secp256k1_fe_is_zero(&fe) == 1);
+        CHECK(secp256k1_fe_is_zero(&fe));
         secp256k1_fe_get_b32(out, &fe);
         CHECK(secp256k1_memcmp_var(out, zero, 32) == 0);
     }
@@ -4089,7 +4089,7 @@ static void test_ec_combine(void) {
         secp256k1_ecmult_gen(&CTX->ecmult_gen_ctx, &Qj, &sum);
         secp256k1_ge_set_gej(&Q, &Qj);
         secp256k1_pubkey_save(&sd, &Q);
-        CHECK(secp256k1_ec_pubkey_combine(CTX, &sd2, d, i) == 1);
+        CHECK(secp256k1_ec_pubkey_combine(CTX, &sd2, d, i));
         CHECK(secp256k1_memcmp_var(&sd, &sd2, sizeof(sd)) == 0);
     }
 }
@@ -5109,37 +5109,37 @@ static void test_ecmult_multi_batch_size_helper(void) {
 
     max_n_batch_points = 1;
     n = 0;
-    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n) == 1);
+    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n));
     CHECK(n_batches == 0);
     CHECK(n_batch_points == 0);
 
     max_n_batch_points = 2;
     n = 5;
-    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n) == 1);
+    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n));
     CHECK(n_batches == 3);
     CHECK(n_batch_points == 2);
 
     max_n_batch_points = ECMULT_MAX_POINTS_PER_BATCH;
     n = ECMULT_MAX_POINTS_PER_BATCH;
-    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n) == 1);
-    CHECK(n_batches == 1);
+    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n));
+    CHECK(n_batches);
     CHECK(n_batch_points == ECMULT_MAX_POINTS_PER_BATCH);
 
     max_n_batch_points = ECMULT_MAX_POINTS_PER_BATCH + 1;
     n = ECMULT_MAX_POINTS_PER_BATCH + 1;
-    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n) == 1);
+    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n));
     CHECK(n_batches == 2);
     CHECK(n_batch_points == ECMULT_MAX_POINTS_PER_BATCH/2 + 1);
 
     max_n_batch_points = 1;
     n = SIZE_MAX;
-    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n) == 1);
+    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n));
     CHECK(n_batches == SIZE_MAX);
     CHECK(n_batch_points == 1);
 
     max_n_batch_points = 2;
     n = SIZE_MAX;
-    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n) == 1);
+    CHECK(secp256k1_ecmult_multi_batch_size_helper(&n_batches, &n_batch_points, max_n_batch_points, n));
     CHECK(n_batches == SIZE_MAX/2 + 1);
     CHECK(n_batch_points == 2);
 }
@@ -5676,11 +5676,11 @@ static void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, in
                 size_t outl;
                 memset(&pubkey, 0, sizeof(pubkey));
                 SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(pubkey));
-                CHECK(secp256k1_ec_pubkey_parse(CTX, &pubkey, pubkeyc, pubkeyclen) == 1);
+                CHECK(secp256k1_ec_pubkey_parse(CTX, &pubkey, pubkeyc, pubkeyclen));
                 SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(pubkey));
                 outl = 65;
                 SECP256K1_CHECKMEM_UNDEFINE(pubkeyo, 65);
-                CHECK(secp256k1_ec_pubkey_serialize(CTX, pubkeyo, &outl, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+                CHECK(secp256k1_ec_pubkey_serialize(CTX, pubkeyo, &outl, &pubkey, SECP256K1_EC_COMPRESSED));
                 SECP256K1_CHECKMEM_CHECK(pubkeyo, outl);
                 CHECK(outl == 33);
                 CHECK(secp256k1_memcmp_var(&pubkeyo[1], &pubkeyc[1], 32) == 0);
@@ -5688,14 +5688,14 @@ static void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, in
                 if (ypass) {
                     /* This test isn't always done because we decode with alternative signs, so the y won't match. */
                     CHECK(pubkeyo[0] == ysign);
-                    CHECK(secp256k1_pubkey_load(CTX, &ge, &pubkey) == 1);
+                    CHECK(secp256k1_pubkey_load(CTX, &ge, &pubkey));
                     memset(&pubkey, 0, sizeof(pubkey));
                     SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(pubkey));
                     secp256k1_pubkey_save(&pubkey, &ge);
                     SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(pubkey));
                     outl = 65;
                     SECP256K1_CHECKMEM_UNDEFINE(pubkeyo, 65);
-                    CHECK(secp256k1_ec_pubkey_serialize(CTX, pubkeyo, &outl, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 1);
+                    CHECK(secp256k1_ec_pubkey_serialize(CTX, pubkeyo, &outl, &pubkey, SECP256K1_EC_UNCOMPRESSED));
                     SECP256K1_CHECKMEM_CHECK(pubkeyo, outl);
                     CHECK(outl == 65);
                     CHECK(pubkeyo[0] == 4);
@@ -5957,11 +5957,11 @@ static void run_ec_pubkey_parse_test(void) {
     /* Valid parse. */
     memset(&pubkey, 0, sizeof(pubkey));
     SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_parse(CTX, &pubkey, pubkeyc, 65) == 1);
-    CHECK(secp256k1_ec_pubkey_parse(secp256k1_context_static, &pubkey, pubkeyc, 65) == 1);
+    CHECK(secp256k1_ec_pubkey_parse(CTX, &pubkey, pubkeyc, 65));
+    CHECK(secp256k1_ec_pubkey_parse(secp256k1_context_static, &pubkey, pubkeyc, 65));
     SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(pubkey));
     SECP256K1_CHECKMEM_UNDEFINE(&ge, sizeof(ge));
-    CHECK(secp256k1_pubkey_load(CTX, &ge, &pubkey) == 1);
+    CHECK(secp256k1_pubkey_load(CTX, &ge, &pubkey));
     SECP256K1_CHECKMEM_CHECK(&ge.x, sizeof(ge.x));
     SECP256K1_CHECKMEM_CHECK(&ge.y, sizeof(ge.y));
     SECP256K1_CHECKMEM_CHECK(&ge.infinity, sizeof(ge.infinity));
@@ -5981,7 +5981,7 @@ static void run_ec_pubkey_parse_test(void) {
     CHECK(len == 0);
     len = 65;
     SECP256K1_CHECKMEM_UNDEFINE(sout, 65);
-    CHECK(secp256k1_ec_pubkey_serialize(CTX, sout, &len, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 1);
+    CHECK(secp256k1_ec_pubkey_serialize(CTX, sout, &len, &pubkey, SECP256K1_EC_UNCOMPRESSED));
     SECP256K1_CHECKMEM_CHECK(sout, 65);
     CHECK(len == 65);
     /* Multiple illegal args. Should still set arg error only once. */
@@ -6038,10 +6038,10 @@ static void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* One must be accepted. */
     ctmp[31] = 0x01;
-    CHECK(secp256k1_ec_seckey_verify(CTX, ctmp) == 1);
+    CHECK(secp256k1_ec_seckey_verify(CTX, ctmp));
     memset(&pubkey, 0, sizeof(pubkey));
     SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, ctmp) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, ctmp));
     SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     pubkey_one = pubkey;
@@ -6056,19 +6056,19 @@ static void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* -1 must be accepted. */
     ctmp[31] = 0x40;
-    CHECK(secp256k1_ec_seckey_verify(CTX, ctmp) == 1);
+    CHECK(secp256k1_ec_seckey_verify(CTX, ctmp));
     memset(&pubkey, 0, sizeof(pubkey));
     SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, ctmp) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, ctmp));
     SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     pubkey_negone = pubkey;
     /* Tweak of zero leaves the value unchanged. */
     memset(ctmp2, 0, 32);
-    CHECK(secp256k1_ec_seckey_tweak_add(CTX, ctmp, ctmp2) == 1);
+    CHECK(secp256k1_ec_seckey_tweak_add(CTX, ctmp, ctmp2));
     CHECK(secp256k1_memcmp_var(orderc, ctmp, 31) == 0 && ctmp[31] == 0x40);
     memcpy(&pubkey2, &pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_tweak_add(CTX, &pubkey, ctmp2) == 1);
+    CHECK(secp256k1_ec_pubkey_tweak_add(CTX, &pubkey, ctmp2));
     CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Multiply tweak of zero zeroizes the output. */
     CHECK(secp256k1_ec_seckey_tweak_mul(CTX, ctmp, ctmp2) == 0);
@@ -6081,7 +6081,7 @@ static void run_eckey_edge_case_test(void) {
     memcpy(ctmp, orderc, 32);
     memset(ctmp2, 0, 32);
     ctmp2[31] = 0x01;
-    CHECK(secp256k1_ec_seckey_verify(CTX, ctmp2) == 1);
+    CHECK(secp256k1_ec_seckey_verify(CTX, ctmp2));
     CHECK(secp256k1_ec_seckey_verify(CTX, ctmp) == 0);
     CHECK(secp256k1_ec_seckey_tweak_add(CTX, ctmp, ctmp2) == 0);
     CHECK(secp256k1_memcmp_var(zeros, ctmp, 32) == 0);
@@ -6123,17 +6123,17 @@ static void run_eckey_edge_case_test(void) {
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* Tweak computation wraps and results in a key of 1. */
     ctmp2[31] = 2;
-    CHECK(secp256k1_ec_seckey_tweak_add(CTX, ctmp2, ctmp) == 1);
+    CHECK(secp256k1_ec_seckey_tweak_add(CTX, ctmp2, ctmp));
     CHECK(secp256k1_memcmp_var(ctmp2, zeros, 31) == 0 && ctmp2[31] == 1);
     ctmp2[31] = 2;
-    CHECK(secp256k1_ec_pubkey_tweak_add(CTX, &pubkey, ctmp2) == 1);
+    CHECK(secp256k1_ec_pubkey_tweak_add(CTX, &pubkey, ctmp2));
     ctmp2[31] = 1;
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey2, ctmp2) == 1);
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey2, ctmp2));
     CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Tweak mul * 2 = 1+1. */
-    CHECK(secp256k1_ec_pubkey_tweak_add(CTX, &pubkey, ctmp2) == 1);
+    CHECK(secp256k1_ec_pubkey_tweak_add(CTX, &pubkey, ctmp2));
     ctmp2[31] = 2;
-    CHECK(secp256k1_ec_pubkey_tweak_mul(CTX, &pubkey2, ctmp2) == 1);
+    CHECK(secp256k1_ec_pubkey_tweak_mul(CTX, &pubkey2, ctmp2));
     CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Zeroize pubkey on parse error. */
     memset(&pubkey, 0, 32);
@@ -6144,7 +6144,7 @@ static void run_eckey_edge_case_test(void) {
     CHECK_ILLEGAL(CTX, secp256k1_ec_pubkey_tweak_mul(CTX, &pubkey2, ctmp2));
     CHECK(secp256k1_memcmp_var(&pubkey2, zeros, sizeof(pubkey2)) == 0);
     /* Plain argument errors. */
-    CHECK(secp256k1_ec_seckey_verify(CTX, ctmp) == 1);
+    CHECK(secp256k1_ec_seckey_verify(CTX, ctmp));
     CHECK_ILLEGAL(CTX, secp256k1_ec_seckey_verify(CTX, NULL));
     memset(ctmp2, 0, 32);
     ctmp2[31] = 4;
@@ -6185,12 +6185,12 @@ static void run_eckey_edge_case_test(void) {
     pubkeys[0] = &pubkey_negone;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(CTX, &pubkey, pubkeys, 1) == 1);
+    CHECK(secp256k1_ec_pubkey_combine(CTX, &pubkey, pubkeys, 1));
     SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     len = 33;
-    CHECK(secp256k1_ec_pubkey_serialize(CTX, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
-    CHECK(secp256k1_ec_pubkey_serialize(CTX, ctmp2, &len, &pubkey_negone, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(secp256k1_ec_pubkey_serialize(CTX, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED));
+    CHECK(secp256k1_ec_pubkey_serialize(CTX, ctmp2, &len, &pubkey_negone, SECP256K1_EC_COMPRESSED));
     CHECK(secp256k1_memcmp_var(ctmp, ctmp2, 33) == 0);
     /* Result is infinity. */
     pubkeys[0] = &pubkey_one;
@@ -6204,18 +6204,18 @@ static void run_eckey_edge_case_test(void) {
     pubkeys[2] = &pubkey_one;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(CTX, &pubkey, pubkeys, 3) == 1);
+    CHECK(secp256k1_ec_pubkey_combine(CTX, &pubkey, pubkeys, 3));
     SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     len = 33;
-    CHECK(secp256k1_ec_pubkey_serialize(CTX, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
-    CHECK(secp256k1_ec_pubkey_serialize(CTX, ctmp2, &len, &pubkey_one, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(secp256k1_ec_pubkey_serialize(CTX, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED));
+    CHECK(secp256k1_ec_pubkey_serialize(CTX, ctmp2, &len, &pubkey_one, SECP256K1_EC_COMPRESSED));
     CHECK(secp256k1_memcmp_var(ctmp, ctmp2, 33) == 0);
     /* Adds to two. */
     pubkeys[1] = &pubkey_one;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     SECP256K1_CHECKMEM_UNDEFINE(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(CTX, &pubkey, pubkeys, 2) == 1);
+    CHECK(secp256k1_ec_pubkey_combine(CTX, &pubkey, pubkeys, 2));
     SECP256K1_CHECKMEM_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(secp256k1_memcmp_var(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
 }
@@ -6228,14 +6228,14 @@ static void run_eckey_negate_test(void) {
     memcpy(seckey_tmp, seckey, 32);
 
     /* Verify negation changes the key and changes it back */
-    CHECK(secp256k1_ec_seckey_negate(CTX, seckey) == 1);
+    CHECK(secp256k1_ec_seckey_negate(CTX, seckey));
     CHECK(secp256k1_memcmp_var(seckey, seckey_tmp, 32) != 0);
-    CHECK(secp256k1_ec_seckey_negate(CTX, seckey) == 1);
+    CHECK(secp256k1_ec_seckey_negate(CTX, seckey));
     CHECK(secp256k1_memcmp_var(seckey, seckey_tmp, 32) == 0);
 
     /* Check that privkey alias gives same result */
-    CHECK(secp256k1_ec_seckey_negate(CTX, seckey) == 1);
-    CHECK(secp256k1_ec_privkey_negate(CTX, seckey_tmp) == 1);
+    CHECK(secp256k1_ec_seckey_negate(CTX, seckey));
+    CHECK(secp256k1_ec_privkey_negate(CTX, seckey_tmp));
     CHECK(secp256k1_memcmp_var(seckey, seckey_tmp, 32) == 0);
 
     /* Negating all 0s fails */
@@ -6374,24 +6374,24 @@ static void test_ecdsa_end_to_end(void) {
     }
 
     /* Construct and verify corresponding public key. */
-    CHECK(secp256k1_ec_seckey_verify(CTX, privkey) == 1);
-    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, privkey) == 1);
+    CHECK(secp256k1_ec_seckey_verify(CTX, privkey));
+    CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, privkey));
 
     /* Verify exporting and importing public key. */
     CHECK(secp256k1_ec_pubkey_serialize(CTX, pubkeyc, &pubkeyclen, &pubkey, secp256k1_testrand_bits(1) == 1 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
     memset(&pubkey, 0, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_parse(CTX, &pubkey, pubkeyc, pubkeyclen) == 1);
+    CHECK(secp256k1_ec_pubkey_parse(CTX, &pubkey, pubkeyc, pubkeyclen));
 
     /* Verify negation changes the key and changes it back */
     memcpy(&pubkey_tmp, &pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_negate(CTX, &pubkey_tmp) == 1);
+    CHECK(secp256k1_ec_pubkey_negate(CTX, &pubkey_tmp));
     CHECK(secp256k1_memcmp_var(&pubkey_tmp, &pubkey, sizeof(pubkey)) != 0);
-    CHECK(secp256k1_ec_pubkey_negate(CTX, &pubkey_tmp) == 1);
+    CHECK(secp256k1_ec_pubkey_negate(CTX, &pubkey_tmp));
     CHECK(secp256k1_memcmp_var(&pubkey_tmp, &pubkey, sizeof(pubkey)) == 0);
 
     /* Verify private key import and export. */
     CHECK(ec_privkey_export_der(CTX, seckey, &seckeylen, privkey, secp256k1_testrand_bits(1) == 1));
-    CHECK(ec_privkey_import_der(CTX, privkey2, seckey, seckeylen) == 1);
+    CHECK(ec_privkey_import_der(CTX, privkey2, seckey, seckeylen));
     CHECK(secp256k1_memcmp_var(privkey, privkey2, 32) == 0);
 
     /* Optionally tweak the keys using addition. */
@@ -6414,7 +6414,7 @@ static void test_ecdsa_end_to_end(void) {
             return;
         }
         CHECK(secp256k1_memcmp_var(privkey, privkey_tmp, 32) == 0);
-        CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey2, privkey) == 1);
+        CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey2, privkey));
         CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     }
 
@@ -6438,19 +6438,19 @@ static void test_ecdsa_end_to_end(void) {
             return;
         }
         CHECK(secp256k1_memcmp_var(privkey, privkey_tmp, 32) == 0);
-        CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey2, privkey) == 1);
+        CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey2, privkey));
         CHECK(secp256k1_memcmp_var(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     }
 
     /* Sign. */
-    CHECK(secp256k1_ecdsa_sign(CTX, &signature[0], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign(CTX, &signature[4], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign(CTX, &signature[1], message, privkey, NULL, extra) == 1);
+    CHECK(secp256k1_ecdsa_sign(CTX, &signature[0], message, privkey, NULL, NULL));
+    CHECK(secp256k1_ecdsa_sign(CTX, &signature[4], message, privkey, NULL, NULL));
+    CHECK(secp256k1_ecdsa_sign(CTX, &signature[1], message, privkey, NULL, extra));
     extra[31] = 1;
-    CHECK(secp256k1_ecdsa_sign(CTX, &signature[2], message, privkey, NULL, extra) == 1);
+    CHECK(secp256k1_ecdsa_sign(CTX, &signature[2], message, privkey, NULL, extra));
     extra[31] = 0;
     extra[0] = 1;
-    CHECK(secp256k1_ecdsa_sign(CTX, &signature[3], message, privkey, NULL, extra) == 1);
+    CHECK(secp256k1_ecdsa_sign(CTX, &signature[3], message, privkey, NULL, extra));
     CHECK(secp256k1_memcmp_var(&signature[0], &signature[4], sizeof(signature[0])) == 0);
     CHECK(secp256k1_memcmp_var(&signature[0], &signature[1], sizeof(signature[0])) != 0);
     CHECK(secp256k1_memcmp_var(&signature[0], &signature[2], sizeof(signature[0])) != 0);
@@ -6459,10 +6459,10 @@ static void test_ecdsa_end_to_end(void) {
     CHECK(secp256k1_memcmp_var(&signature[1], &signature[3], sizeof(signature[0])) != 0);
     CHECK(secp256k1_memcmp_var(&signature[2], &signature[3], sizeof(signature[0])) != 0);
     /* Verify. */
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[0], message, &pubkey) == 1);
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[1], message, &pubkey) == 1);
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[2], message, &pubkey) == 1);
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[3], message, &pubkey) == 1);
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[0], message, &pubkey));
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[1], message, &pubkey));
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[2], message, &pubkey));
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[3], message, &pubkey));
     /* Test lower-S form, malleate, verify and fail, test again, malleate again */
     CHECK(!secp256k1_ecdsa_signature_normalize(CTX, NULL, &signature[0]));
     secp256k1_ecdsa_signature_load(CTX, &r, &s, &signature[0]);
@@ -6473,21 +6473,21 @@ static void test_ecdsa_end_to_end(void) {
     CHECK(secp256k1_ecdsa_signature_normalize(CTX, &signature[5], &signature[5]));
     CHECK(!secp256k1_ecdsa_signature_normalize(CTX, NULL, &signature[5]));
     CHECK(!secp256k1_ecdsa_signature_normalize(CTX, &signature[5], &signature[5]));
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[5], message, &pubkey) == 1);
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[5], message, &pubkey));
     secp256k1_scalar_negate(&s, &s);
     secp256k1_ecdsa_signature_save(&signature[5], &r, &s);
     CHECK(!secp256k1_ecdsa_signature_normalize(CTX, NULL, &signature[5]));
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[5], message, &pubkey) == 1);
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[5], message, &pubkey));
     CHECK(secp256k1_memcmp_var(&signature[5], &signature[0], 64) == 0);
 
     /* Serialize/parse DER and verify again */
-    CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, sig, &siglen, &signature[0]) == 1);
+    CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, sig, &siglen, &signature[0]));
     memset(&signature[0], 0, sizeof(signature[0]));
-    CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &signature[0], sig, siglen) == 1);
-    CHECK(secp256k1_ecdsa_verify(CTX, &signature[0], message, &pubkey) == 1);
+    CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &signature[0], sig, siglen));
+    CHECK(secp256k1_ecdsa_verify(CTX, &signature[0], message, &pubkey));
     /* Serialize/destroy/parse DER and verify again. */
     siglen = 74;
-    CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, sig, &siglen, &signature[0]) == 1);
+    CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, sig, &siglen, &signature[0]));
     sig[secp256k1_testrand_int(siglen)] += 1 + secp256k1_testrand_int(255);
     CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &signature[0], sig, siglen) == 0 ||
           secp256k1_ecdsa_verify(CTX, &signature[0], message, &pubkey) == 0);
@@ -6567,8 +6567,8 @@ static void run_pubkey_comparison(void) {
     secp256k1_pubkey pk1;
     secp256k1_pubkey pk2;
 
-    CHECK(secp256k1_ec_pubkey_parse(CTX, &pk1, pk1_ser, sizeof(pk1_ser)) == 1);
-    CHECK(secp256k1_ec_pubkey_parse(CTX, &pk2, pk2_ser, sizeof(pk2_ser)) == 1);
+    CHECK(secp256k1_ec_pubkey_parse(CTX, &pk1, pk1_ser, sizeof(pk1_ser)));
+    CHECK(secp256k1_ec_pubkey_parse(CTX, &pk2, pk2_ser, sizeof(pk2_ser)));
 
     CHECK_ILLEGAL_VOID(CTX, CHECK(secp256k1_ec_pubkey_cmp(CTX, NULL, &pk2) < 0));
     CHECK_ILLEGAL_VOID(CTX, CHECK(secp256k1_ec_pubkey_cmp(CTX, &pk1, NULL) > 0));
@@ -6593,7 +6593,7 @@ static void run_pubkey_comparison(void) {
     /* Make pk2 the same as pk1 but with 3 rather than 2. Note that in
      * an uncompressed encoding, these would have the opposite ordering */
     pk1_ser[0] = 3;
-    CHECK(secp256k1_ec_pubkey_parse(CTX, &pk2, pk1_ser, sizeof(pk1_ser)) == 1);
+    CHECK(secp256k1_ec_pubkey_parse(CTX, &pk2, pk1_ser, sizeof(pk1_ser)));
     CHECK(secp256k1_ec_pubkey_cmp(CTX, &pk1, &pk2) < 0);
     CHECK(secp256k1_ec_pubkey_cmp(CTX, &pk2, &pk1) > 0);
 }
@@ -6972,11 +6972,11 @@ static void test_ecdsa_edge_cases(void) {
         secp256k1_scalar_set_int(&sr, 2);
         CHECK(secp256k1_eckey_pubkey_parse(&key, pubkey, 33));
         CHECK(secp256k1_eckey_pubkey_parse(&key2, pubkey2, 33));
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg) == 1);
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg));
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg));
         secp256k1_scalar_negate(&ss, &ss);
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg) == 1);
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg));
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg));
         secp256k1_scalar_set_int(&ss, 1);
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 0);
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg) == 0);
@@ -7013,11 +7013,11 @@ static void test_ecdsa_edge_cases(void) {
         secp256k1_scalar_set_b32(&sr, csr, NULL);
         CHECK(secp256k1_eckey_pubkey_parse(&key, pubkey, 33));
         CHECK(secp256k1_eckey_pubkey_parse(&key2, pubkey2, 33));
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg) == 1);
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg));
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg));
         secp256k1_scalar_negate(&ss, &ss);
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg) == 1);
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg));
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg));
         secp256k1_scalar_set_int(&ss, 2);
         secp256k1_scalar_inverse_var(&ss, &ss);
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 0);
@@ -7047,9 +7047,9 @@ static void test_ecdsa_edge_cases(void) {
         secp256k1_scalar_negate(&msg, &msg);
         secp256k1_scalar_set_b32(&sr, csr, NULL);
         CHECK(secp256k1_eckey_pubkey_parse(&key, pubkey, 33));
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg));
         secp256k1_scalar_negate(&ss, &ss);
-        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
+        CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg));
         secp256k1_scalar_set_int(&ss, 3);
         secp256k1_scalar_inverse_var(&ss, &ss);
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 0);
@@ -7087,16 +7087,16 @@ static void test_ecdsa_edge_cases(void) {
         CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, precomputed_nonce_function, nonce) == 0);
         CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, precomputed_nonce_function, nonce2) == 0);
         msg[31] = 0xaa;
-        CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, precomputed_nonce_function, nonce) == 1);
+        CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, precomputed_nonce_function, nonce));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_sign(CTX, NULL, msg, key, precomputed_nonce_function, nonce2));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_sign(CTX, &sig, NULL, key, precomputed_nonce_function, nonce2));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_sign(CTX, &sig, msg, NULL, precomputed_nonce_function, nonce2));
-        CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, precomputed_nonce_function, nonce2) == 1);
-        CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, key) == 1);
+        CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, precomputed_nonce_function, nonce2));
+        CHECK(secp256k1_ec_pubkey_create(CTX, &pubkey, key));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_verify(CTX, NULL, msg, &pubkey));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_verify(CTX, &sig, NULL, &pubkey));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_verify(CTX, &sig, msg, NULL));
-        CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg, &pubkey) == 1);
+        CHECK(secp256k1_ecdsa_verify(CTX, &sig, msg, &pubkey));
         CHECK_ILLEGAL(CTX, secp256k1_ec_pubkey_create(CTX, &pubkey, NULL));
         /* That pubkeyload fails via an ARGCHECK is a little odd but makes sense because pubkeys are an opaque data type. */
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_verify(CTX, &sig, msg, &pubkey));
@@ -7104,20 +7104,20 @@ static void test_ecdsa_edge_cases(void) {
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_serialize_der(CTX, NULL, &siglen, &sig));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_serialize_der(CTX, signature, NULL, &sig));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_serialize_der(CTX, signature, &siglen, NULL));
-        CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, signature, &siglen, &sig) == 1);
+        CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, signature, &siglen, &sig));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_parse_der(CTX, NULL, signature, siglen));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_parse_der(CTX, &sig, NULL, siglen));
-        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, signature, siglen) == 1);
+        CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &sig, signature, siglen));
         siglen = 10;
         /* Too little room for a signature does not fail via ARGCHECK. */
         CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, signature, &siglen, &sig) == 0);
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_normalize(CTX, NULL, NULL));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_serialize_compact(CTX, NULL, &sig));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_serialize_compact(CTX, signature, NULL));
-        CHECK(secp256k1_ecdsa_signature_serialize_compact(CTX, signature, &sig) == 1);
+        CHECK(secp256k1_ecdsa_signature_serialize_compact(CTX, signature, &sig));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_parse_compact(CTX, NULL, signature));
         CHECK_ILLEGAL(CTX, secp256k1_ecdsa_signature_parse_compact(CTX, &sig, NULL));
-        CHECK(secp256k1_ecdsa_signature_parse_compact(CTX, &sig, signature) == 1);
+        CHECK(secp256k1_ecdsa_signature_parse_compact(CTX, &sig, signature));
         memset(signature, 255, 64);
         CHECK(secp256k1_ecdsa_signature_parse_compact(CTX, &sig, signature) == 0);
     }
@@ -7147,20 +7147,20 @@ static void test_ecdsa_edge_cases(void) {
         CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, nonce_function_test_fail, extra) == 0);
         CHECK(is_empty_signature(&sig));
         /* The retry loop successfully makes its way to the first good value. */
-        CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, nonce_function_test_retry, extra) == 1);
+        CHECK(secp256k1_ecdsa_sign(CTX, &sig, msg, key, nonce_function_test_retry, extra));
         CHECK(!is_empty_signature(&sig));
-        CHECK(secp256k1_ecdsa_sign(CTX, &sig2, msg, key, nonce_function_rfc6979, extra) == 1);
+        CHECK(secp256k1_ecdsa_sign(CTX, &sig2, msg, key, nonce_function_rfc6979, extra));
         CHECK(!is_empty_signature(&sig2));
         CHECK(secp256k1_memcmp_var(&sig, &sig2, sizeof(sig)) == 0);
         /* The default nonce function is deterministic. */
-        CHECK(secp256k1_ecdsa_sign(CTX, &sig2, msg, key, NULL, extra) == 1);
+        CHECK(secp256k1_ecdsa_sign(CTX, &sig2, msg, key, NULL, extra));
         CHECK(!is_empty_signature(&sig2));
         CHECK(secp256k1_memcmp_var(&sig, &sig2, sizeof(sig)) == 0);
         /* The default nonce function changes output with different messages. */
         for(i = 0; i < 256; i++) {
             int j;
             msg[0] = i;
-            CHECK(secp256k1_ecdsa_sign(CTX, &sig2, msg, key, NULL, extra) == 1);
+            CHECK(secp256k1_ecdsa_sign(CTX, &sig2, msg, key, NULL, extra));
             CHECK(!is_empty_signature(&sig2));
             secp256k1_ecdsa_signature_load(CTX, &sr[i], &ss, &sig2);
             for (j = 0; j < i; j++) {
@@ -7173,7 +7173,7 @@ static void test_ecdsa_edge_cases(void) {
         for(i = 256; i < 512; i++) {
             int j;
             key[0] = i - 256;
-            CHECK(secp256k1_ecdsa_sign(CTX, &sig2, msg, key, NULL, extra) == 1);
+            CHECK(secp256k1_ecdsa_sign(CTX, &sig2, msg, key, NULL, extra));
             CHECK(!is_empty_signature(&sig2));
             secp256k1_ecdsa_signature_load(CTX, &sr[i], &ss, &sig2);
             for (j = 0; j < i; j++) {
@@ -7194,13 +7194,13 @@ static void test_ecdsa_edge_cases(void) {
         SECP256K1_CHECKMEM_UNDEFINE(nonce2,32);
         SECP256K1_CHECKMEM_UNDEFINE(nonce3,32);
         SECP256K1_CHECKMEM_UNDEFINE(nonce4,32);
-        CHECK(nonce_function_rfc6979(nonce, zeros, zeros, NULL, NULL, 0) == 1);
+        CHECK(nonce_function_rfc6979(nonce, zeros, zeros, NULL, NULL, 0));
         SECP256K1_CHECKMEM_CHECK(nonce,32);
-        CHECK(nonce_function_rfc6979(nonce2, zeros, zeros, zeros, NULL, 0) == 1);
+        CHECK(nonce_function_rfc6979(nonce2, zeros, zeros, zeros, NULL, 0));
         SECP256K1_CHECKMEM_CHECK(nonce2,32);
-        CHECK(nonce_function_rfc6979(nonce3, zeros, zeros, NULL, (void *)zeros, 0) == 1);
+        CHECK(nonce_function_rfc6979(nonce3, zeros, zeros, NULL, (void *)zeros, 0));
         SECP256K1_CHECKMEM_CHECK(nonce3,32);
-        CHECK(nonce_function_rfc6979(nonce4, zeros, zeros, zeros, (void *)zeros, 0) == 1);
+        CHECK(nonce_function_rfc6979(nonce4, zeros, zeros, zeros, (void *)zeros, 0));
         SECP256K1_CHECKMEM_CHECK(nonce4,32);
         CHECK(secp256k1_memcmp_var(nonce, nonce2, 32) != 0);
         CHECK(secp256k1_memcmp_var(nonce, nonce3, 32) != 0);
@@ -7249,7 +7249,7 @@ static void test_ecdsa_wycheproof(void) {
 
         memset(&pubkey, 0, sizeof(pubkey));
         pk = &wycheproof_ecdsa_public_keys[testvectors[t].pk_offset];
-        CHECK(secp256k1_ec_pubkey_parse(CTX, &pubkey, pk, 65) == 1);
+        CHECK(secp256k1_ec_pubkey_parse(CTX, &pubkey, pk, 65));
 
         secp256k1_sha256_initialize(&hasher);
         msg = &wycheproof_ecdsa_messages[testvectors[t].msg_offset];

--- a/src/tests.c
+++ b/src/tests.c
@@ -5090,10 +5090,10 @@ static void test_ecmult_multi_pippenger_max_points(void) {
         /* allocate `total_alloc` bytes over `PIPPENGER_SCRATCH_OBJECTS` many allocations */
         total_alloc = secp256k1_pippenger_scratch_size(n_points_supported, bucket_window);
         for (i = 0; i < PIPPENGER_SCRATCH_OBJECTS - 1; i++) {
-            CHECK(secp256k1_scratch_alloc(&CTX->error_callback, scratch, 1));
+            CHECK(secp256k1_scratch_alloc(&CTX->error_callback, scratch, 1) != NULL);
             total_alloc--;
         }
-        CHECK(secp256k1_scratch_alloc(&CTX->error_callback, scratch, total_alloc));
+        CHECK(secp256k1_scratch_alloc(&CTX->error_callback, scratch, total_alloc) != NULL);
         secp256k1_scratch_apply_checkpoint(&CTX->error_callback, scratch, checkpoint);
         secp256k1_scratch_destroy(&CTX->error_callback, scratch);
     }

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -306,7 +306,7 @@ static void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_g
                 secp256k1_scalar_get_b32(msg32, &msg);
 
                 ret = secp256k1_ecdsa_sign(ctx, &sig, msg32, sk32, secp256k1_nonce_function_smallint, &k);
-                CHECK(ret == 1);
+                CHECK(ret);
 
                 secp256k1_ecdsa_signature_load(ctx, &r, &s, &sig);
                 /* Note that we compute expected_r *after* signing -- this is important

--- a/src/util.h
+++ b/src/util.h
@@ -134,14 +134,14 @@ static const secp256k1_callback default_error_callback = {
 
 #ifdef DETERMINISTIC
 #define CHECK(cond) do { \
-    if (EXPECT(!(cond), 0)) { \
-        TEST_FAILURE("test condition failed"); \
+    if (EXPECT((cond) != 1, 0)) { \
+        TEST_FAILURE("test condition failed:"); \
     } \
 } while(0)
 #else
 #define CHECK(cond) do { \
-    if (EXPECT(!(cond), 0)) { \
-        TEST_FAILURE("test condition failed: " #cond); \
+    if (EXPECT((cond) != 1, 0)) { \
+        TEST_FAILURE("test condition failed: ( " #cond " ) == 1"); \
     } \
 } while(0)
 #endif


### PR DESCRIPTION
This ensures that we don't omit the "== 1" in tests accidentally,
and thus also strengthens existing tests in which it has been omitted.

We want to check "== 1" in particular for the return values of API
functions, but it also makes sense in the case of internal functions.

If you really want to check "!= 0", you can still write it explicitly.

---

The second commit drops redundant "-1". I tried to be careful to drop it only where it makes sense. Now, `git grep "== 1"` shows only instances where the 1 is supposed to be an actual integer and not a boolean.  Still, this touches many lines, so I can drop this commit if you think it's too intrusive.