### PR TITLE
ci: Update cache action

### DIFF
--- a/.github/actions/install-homebrew-valgrind/action.yml
+++ b/.github/actions/install-homebrew-valgrind/action.yml
@@ -16,7 +16,7 @@ runs:
         cat valgrind_fingerprint
       shell: bash
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: cache
       with:
         path: ${{ env.CI_HOMEBREW_CELLAR_VALGRIND }}


### PR DESCRIPTION
This PR fixes deprecation warnings for Node.js 16 actions in the GHA CI.

See:
- https://github.com/marketplace/actions/cache
- https://github.com/actions/cache/releases/tag/v4.0.0