### PR TITLE
tests: improve fe_sqr test (issue #1472)

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -255,8 +255,8 @@ static void secp256k1_fe_add(secp256k1_fe *r, const secp256k1_fe *a);
 /** Multiply two field elements.
  *
  * On input, a and b must be valid field elements; r does not need to be initialized.
- * r and a may point to the same object, but neither can be equal to b. The magnitudes
- * of a and b must not exceed 8.
+ * r and a may point to the same object, but neither may point to the object pointed
+ * to by b. The magnitudes of a and b must not exceed 8.
  * Performs {r = a * b}
  * On output, r will have magnitude 1, but won't be normalized.
  */


### PR DESCRIPTION
As pointed out in issue #1472, currently the `run_sqr` test doesn't do anything with the result of the `fe_sqr` call. Improve that by checking that the equation `(x+y)*(x-y) = x^2 - y^2` holds for some random values y, as suggested by real-or-random in https://github.com/bitcoin-core/secp256k1/issues/1472#issuecomment-1868562354. The existing loop for generating the x values is kept as-is, the sqr call on x is still included in each iteration on the course of calulating the RHS of the equation (`secp256k1_fe_sqr(&rhs, &x);`).

The suggestion says "for random values `y != 0`", but I couldn't see a good reason to exclude zero. Happy to apply s/random_fe_test/random_fe_non_zero_test/ if needed.
