### PR TITLE
check-abi: explicitly provide public headers

### DIFF
--- a/tools/check-abi.sh
+++ b/tools/check-abi.sh
@@ -49,7 +49,7 @@ checkout_and_build() {
         -DSECP256K1_BUILD_CTIME_TESTS=OFF \
         -DSECP256K1_BUILD_EXAMPLES=OFF
     cmake --build . -j "$(nproc)"
-    abi-dumper src/libsecp256k1.so -o ABI.dump -lver "$2"
+    abi-dumper src/libsecp256k1.so -o ABI.dump -lver "$2" -public-headers ../include/
     cd "$_orig_dir"
 }
 


### PR DESCRIPTION
Without this commit, the check-abi shell script outputs false positives because it consider some headers public that are actually not public.