### PR TITLE
cmake: Do not set `CTEST_TEST_TARGET_ALIAS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,10 +273,6 @@ if(SECP256K1_BUILD_CTIME_TESTS)
   unset(msan_enabled)
 endif()
 
-# Ask CTest to create a "check" target (e.g., make check) as alias for the "test" target.
-# CTEST_TEST_TARGET_ALIAS is not documented but supposed to be user-facing.
-# See: https://gitlab.kitware.com/cmake/cmake/-/commit/816c9d1aa1f2b42d40c81a991b68c96eb12b6d2
-set(CTEST_TEST_TARGET_ALIAS check)
 include(CTest)
 # We do not use CTest's BUILD_TESTING because a single toggle for all tests is too coarse for our needs.
 mark_as_advanced(BUILD_TESTING)


### PR DESCRIPTION
An alias for the "test" target can be confusing for the downstream project.

For instance, when integrating using `add_subdirectory(secp256k1 EXCLUDE_FROM_ALL)` (see https://github.com/hebasto/bitcoin/pull/192), test binaries are not being built by default. But the `check` alias target is exposed to the downstream project build system, which in turn fails:
```
$ make -C build check
...
Unable to find executable: /home/hebasto/git/bitcoin/build/src/secp256k1/src/exhaustive_tests
3/3 Test #3: exhaustive_tests .................***Not Run   0.00 sec

0% tests passed, 3 tests failed out of 3

Total Test time (real) =   0.03 sec

The following tests FAILED:
	  1 - noverify_tests (Not Run)
	  2 - tests (Not Run)
	  3 - exhaustive_tests (Not Run)
Errors while running CTest
...
```

This PR fixes this issue by deleting the `CTEST_TEST_TARGET_ALIAS` usage.