### PR TITLE
ci: Switch from "RelWithDebInfo" to "Release" config for MSVC jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,20 +735,20 @@ jobs:
         run: cmake -E env CFLAGS="/WX ${{ matrix.configuration.cpp_flags }}" cmake -B build -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON ${{ matrix.configuration.cmake_options }}
 
       - name: Build
-        run: cmake --build build --config RelWithDebInfo -- /p:UseMultiToolTask=true /maxCpuCount
+        run: cmake --build build --config Release -- /p:UseMultiToolTask=true /maxCpuCount
 
       - name: Binaries info
         # Use the bash shell included with Git for Windows.
         shell: bash
         run: |
-          cd build/src/RelWithDebInfo && file *tests.exe bench*.exe libsecp256k1-*.dll || true
+          cd build/src/Release && file *tests.exe bench*.exe libsecp256k1-*.dll || true
 
       - name: Check
         run: |
-          ctest -C RelWithDebInfo --test-dir build -j ([int]$env:NUMBER_OF_PROCESSORS + 1)
-          build\src\RelWithDebInfo\bench_ecmult.exe
-          build\src\RelWithDebInfo\bench_internal.exe
-          build\src\RelWithDebInfo\bench.exe
+          ctest -C Release --test-dir build -j ([int]$env:NUMBER_OF_PROCESSORS + 1)
+          build\src\Release\bench_ecmult.exe
+          build\src\Release\bench_internal.exe
+          build\src\Release\bench.exe
 
   win64-native-headers:
     name: "x64 (MSVC): C++ (public headers)"


### PR DESCRIPTION
It is [reasonable](https://github.com/bitcoin-core/secp256k1/pull/1543#issuecomment-2176914205) to test a configuration that is used in the Bitcoin Core build.

For MSVC, the "Release" config (`/O2 /Ob2`) is preferable over "RelWithDebInfo" (`/Zi /O2 /Ob1`) for the following reasons:

1. `/Ob2` can be slightly better than `/Ob1` for performance; see:
- https://learn.microsoft.com/en-us/cpp/build/reference/ob-inline-function-expansion

3. `/Zi`, which produces a separate PDB file that contains all the symbolic debugging information, is incompatible with `ccache`; see:
- https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format
- https://github.com/ccache/ccache/wiki/MS-Visual-Studio