### PR TITLE
[POC, DO NOT MERGE] cmake: Switch to CMake utilities repository

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,18 @@ set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_EXTENSIONS OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+include(FetchContent)
+FetchContent_Declare(BitcoinCoreCmakeUtils
+  GIT_REPOSITORY https://github.com/hebasto/bitcoin-core-cmake-utils.git
+  GIT_TAG e7b3bbb31da6675b0c9cd5f4e46cedee9c225233
+)
+FetchContent_GetProperties(BitcoinCoreCmakeUtils)
+if(NOT bitcoincorecmakeutils_POPULATED)
+  FetchContent_Populate(BitcoinCoreCmakeUtils)
+endif()
+if(NOT "${bitcoincorecmakeutils_SOURCE_DIR}" STREQUAL "")
+  list(APPEND CMAKE_MODULE_PATH ${bitcoincorecmakeutils_SOURCE_DIR}/cmake)
+endif()
 
 option(BUILD_SHARED_LIBS "Build shared libraries." ON)
 option(SECP256K1_DISABLE_SHARED "Disable shared library. Overrides BUILD_SHARED_LIBS." OFF)
@@ -198,17 +210,10 @@ endif()
 
 # Redefine configuration flags.
 # We leave assertions on, because they are only used in the examples, and we want them always on there.
-if(MSVC)
-  string(REGEX REPLACE "/DNDEBUG[ \t\r\n]*" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
-  string(REGEX REPLACE "/DNDEBUG[ \t\r\n]*" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-  string(REGEX REPLACE "/DNDEBUG[ \t\r\n]*" "" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
-else()
-  string(REGEX REPLACE "-DNDEBUG[ \t\r\n]*" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
-  string(REGEX REPLACE "-DNDEBUG[ \t\r\n]*" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-  string(REGEX REPLACE "-DNDEBUG[ \t\r\n]*" "" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
-  # Prefer -O2 optimization level. (-O3 is CMake's default for Release for many compilers.)
-  string(REGEX REPLACE "-O3[ \t\r\n]*" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-endif()
+include(DeleteNDebugFromAllConfig)
+bitcoincore_delete_ndebug_from_all_configs(C)
+# Prefer -O2 optimization level. (-O3 is CMake's default for Release for many compilers.)
+string(REGEX REPLACE "-O3[ \t\r\n]*" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 
 # Define custom "Coverage" build type.
 set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O0 -DCOVERAGE=1 --coverage" CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,28 @@ option(SECP256K1_BUILD_EXHAUSTIVE_TESTS "Build exhaustive tests." ON)
 option(SECP256K1_BUILD_CTIME_TESTS "Build constant-time tests." ${SECP256K1_VALGRIND})
 option(SECP256K1_BUILD_EXAMPLES "Build examples." OFF)
 
+if(PROJECT_IS_TOP_LEVEL)
+  get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  set(default_build_type "RelWithDebInfo")
+  if(is_multi_config)
+    set(CMAKE_CONFIGURATION_TYPES "${default_build_type}" "Release" "Debug" "MinSizeRel" "Coverage" CACHE STRING
+      "Supported configuration types."
+      FORCE
+    )
+  else()
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
+      STRINGS "${default_build_type}" "Release" "Debug" "MinSizeRel" "Coverage"
+    )
+    if(NOT CMAKE_BUILD_TYPE)
+      message(STATUS "Setting build type to \"${default_build_type}\" as none was specified")
+      set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING
+        "Choose the type of build."
+        FORCE
+      )
+    endif()
+  endif()
+endif()
+
 # Redefine configuration flags.
 # We leave assertions on, because they are only used in the examples, and we want them always on there.
 if(MSVC)
@@ -206,28 +228,6 @@ mark_as_advanced(
   CMAKE_EXE_LINKER_FLAGS_COVERAGE
   CMAKE_SHARED_LINKER_FLAGS_COVERAGE
 )
-
-if(PROJECT_IS_TOP_LEVEL)
-  get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-  set(default_build_type "RelWithDebInfo")
-  if(is_multi_config)
-    set(CMAKE_CONFIGURATION_TYPES "${default_build_type}" "Release" "Debug" "MinSizeRel" "Coverage" CACHE STRING
-      "Supported configuration types."
-      FORCE
-    )
-  else()
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
-      STRINGS "${default_build_type}" "Release" "Debug" "MinSizeRel" "Coverage"
-    )
-    if(NOT CMAKE_BUILD_TYPE)
-      message(STATUS "Setting build type to \"${default_build_type}\" as none was specified")
-      set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING
-        "Choose the type of build."
-        FORCE
-      )
-    endif()
-  endif()
-endif()
 
 include(TryAppendCFlags)
 if(MSVC)


### PR DESCRIPTION
This PR proposes reducing code repetition by reusing CMake utilities (functions and macros) shared between this project and Bitcoin Core. Both projects use similar functionality, including:
1. Defining a default build configuration.
2. Modifying configuration-specific flags.
3. Checking compiler and linker flags.
4. Reporting a summary.

To achieve this, I suggest creating a dedicated repository under https://github.com/bitcoin-core to house these utilities. Such a repository could also benefit other projects like https://github.com/sipa/minisketch and https://github.com/chaincodelabs/libmultiprocess. Additionally, the CMake utilities repository could include CI tests for the provided utilities.

Seeking Concept (N)ACKs for this proposal. Please note that only one function is replaced in this PR.