### PR TITLE
Fixed O3 replacement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ else()
   string(REGEX REPLACE "-DNDEBUG[ \t\r\n]*" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
   string(REGEX REPLACE "-DNDEBUG[ \t\r\n]*" "" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
   # Prefer -O2 optimization level. (-O3 is CMake's default for Release for many compilers.)
-  string(REGEX REPLACE "-O3[ \t\r\n]*" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+  string(REGEX REPLACE "-O3( |$)" "-O2\\1" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 endif()
 
 # Define custom "Coverage" build type.


### PR DESCRIPTION
Old replacement of `O3` in `CMAKE_C_FLAGS_RELEASE` skip spaces, which is problematic. For instance, if `CMAKE_C_FLAGS_RELEASE = "-O3 -DFOO"`, regex will replace it with `-O2-DFOO`, which causes a compile error.

This patch changes this behavior, keeping whichever space exists between the flags.

If I may question, what is the rationale behind replacing `O3` with `O2`? Changing the user's flags is a bad practice overall, and I don't see how this replacement is beneficial.