### PR TITLE
cmake: Clean up coverage flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,21 +190,11 @@ endif()
 
 # Define custom "Coverage" build type.
 set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O0 -DCOVERAGE=1 --coverage" CACHE STRING
-  "Flags used by the C compiler during \"Coverage\" builds."
-  FORCE
-)
-set(CMAKE_EXE_LINKER_FLAGS_COVERAGE "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} --coverage" CACHE STRING
-  "Flags used for linking binaries during \"Coverage\" builds."
-  FORCE
-)
-set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} --coverage" CACHE STRING
-  "Flags used by the shared libraries linker during \"Coverage\" builds."
+  "Flags used by the C compiler for compiling and linking during \"Coverage\" builds."
   FORCE
 )
 mark_as_advanced(
   CMAKE_C_FLAGS_COVERAGE
-  CMAKE_EXE_LINKER_FLAGS_COVERAGE
-  CMAKE_SHARED_LINKER_FLAGS_COVERAGE
 )
 
 if(PROJECT_IS_TOP_LEVEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,6 @@ endif()
 # Define custom "Coverage" build type.
 set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O0 -DCOVERAGE=1 --coverage" CACHE STRING
   "Flags used by the C compiler for compiling and linking during \"Coverage\" builds."
-  FORCE
 )
 mark_as_advanced(
   CMAKE_C_FLAGS_COVERAGE


### PR DESCRIPTION
The [`CMAKE_C_FLAGS_COVERAGE`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html) is a language-wide variable. These flags will be passed to all invocations of the compiler, including invocations that drive compiling and those that drive linking.

Therefore, `--coverage` in the `CMAKE_*_LINKER_FLAGS_COVERAGE` variables is redundant.

Also this PR allows the user to override `CMAKE_C_FLAGS_COVERAGE` by setting a cache variable in the command line.