### PR TITLE
cmake: Add `--no-undefined` linker option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,11 @@ if(SECP256K1_BUILD_CTIME_TESTS)
   unset(msan_enabled)
 endif()
 
+if(NOT SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS)
+  include(TryAppendLinkerFlags)
+  try_append_linker_flags(-Wl,--no-undefined)
+endif()
+
 include(CTest)
 # We do not use CTest's BUILD_TESTING because a single toggle for all tests is too coarse for our needs.
 mark_as_advanced(BUILD_TESTING)

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,7 @@ endif
 libsecp256k1_la_SOURCES = src/secp256k1.c
 libsecp256k1_la_CPPFLAGS = $(SECP_CONFIG_DEFINES)
 libsecp256k1_la_LIBADD = $(COMMON_LIB) $(PRECOMPUTED_LIB)
-libsecp256k1_la_LDFLAGS = -no-undefined -version-info $(LIB_VERSION_CURRENT):$(LIB_VERSION_REVISION):$(LIB_VERSION_AGE)
+libsecp256k1_la_LDFLAGS = -no-undefined -version-info $(LIB_VERSION_CURRENT):$(LIB_VERSION_REVISION):$(LIB_VERSION_AGE) $(SECP_LIB_LDFLAGS)
 
 noinst_PROGRAMS =
 if USE_BENCHMARK

--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -77,6 +77,22 @@ AC_DEFUN([SECP_TRY_APPEND_CFLAGS], [
   AC_SUBST($2)
 ])
 
+dnl SECP_TRY_APPEND_LDFLAGS(flags, VAR)
+dnl Append flags to VAR if a linker accepts them.
+AC_DEFUN([SECP_TRY_APPEND_LDFLAGS], [
+  AC_MSG_CHECKING([if linker supports $1])
+  SECP_TRY_APPEND_LDFLAGS_saved_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$1 $LDFLAGS"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM()], [flag_works=yes], [flag_works=no])
+  AC_MSG_RESULT($flag_works)
+  LDFLAGS="$SECP_TRY_APPEND_LDFLAGS_saved_LDFLAGS"
+  if test x"$flag_works" = x"yes"; then
+    $2="$$2 $1"
+  fi
+  unset flag_works
+  AC_SUBST($2)
+])
+
 dnl SECP_SET_DEFAULT(VAR, default, default-dev-mode)
 dnl Set VAR to default or default-dev-mode, depending on whether dev mode is enabled
 AC_DEFUN([SECP_SET_DEFAULT], [

--- a/cmake/TryAppendLinkerFlags.cmake
+++ b/cmake/TryAppendLinkerFlags.cmake
@@ -1,0 +1,32 @@
+include_guard(GLOBAL)
+
+include(CheckCSourceCompiles)
+
+function(secp256k1_check_linker_flags_internal flags output)
+  string(MAKE_C_IDENTIFIER "${flags}" result)
+  string(TOUPPER "${result}" result)
+  set(result "LINKER_SUPPORTS_${result}")
+  set(CMAKE_REQUIRED_FLAGS "${flags}")
+  if(MSVC)
+    string(APPEND " /WX")
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    string(APPEND " -Wl,-fatal_warnings")
+  else()
+    string(APPEND " -Wl,--fatal-warnings")
+  endif()
+
+  # This ensures running a linker.
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+  check_c_source_compiles("int main() { return 0; }" ${result})
+
+  set(${output} ${${result}} PARENT_SCOPE)
+endfunction()
+
+# Append flags to the LINK_OPTIONS directory property if a linker accepts them.
+macro(try_append_linker_flags)
+  secp256k1_check_linker_flags_internal("${ARGV}" result)
+  if(result)
+    add_link_options(${ARGV})
+  endif()
+  unset(result)
+endmacro()

--- a/configure.ac
+++ b/configure.ac
@@ -420,6 +420,8 @@ fi
 
 if test x"$enable_external_default_callbacks" = x"yes"; then
   SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DUSE_EXTERNAL_DEFAULT_CALLBACKS=1"
+else
+  SECP_TRY_APPEND_LDFLAGS([-Wl,--no-undefined], [SECP_LIB_LDFLAGS])
 fi
 
 ###
@@ -486,6 +488,7 @@ echo "  CC                      = $CC"
 echo "  CPPFLAGS                = $CPPFLAGS"
 echo "  SECP_CFLAGS             = $SECP_CFLAGS"
 echo "  CFLAGS                  = $CFLAGS"
+echo "  SECP_LIB_LDFLAGS        = $SECP_LIB_LDFLAGS"
 echo "  LDFLAGS                 = $LDFLAGS"
 
 if test x"$print_msan_notice" = x"yes"; then


### PR DESCRIPTION
This PR adds the `--no-undefined` option to a linker, which supports it.

From the GNU ld [docs](https://sourceware.org/binutils/docs/ld.html):
> `--no-undefined`
>
> Report unresolved symbol references from regular object files. This is done even if the linker is creating a non-symbolic shared library.

Closes https://github.com/bitcoin-core/secp256k1/issues/1556.

~Looking for Concept (N)ACKs. Once ACKed, I'll add the same functionality to the Autotools-based build system.~