### PR TITLE
build, ci: Adjust the default size of the precomputed table for signing 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   BUILD: 'check'
   ### secp256k1 config
   ECMULTWINDOW: 15
-  ECMULTGENKB: 22
+  ECMULTGENKB: 86
   ASM: 'no'
   WIDEMUL: 'auto'
   WITH_VALGRIND: 'yes'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ include(CheckStringOptionValue)
 check_string_option_value(SECP256K1_ECMULT_WINDOW_SIZE)
 add_compile_definitions(ECMULT_WINDOW_SIZE=${SECP256K1_ECMULT_WINDOW_SIZE})
 
-set(SECP256K1_ECMULT_GEN_KB 22 CACHE STRING "The size of the precomputed table for signing in multiples of 1024 bytes (on typical platforms). Larger values result in possibly better signing or key generation performance at the cost of a larger table. Valid choices are 2, 22, 86. The default value is a reasonable setting for desktop machines (currently 22). [default=22]")
+set(SECP256K1_ECMULT_GEN_KB 86 CACHE STRING "The size of the precomputed table for signing in multiples of 1024 bytes (on typical platforms). Larger values result in possibly better signing or key generation performance at the cost of a larger table. Valid choices are 2, 22, 86. The default value is a reasonable setting for desktop machines (currently 86). [default=86]")
 set_property(CACHE SECP256K1_ECMULT_GEN_KB PROPERTY STRINGS 2 22 86)
 check_string_option_value(SECP256K1_ECMULT_GEN_KB)
 if(SECP256K1_ECMULT_GEN_KB EQUAL 2)

--- a/configure.ac
+++ b/configure.ac
@@ -216,9 +216,9 @@ AC_ARG_WITH([ecmult-window], [AS_HELP_STRING([--with-ecmult-window=SIZE],
 AC_ARG_WITH([ecmult-gen-kb], [AS_HELP_STRING([--with-ecmult-gen-kb=2|22|86],
 [The size of the precomputed table for signing in multiples of 1024 bytes (on typical platforms).]
 [Larger values result in possibly better signing/keygeneration performance at the cost of a larger table.]
-[The default value is a reasonable setting for desktop machines (currently 22). [default=22]]
+[The default value is a reasonable setting for desktop machines (currently 86). [default=86]]
 )],
-[set_ecmult_gen_kb=$withval], [set_ecmult_gen_kb=22])
+[set_ecmult_gen_kb=$withval], [set_ecmult_gen_kb=86])
 
 AC_ARG_WITH([valgrind], [AS_HELP_STRING([--with-valgrind=yes|no|auto],
 [Build with extra checks for running inside Valgrind [default=auto]]


### PR DESCRIPTION
This PR implements the [outcomes](https://github.com/bitcoin-core/secp256k1/issues/1549#issuecomment-2200559257) from today's IRC meeting:

1. The default size of the precomputed table for signing is now aligned with Bitcoin Core's [default](https://github.com/bitcoin/bitcoin/commit/a057869aa3c42457570765966cb66accb2375b13).

2. The default value in CI has been updated to reflect the new default.