### PR TITLE
cmake: Bump CMake minimum required version up to 3.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -864,5 +864,5 @@ jobs:
           CI_BUILD: ${{ runner.temp }}/${{ github.run_id }}${{ github.action }}/build
           CI_INSTALL: ${{ runner.temp }}/${{ github.run_id }}${{ github.action }}/install
         run: |
-          cmake -B ${{ env.CI_BUILD }} -DCMAKE_INSTALL_PREFIX=${{ env.CI_INSTALL }} && cmake --build ${{ env.CI_BUILD }} --target install && ls -RlAh ${{ env.CI_INSTALL }}
+          cmake -B ${{ env.CI_BUILD }} -DCMAKE_INSTALL_PREFIX=${{ env.CI_INSTALL }} && cmake --build ${{ env.CI_BUILD }} && cmake --install ${{ env.CI_BUILD }} && ls -RlAh ${{ env.CI_INSTALL }}
           gcc -o ecdsa examples/ecdsa.c -I ${{ env.CI_INSTALL }}/include -L ${{ env.CI_INSTALL }}/lib*/ -l secp256k1 -Wl,-rpath,"${{ env.CI_INSTALL }}/lib",-rpath,"${{ env.CI_INSTALL }}/lib64" && ./ecdsa

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
-
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
-  # MSVC runtime library flags are selected by the CMAKE_MSVC_RUNTIME_LIBRARY abstraction.
-  cmake_policy(SET CMP0091 NEW)
-  # MSVC warning flags are not in CMAKE_<LANG>_FLAGS by default.
-  cmake_policy(SET CMP0092 NEW)
-endif()
+cmake_minimum_required(VERSION 3.16)
 
 project(libsecp256k1
   # The package (a.k.a. release) version is based on semantic versioning 2.0.0 of

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To maintain a pristine source tree, CMake encourages to perform an out-of-source
     $ cmake ..
     $ cmake --build .
     $ ctest  # run the test suite
-    $ sudo cmake --build . --target install  # optional
+    $ sudo cmake --install .  # optional
 
 To compile optional modules (such as Schnorr signatures), you need to run `cmake` with additional flags (such as `-DSECP256K1_ENABLE_MODULE_SCHNORRSIG=ON`). Run `cmake .. -LH` to see the full list of available flags.
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -31,7 +31,7 @@ Perform these checks when reviewing the release PR (see below):
    ```shell
    dir=$(mktemp -d)
    build=$(mktemp -d)
-   cmake -B $build -DCMAKE_INSTALL_PREFIX=$dir && cmake --build $build --target install && ls -RlAh $dir
+   cmake -B $build -DCMAKE_INSTALL_PREFIX=$dir && cmake --build $build && cmake --install $build && ls -RlAh $dir
    gcc -o ecdsa examples/ecdsa.c -I $dir/include -L $dir/lib*/ -l secp256k1 -Wl,-rpath,"$dir/lib",-rpath,"$dir/lib64" && ./ecdsa
    ```
 4. Use the [`check-abi.sh`](/tools/check-abi.sh) tool to verify that there are no unexpected ABI incompatibilities and that the version number and the release notes accurately reflect all potential ABI changes. To run this tool, the `abi-dumper` and `abi-compliance-checker` packages are required.


### PR DESCRIPTION
Debian 10 [reached](https://wiki.debian.org/DebianReleases) EOL LTS yesterday, on 2024-06-30.

There no longer seem to be compelling reasons to maintain support for CMake 3.13.

The suggested minimum required version, CMake 3.16, is shipped with Ubuntu 20.04 LTS, which is [supported](https://wiki.ubuntu.com/Releases) until April 2025.

Debian 11 ships with CMake 3.18 (3.25 in backports). In [other](https://repology.org/project/cmake/versions) major distros and package managers, CMake versions are not older.