### PR TITLE
ci: Silent Homebrew's noisy reinstall warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,7 +632,7 @@ jobs:
 
       - name: Install Homebrew packages
         run: |
-          brew install automake libtool gcc
+          brew install --quiet automake libtool gcc
           ln -s $(brew --prefix gcc)/bin/gcc-?? /usr/local/bin/gcc
 
       - name: Install and cache Valgrind
@@ -691,7 +691,7 @@ jobs:
 
       - name: Install Homebrew packages
         run: |
-          brew install automake libtool gcc
+          brew install --quiet automake libtool gcc
           ln -s $(brew --prefix gcc)/bin/gcc-?? /usr/local/bin/gcc
 
       - name: CI script


### PR DESCRIPTION
Homebrew's warnings are quite noisy on the master branch:
![image](https://github.com/user-attachments/assets/82b95369-b8c9-4b99-b72c-41d0b084d4b8)

This PR silents them to allow us to focus on any other CI infra warnings once they happen.