### PR TITLE
fix: remove duplicate 'the' from header file comment

### DIFF
--- a/include/secp256k1_ellswift.h
+++ b/include/secp256k1_ellswift.h
@@ -35,7 +35,7 @@ extern "C" {
  *
  * If the Y coordinate is relevant, it is given the same parity as t.
  *
- * Changes w.r.t. the the paper:
+ * Changes w.r.t. the paper:
  * - The u=0, t=0, and u^3+t^2+7=0 conditions result in decoding to the point
  *   at infinity in the paper. Here they are remapped to finite points.
  * - The paper uses an additional encoding bit for the parity of y. Here the


### PR DESCRIPTION
Replaces:
` * Changes w.r.t. the the paper:`

With:
` * Changes w.r.t. the paper:`

in the `include/secp256k1_ellswift.h` header file.
