### PR TITLE
#1570 - Improve examples: remove key generation loops

### DIFF
--- a/examples/ecdh.c
+++ b/examples/ecdh.c
@@ -46,14 +46,12 @@ int main(void) {
     /* If the secret key is zero or out of range (bigger than secp256k1's
      * order), we try to sample a new key. Note that the probability of this
      * happening is negligible. */
-    while (1) {
-        if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
-            printf("Failed to generate randomness\n");
-            return 1;
-        }
-        if (secp256k1_ec_seckey_verify(ctx, seckey1) && secp256k1_ec_seckey_verify(ctx, seckey2)) {
-            break;
-        }
+    if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
+        printf("Failed to generate randomness\n");
+        return 1;
+    }
+    if (secp256k1_ec_seckey_verify(ctx, seckey1) && secp256k1_ec_seckey_verify(ctx, seckey2)) {
+        break;
     }
 
     /* Public key creation using a valid context with a verified secret key should never fail */

--- a/examples/ecdsa.c
+++ b/examples/ecdsa.c
@@ -53,14 +53,12 @@ int main(void) {
     /* If the secret key is zero or out of range (bigger than secp256k1's
      * order), we try to sample a new key. Note that the probability of this
      * happening is negligible. */
-    while (1) {
-        if (!fill_random(seckey, sizeof(seckey))) {
-            printf("Failed to generate randomness\n");
-            return 1;
-        }
-        if (secp256k1_ec_seckey_verify(ctx, seckey)) {
-            break;
-        }
+    if (!fill_random(seckey, sizeof(seckey))) {
+        printf("Failed to generate randomness\n");
+        return 1;
+    }
+    if (secp256k1_ec_seckey_verify(ctx, seckey)) {
+        break;
     }
 
     /* Public key creation using a valid context with a verified secret key should never fail */

--- a/examples/ellswift.c
+++ b/examples/ellswift.c
@@ -51,14 +51,12 @@ int main(void) {
     /* If the secret key is zero or out of range (bigger than secp256k1's
      * order), we try to sample a new key. Note that the probability of this
      * happening is negligible. */
-    while (1) {
-        if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
-            printf("Failed to generate randomness\n");
-            return 1;
-        }
-        if (secp256k1_ec_seckey_verify(ctx, seckey1) && secp256k1_ec_seckey_verify(ctx, seckey2)) {
-            break;
-        }
+    if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
+        printf("Failed to generate randomness\n");
+        return 1;
+    }
+    if (secp256k1_ec_seckey_verify(ctx, seckey1) && secp256k1_ec_seckey_verify(ctx, seckey2)) {
+        break;
     }
 
     /* Generate ElligatorSwift public keys. This should never fail with valid context and


### PR DESCRIPTION
Hi! As discussed in #1570 I propose this as a change to the examples.c

If the key is either zero or out of range we just return 1 and end the example instead of looping until a good key is found. This is all very unlikely but could indicate a faulty/manipulated RNG.
Anybody knows where I can find the docs for this? First commit to this library, hope I don't break anything!