### PR TITLE
#1570 improve examples: remove key generation loop

### DIFF
--- a/examples/ecdh.c
+++ b/examples/ecdh.c
@@ -42,18 +42,16 @@ int main(void) {
     assert(return_val);
 
     /*** Key Generation ***/
-
-    /* If the secret key is zero or out of range (bigger than secp256k1's
-     * order), we try to sample a new key. Note that the probability of this
-     * happening is negligible. */
-    while (1) {
-        if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
-            printf("Failed to generate randomness\n");
-            return 1;
-        }
-        if (secp256k1_ec_seckey_verify(ctx, seckey1) && secp256k1_ec_seckey_verify(ctx, seckey2)) {
-            break;
-        }
+    if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
+        printf("Failed to generate randomness\n");
+        return 1;
+    }
+    /* If the secret key is zero or out of range (greater than secp256k1's
+    * order), we fail. Note that the probability of this occurring
+    * is negligible with a properly functioning random number generator. */
+    if (!secp256k1_ec_seckey_verify(ctx, seckey1) || !secp256k1_ec_seckey_verify(ctx, seckey2)) {
+        printf("Generated secret key is invalid. This indicates an issue with the random number generator.\n");
+        return 1;
     }
 
     /* Public key creation using a valid context with a verified secret key should never fail */

--- a/examples/ecdsa.c
+++ b/examples/ecdsa.c
@@ -49,18 +49,16 @@ int main(void) {
     assert(return_val);
 
     /*** Key Generation ***/
-
-    /* If the secret key is zero or out of range (bigger than secp256k1's
-     * order), we try to sample a new key. Note that the probability of this
-     * happening is negligible. */
-    while (1) {
-        if (!fill_random(seckey, sizeof(seckey))) {
-            printf("Failed to generate randomness\n");
-            return 1;
-        }
-        if (secp256k1_ec_seckey_verify(ctx, seckey)) {
-            break;
-        }
+    /* If the secret key is zero or out of range (greater than secp256k1's
+    * order), we return 1. Note that the probability of this occurring
+    * is negligible with a properly functioning random number generator. */
+    if (!fill_random(seckey, sizeof(seckey))) {
+        printf("Failed to generate randomness\n");
+        return 1;
+    }
+    if (!secp256k1_ec_seckey_verify(ctx, seckey)) {
+        printf("Generated secret key is invalid. This indicates an issue with the random number generator.\n");
+        return 1;
     }
 
     /* Public key creation using a valid context with a verified secret key should never fail */

--- a/examples/ellswift.c
+++ b/examples/ellswift.c
@@ -48,17 +48,16 @@ int main(void) {
 
     /*** Generate secret keys ***/
 
-    /* If the secret key is zero or out of range (bigger than secp256k1's
-     * order), we try to sample a new key. Note that the probability of this
-     * happening is negligible. */
-    while (1) {
-        if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
-            printf("Failed to generate randomness\n");
-            return 1;
-        }
-        if (secp256k1_ec_seckey_verify(ctx, seckey1) && secp256k1_ec_seckey_verify(ctx, seckey2)) {
-            break;
-        }
+    /* If the secret key is zero or out of range (greater than secp256k1's
+     * order), we return 1. Note that the probability of this occurring
+     * is negligible with a properly functioning random number generator. */
+    if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
+        printf("Failed to generate randomness\n");
+        return 1;
+    }
+    if (!secp256k1_ec_seckey_verify(ctx, seckey1) || !secp256k1_ec_seckey_verify(ctx, seckey2)) {
+        printf("Generated secret key is invalid. This indicates an issue with the random number generator.\n");
+        return 1;
     }
 
     /* Generate ElligatorSwift public keys. This should never fail with valid context and

--- a/examples/schnorr.c
+++ b/examples/schnorr.c
@@ -43,20 +43,18 @@ int main(void) {
     assert(return_val);
 
     /*** Key Generation ***/
-
-    /* If the secret key is zero or out of range (bigger than secp256k1's
-     * order), we try to sample a new key. Note that the probability of this
-     * happening is negligible. */
-    while (1) {
-        if (!fill_random(seckey, sizeof(seckey))) {
-            printf("Failed to generate randomness\n");
-            return 1;
-        }
-        /* Try to create a keypair with a valid context, it should only fail if
-         * the secret key is zero or out of range. */
-        if (secp256k1_keypair_create(ctx, &keypair, seckey)) {
-            break;
-        }
+    /* If the secret key is zero or out of range (greater than secp256k1's
+    * order), we return 1. Note that the probability of this occurring
+    * is negligible with a properly functioning random number generator. */
+    if (!fill_random(seckey, sizeof(seckey))) {
+        printf("Failed to generate randomness\n");
+        return 1;
+    }
+    /* Try to create a keypair with a valid context, it should only fail if
+     * the secret key is zero or out of range. */
+    if (!secp256k1_keypair_create(ctx, &keypair, seckey)) {
+        printf("Generated secret key is invalid. This indicates an issue with the random number generator.\n");
+	return 1;
     }
 
     /* Extract the X-only public key from the keypair. We pass NULL for

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -679,12 +679,14 @@ SECP256K1_API int secp256k1_ecdsa_sign(
     const void *ndata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
-/** Verify an ECDSA secret key.
+/** Verify an elliptic curve secret key.
  *
  *  A secret key is valid if it is not 0 and less than the secp256k1 curve order
  *  when interpreted as an integer (most significant byte first). The
  *  probability of choosing a 32-byte string uniformly at random which is an
- *  invalid secret key is negligible.
+ *  invalid secret key is negligible. However, if it does happen it should 
+ *  be assumed that the randomness source is severely broken and there should
+ *  be no retry.
  *
  *  Returns: 1: secret key is valid
  *           0: secret key is invalid


### PR DESCRIPTION
Hi! As discussed in #1570 I propose this as a change to the examples.c

If the key is either zero or out of range we just return 1 and end the example instead of looping until a good key is found. This is all very unlikely but could indicate a faulty/manipulated RNG.
Anybody knows where I can find the docs for this? First commit to this library, hope I don't break anything!