### PR TITLE
doc: fix typos in `secp256k1_ecdsa_{recoverable_,}signature` API description

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -75,7 +75,7 @@ typedef struct {
     unsigned char data[64];
 } secp256k1_pubkey;
 
-/** Opaque data structured that holds a parsed ECDSA signature.
+/** Opaque data structure that holds a parsed ECDSA signature.
  *
  *  The exact representation of data inside is implementation defined and not
  *  guaranteed to be portable between different platforms or versions. It is

--- a/include/secp256k1_recovery.h
+++ b/include/secp256k1_recovery.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-/** Opaque data structured that holds a parsed ECDSA signature,
+/** Opaque data structure that holds a parsed ECDSA signature,
  *  supporting pubkey recovery.
  *
  *  The exact representation of data inside is implementation defined and not


### PR DESCRIPTION
This small PR fixes two small typos I noticed while looking at the pubkey recovery module (s/structured/structure/).