### PR TITLE
RFC: Add exhaustive test for 2-of-2 musig [WIP]

### DIFF
--- a/src/modules/musig/Makefile.am.include
+++ b/src/modules/musig/Makefile.am.include
@@ -5,4 +5,5 @@ noinst_HEADERS += src/modules/musig/keyagg_impl.h
 noinst_HEADERS += src/modules/musig/session.h
 noinst_HEADERS += src/modules/musig/session_impl.h
 noinst_HEADERS += src/modules/musig/tests_impl.h
+noinst_HEADERS += src/modules/musig/tests_exhaustive_impl.h
 noinst_HEADERS += src/modules/musig/vectors.h

--- a/src/modules/musig/keyagg_impl.h
+++ b/src/modules/musig/keyagg_impl.h
@@ -213,8 +213,12 @@ int secp256k1_musig_pubkey_agg(const secp256k1_context* ctx, secp256k1_xonly_pub
     }
     secp256k1_ge_set_gej(&pkp, &pkj);
     secp256k1_fe_normalize_var(&pkp.y);
+#if defined(EXHAUSTIVE_TEST_ORDER)
+    if (secp256k1_ge_is_infinity(&pkp)) return 0;
+#else
     /* The resulting public key is infinity with negligible probability */
     VERIFY_CHECK(!secp256k1_ge_is_infinity(&pkp));
+#endif
     if (keyagg_cache != NULL) {
         secp256k1_keyagg_cache_internal cache_i = { 0 };
         cache_i.pk = pkp;

--- a/src/modules/musig/session_impl.h
+++ b/src/modules/musig/session_impl.h
@@ -439,8 +439,12 @@ int secp256k1_musig_nonce_gen_internal(const secp256k1_context* ctx, secp256k1_m
 #endif
 
     secp256k1_nonce_function_musig(k, input_nonce, msg32, seckey, pk_ser, aggpk_ser_ptr, extra_input32);
+#if defined(EXHAUSTIVE_TEST_ORDER)
+    if (secp256k1_scalar_is_zero(&k[0]) || secp256k1_scalar_is_zero(&k[1])) return 0;
+#else
     VERIFY_CHECK(!secp256k1_scalar_is_zero(&k[0]));
     VERIFY_CHECK(!secp256k1_scalar_is_zero(&k[1]));
+#endif
     secp256k1_musig_secnonce_save(secnonce, k, &pk);
     secp256k1_musig_secnonce_invalidate(ctx, secnonce, !ret);
 

--- a/src/modules/musig/tests_exhaustive_impl.h
+++ b/src/modules/musig/tests_exhaustive_impl.h
@@ -1,0 +1,119 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
+#ifndef SECP256K1_MODULE_MUSIG_TESTS_EXHAUSTIVE_H
+#define SECP256K1_MODULE_MUSIG_TESTS_EXHAUSTIVE_H
+
+#include "../../../include/secp256k1_extrakeys.h"
+#include "../../../include/secp256k1_musig.h"
+#include "../../../include/secp256k1_schnorrsig.h"
+#include "main_impl.h"
+
+static void test_exhaustive_musig(const secp256k1_context *ctx) {
+    int s1, s2;
+    int skipped_iterations = 0;
+    uint64_t nonce_counter = 0;
+    /* TODO: improve this, maybe loop over all challenges like in the schnorr exhaustive test? */
+    unsigned char message_to_sign[32] = "this_could_be_the_hash_of_a_msg";
+
+    /* Exercise 2-of-2 musig, looping over all possible signing keys for both participants. Note that this
+       test is not fully exhaustive, as other involved cryptographic elements (nonces, challenges etc.)
+       are currently not exhausted, but either derived from a counter or constant. */
+    for (s1 = 1; s1 < EXHAUSTIVE_TEST_ORDER; s1++) {
+        for (s2 = 1; s2 < EXHAUSTIVE_TEST_ORDER; s2++) {
+            /* TODO: move first participant's key generation to outer loop */
+            secp256k1_scalar sc1, sc2;
+            unsigned char seckey1[32], seckey2[32];
+            secp256k1_keypair keypair1, keypair2;
+            secp256k1_pubkey pubkey1, pubkey2;
+            const secp256k1_pubkey *pubkeys_ptr[2];
+            secp256k1_xonly_pubkey agg_pk;
+            secp256k1_musig_keyagg_cache cache;
+            secp256k1_musig_secnonce secnonce1, secnonce2;
+            secp256k1_musig_pubnonce pubnonce1, pubnonce2;
+            const secp256k1_musig_pubnonce *pubnonces[2];
+            secp256k1_musig_aggnonce agg_pubnonce;
+            secp256k1_musig_session session;
+            secp256k1_musig_partial_sig partialsig1, partialsig2;
+            const secp256k1_musig_partial_sig *partial_sigs_ptr[2];
+            unsigned char agg_sig[64];
+            int ret;
+
+            /* Construct key pairs from exhaustive loop scalars s1, s2 */
+            secp256k1_scalar_set_int(&sc1, s1);
+            secp256k1_scalar_set_int(&sc2, s2);
+            secp256k1_scalar_get_b32(seckey1, &sc1);
+            secp256k1_scalar_get_b32(seckey2, &sc2);
+            CHECK(secp256k1_keypair_create(ctx, &keypair1, seckey1));
+            CHECK(secp256k1_keypair_create(ctx, &keypair2, seckey2));
+            CHECK(secp256k1_keypair_pub(ctx, &pubkey1, &keypair1));
+            CHECK(secp256k1_keypair_pub(ctx, &pubkey2, &keypair2));
+            pubkeys_ptr[0] = &pubkey1;
+            pubkeys_ptr[1] = &pubkey2;
+
+            /* Aggregate public keys */
+            if (!secp256k1_musig_pubkey_agg(ctx, &agg_pk, &cache, pubkeys_ptr, 2)) {
+                /* can fail if aggregated pubkey is point at infinity */
+                skipped_iterations++;
+                continue;
+            }
+
+            /* Generate nonces (using the counter variant to keep it simple) and aggregate them */
+            ret = 0;
+            while (!ret) {
+                /* can fail if one of the generated nonce scalars is zero, so try again in that case */
+                ret = secp256k1_musig_nonce_gen_counter(ctx, &secnonce1, &pubnonce1,
+                        nonce_counter++, &keypair1, NULL, NULL, NULL);
+            }
+            ret = 0;
+            while (!ret) {
+                ret = secp256k1_musig_nonce_gen_counter(ctx, &secnonce2, &pubnonce2,
+                        nonce_counter++, &keypair2, NULL, NULL, NULL);
+            }
+            pubnonces[0] = &pubnonce1;
+            pubnonces[1] = &pubnonce2;
+            CHECK(secp256k1_musig_nonce_agg(ctx, &agg_pubnonce, pubnonces, 2));
+
+            /* Start signing session */
+            CHECK(secp256k1_musig_nonce_process(ctx, &session, &agg_pubnonce, message_to_sign, &cache));
+
+            /* If the final nonce is the generator point, this means that possibly a reduction from an
+               invalid final nonce (i.e. point of infinity) has happened and the aggregated signature
+               verification would fail (see BIP327, section "Dealing with Infinity in Nonce Aggregation",
+               and the `GetSessionValues` algorithm, at the condition `If is_infinite(R'):`), so skip
+               the signing/verification part in this case.
+               TODO: detect this directly in _musig_nonce_process and return 0 accordingly, in order to
+                     avoid false positives (i.e. final nonce is the generator point without reduction),
+                     leading to skips even if the aggregated signature verification would succeed
+            */
+            {
+                secp256k1_musig_session_internal session_i;
+                unsigned char ge_x[32];
+                CHECK(secp256k1_musig_session_load(ctx, &session_i, &session));
+                secp256k1_fe_get_b32(ge_x, &secp256k1_ge_const_g.x);
+                if (secp256k1_memcmp_var(session_i.fin_nonce, ge_x, 32) == 0) {
+                    skipped_iterations++;
+                    continue;
+                }
+            }
+
+            /* Create partial signatures and verify them */
+            CHECK(secp256k1_musig_partial_sign(ctx, &partialsig1, &secnonce1, &keypair1, &cache, &session));
+            CHECK(secp256k1_musig_partial_sign(ctx, &partialsig2, &secnonce2, &keypair2, &cache, &session));
+            CHECK(secp256k1_musig_partial_sig_verify(ctx, &partialsig1, &pubnonce1, &pubkey1, &cache, &session));
+            CHECK(secp256k1_musig_partial_sig_verify(ctx, &partialsig2, &pubnonce2, &pubkey2, &cache, &session));
+
+            /* Aggregate signature and verify it */
+            partial_sigs_ptr[0] = &partialsig1;
+            partial_sigs_ptr[1] = &partialsig2;
+            CHECK(secp256k1_musig_partial_sig_agg(ctx, agg_sig, &session, partial_sigs_ptr, 2));
+            CHECK(secp256k1_schnorrsig_verify(ctx, agg_sig, message_to_sign, 32, &agg_pk));
+        }
+    }
+    printf("musig exhaustive test, skipped iterations: %d/%d\n",
+        skipped_iterations, (EXHAUSTIVE_TEST_ORDER-1)*(EXHAUSTIVE_TEST_ORDER-1));
+}
+
+#endif

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -351,6 +351,10 @@ static void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_g
 #include "modules/ellswift/tests_exhaustive_impl.h"
 #endif
 
+#ifdef ENABLE_MODULE_MUSIG
+#include "modules/musig/tests_exhaustive_impl.h"
+#endif
+
 int main(int argc, char** argv) {
     int i;
     secp256k1_gej groupj[EXHAUSTIVE_TEST_ORDER];
@@ -454,6 +458,9 @@ int main(int argc, char** argv) {
     #if !EXHAUSTIVE_TEST_CURVE_HAS_EVEN_ORDER
         test_exhaustive_ellswift(ctx, group);
     #endif
+#endif
+#ifdef ENABLE_MODULE_MUSIG
+        test_exhaustive_musig(ctx);
 #endif
 
         secp256k1_context_destroy(ctx);


### PR DESCRIPTION
This PR attempts to add an exhaustive test for 2-of-2 signature aggregation via MuSig2. Currently, only the combinations of each participant's possible signing keys are fully iterated, and other involved cryptographic elements (generated nonces, signing challenge etc.) are either derived from a counter or statically set. Some invalid conditions that are practically unreachable on the full group order for secp256k1 (due to negligible probablity) can obviously hit for the exhaustive group test orders, so some special treatment is needed here to avoid a crash in the test. Those three conditions are:

* aggregated public key results in the point at infinity (in `secp256k1_musig_pubkey_agg`): https://github.com/bitcoin-core/secp256k1/blob/a88aa9350633c2d2472bace5c290aa291c7f12c9/src/modules/musig/keyagg_impl.h#L216-L217
&rarr; the PR copes with that by letting the function return 0 instead if the condition hits and we compile for exhaustive tests, and skip the current iteration at the call-site in that case
* one of the generated nonce scalars is zero (in `secp256k1_musig_nonce_gen{,_counter}`): https://github.com/bitcoin-core/secp256k1/blob/a88aa9350633c2d2472bace5c290aa291c7f12c9/src/modules/musig/session_impl.h#L442-L443
&rarr; the PR copes with that by letting the function return 0 instead if the condition hits and we compile for exhaustive tests, and try to generate a nonce another time with different input (increased counter), until it succeeds
* the generated final nonce is the point at infinity (in `secp256k1_musig_nonce_process`): https://github.com/bitcoin-core/secp256k1/blob/a88aa9350633c2d2472bace5c290aa291c7f12c9/src/modules/musig/session_impl.h#L601-L603
 This one was a bit tricky. On the full group order, this condition can only be true if both of the aggregated nonce group elements (which are supplied externally) are the point at infinity (encoded as 66 zero-bytes), caused by either a dishonest nonce aggregator or dishonest signer, see https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#user-content-Dealing_with_Infinity_in_Nonce_Aggregation. On the reduced group orders, this can hit frequently, making the aggregated signature verification fail in the end.
&rarr; the PR copes with that by checking if the final nonce is G (when possibly a reduction has happened) and skip signing/verification then. that's a bit hacky and skips also legit cases (i.e. we arrive at G for the final nonce without the reduction being involved), but works for now :-)

I'm asking for general comments at this point what would make the most sense in an exhaustive musig test, or if it is even worth it to have one at all. If yes, is it a good idea to change function behaviour depending on exhaustive tests being compiled? Are there other solutions that I haven't thought of? It's also a bit strange that some iterations are skipped, so there should probably an extra check at the end (right now if all iterations are skipped, we wouldn't even notice it, apart from the WIP-printf output). I guess the basic idea of the PR is still slightly better than having nothing, but still far away from what we would want ideally.

Number of full iterations (i.e. nothing is skipped due to any condition described above) depending on the exhaustive test order:
* EXHAUSTIVE_TEST_ORDER=7 &rarr; 18/36 full iterations (50%)
* EXHAUSTIVE_TEST_ORDER=13 &rarr; 99/144 full iterations (68.75%)
* EXHAUSTIVE_TEST_ORDER=199 &rarr; 38453/39204 full iterations (98.08%)