### PR TITLE
Examples: swap magic numbers for EXIT_ codes

### DIFF
--- a/examples/ecdh.c
+++ b/examples/ecdh.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <secp256k1.h>
 #include <secp256k1_ecdh.h>
@@ -33,7 +34,7 @@ int main(void) {
     secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     if (!fill_random(randomize, sizeof(randomize))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     /* Randomizing the context is recommended to protect against side-channel
      * leakage See `secp256k1_context_randomize` in secp256k1.h for more
@@ -44,14 +45,14 @@ int main(void) {
     /*** Key Generation ***/
     if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     /* If the secret key is zero or out of range (greater than secp256k1's
     * order), we fail. Note that the probability of this occurring
     * is negligible with a properly functioning random number generator. */
     if (!secp256k1_ec_seckey_verify(ctx, seckey1) || !secp256k1_ec_seckey_verify(ctx, seckey2)) {
         printf("Generated secret key is invalid. This indicates an issue with the random number generator.\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Public key creation using a valid context with a verified secret key should never fail */
@@ -116,5 +117,5 @@ int main(void) {
     secure_erase(shared_secret1, sizeof(shared_secret1));
     secure_erase(shared_secret2, sizeof(shared_secret2));
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/examples/ecdsa.c
+++ b/examples/ecdsa.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <secp256k1.h>
 
@@ -40,7 +41,7 @@ int main(void) {
     secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     if (!fill_random(randomize, sizeof(randomize))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     /* Randomizing the context is recommended to protect against side-channel
      * leakage See `secp256k1_context_randomize` in secp256k1.h for more
@@ -50,15 +51,15 @@ int main(void) {
 
     /*** Key Generation ***/
     /* If the secret key is zero or out of range (greater than secp256k1's
-    * order), we return 1. Note that the probability of this occurring
+    * order), we fail. Note that the probability of this occurring
     * is negligible with a properly functioning random number generator. */
     if (!fill_random(seckey, sizeof(seckey))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     if (!secp256k1_ec_seckey_verify(ctx, seckey)) {
         printf("Generated secret key is invalid. This indicates an issue with the random number generator.\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Public key creation using a valid context with a verified secret key should never fail */
@@ -92,13 +93,13 @@ int main(void) {
     /* Deserialize the signature. This will return 0 if the signature can't be parsed correctly. */
     if (!secp256k1_ecdsa_signature_parse_compact(ctx, &sig, serialized_signature)) {
         printf("Failed parsing the signature\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Deserialize the public key. This will return 0 if the public key can't be parsed correctly. */
     if (!secp256k1_ec_pubkey_parse(ctx, &pubkey, compressed_pubkey, sizeof(compressed_pubkey))) {
         printf("Failed parsing the public key\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Verify a signature. This will return 1 if it's valid and 0 if it's not. */
@@ -133,5 +134,5 @@ int main(void) {
      * will remove any writes that aren't used. */
     secure_erase(seckey, sizeof(seckey));
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/examples/ellswift.c
+++ b/examples/ellswift.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <secp256k1.h>
 #include <secp256k1_ellswift.h>
@@ -38,7 +39,7 @@ int main(void) {
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     if (!fill_random(randomize, sizeof(randomize))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     /* Randomizing the context is recommended to protect against side-channel
      * leakage. See `secp256k1_context_randomize` in secp256k1.h for more
@@ -53,11 +54,11 @@ int main(void) {
      * is negligible with a properly functioning random number generator. */
     if (!fill_random(seckey1, sizeof(seckey1)) || !fill_random(seckey2, sizeof(seckey2))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     if (!secp256k1_ec_seckey_verify(ctx, seckey1) || !secp256k1_ec_seckey_verify(ctx, seckey2)) {
         printf("Generated secret key is invalid. This indicates an issue with the random number generator.\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Generate ElligatorSwift public keys. This should never fail with valid context and
@@ -65,7 +66,7 @@ int main(void) {
        optional, but recommended. */
     if (!fill_random(auxrand1, sizeof(auxrand1)) || !fill_random(auxrand2, sizeof(auxrand2))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     return_val = secp256k1_ellswift_create(ctx, ellswift_pubkey1, seckey1, auxrand1);
     assert(return_val);
@@ -118,5 +119,5 @@ int main(void) {
     secure_erase(shared_secret1, sizeof(shared_secret1));
     secure_erase(shared_secret2, sizeof(shared_secret2));
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/examples/schnorr.c
+++ b/examples/schnorr.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <secp256k1.h>
 #include <secp256k1_extrakeys.h>
@@ -34,7 +35,7 @@ int main(void) {
     secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     if (!fill_random(randomize, sizeof(randomize))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     /* Randomizing the context is recommended to protect against side-channel
      * leakage See `secp256k1_context_randomize` in secp256k1.h for more
@@ -48,13 +49,13 @@ int main(void) {
     * is negligible with a properly functioning random number generator. */
     if (!fill_random(seckey, sizeof(seckey))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
     /* Try to create a keypair with a valid context, it should only fail if
      * the secret key is zero or out of range. */
     if (!secp256k1_keypair_create(ctx, &keypair, seckey)) {
         printf("Generated secret key is invalid. This indicates an issue with the random number generator.\n");
-	return 1;
+	return EXIT_FAILURE;
     }
 
     /* Extract the X-only public key from the keypair. We pass NULL for
@@ -91,7 +92,7 @@ int main(void) {
     /* Generate 32 bytes of randomness to use with BIP-340 schnorr signing. */
     if (!fill_random(auxiliary_rand, sizeof(auxiliary_rand))) {
         printf("Failed to generate randomness\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Generate a Schnorr signature.
@@ -111,7 +112,7 @@ int main(void) {
      * be parsed correctly */
     if (!secp256k1_xonly_pubkey_parse(ctx, &pubkey, serialized_pubkey)) {
         printf("Failed parsing the public key\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Compute the tagged hash on the received messages using the same tag as the signer. */
@@ -150,5 +151,5 @@ int main(void) {
      * Here we are preventing these writes from being optimized out, as any good compiler
      * will remove any writes that aren't used. */
     secure_erase(seckey, sizeof(seckey));
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
As discussed in #1609 this PR will use EXIT_{success, failure} codes instead of magic numbers in the return statements.

If it looks good I will continue to remove the asserts too in another commit.