### PR TITLE
Remove unused scratch space from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Document `doc/musig.md` for further notes on API usage.
    - Usage example `examples/musig.c`.
 
+#### Removed
+ - Removed the `secp256k1_scratch_space` struct and its associated functions `secp256k1_scratch_space_create` `secp256k1_scratch_space_destroy` because the scratch space was unused in the API.
+
 ## [0.5.1] - 2024-08-01
 
 #### Added

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -49,19 +49,6 @@ extern "C" {
  */
 typedef struct secp256k1_context_struct secp256k1_context;
 
-/** Opaque data structure that holds rewritable "scratch space"
- *
- *  The purpose of this structure is to replace dynamic memory allocations,
- *  because we target architectures where this may not be available. It is
- *  essentially a resizable (within specified parameters) block of bytes,
- *  which is initially created either by memory allocation or TODO as a pointer
- *  into some fixed rewritable space.
- *
- *  Unlike the context object, this cannot safely be shared between threads
- *  without additional synchronization logic.
- */
-typedef struct secp256k1_scratch_space_struct secp256k1_scratch_space;
-
 /** Opaque data structure that holds a parsed and valid public key.
  *
  *  The exact representation of data inside is implementation defined and not
@@ -390,29 +377,6 @@ SECP256K1_API void secp256k1_context_set_error_callback(
     secp256k1_context *ctx,
     void (*fun)(const char *message, void *data),
     const void *data
-) SECP256K1_ARG_NONNULL(1);
-
-/** Create a secp256k1 scratch space object.
- *
- *  Returns: a newly created scratch space.
- *  Args: ctx:  pointer to a context object.
- *  In:   size: amount of memory to be available as scratch space. Some extra
- *              (<100 bytes) will be allocated for extra accounting.
- */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT secp256k1_scratch_space *secp256k1_scratch_space_create(
-    const secp256k1_context *ctx,
-    size_t size
-) SECP256K1_ARG_NONNULL(1);
-
-/** Destroy a secp256k1 scratch space.
- *
- *  The pointer may not be used afterwards.
- *  Args:       ctx: pointer to a context object.
- *          scratch: space to destroy
- */
-SECP256K1_API void secp256k1_scratch_space_destroy(
-    const secp256k1_context *ctx,
-    secp256k1_scratch_space *scratch
 ) SECP256K1_ARG_NONNULL(1);
 
 /** Parse a variable-length public key into the pubkey object.

--- a/src/scratch.h
+++ b/src/scratch.h
@@ -21,6 +21,8 @@ typedef struct secp256k1_scratch_space_struct {
     size_t max_size;
 } secp256k1_scratch;
 
+typedef struct secp256k1_scratch_space_struct secp256k1_scratch_space;
+
 static secp256k1_scratch* secp256k1_scratch_create(const secp256k1_callback* error_callback, size_t max_size);
 
 static void secp256k1_scratch_destroy(const secp256k1_callback* error_callback, secp256k1_scratch* scratch);

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -220,12 +220,12 @@ void secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(co
     ctx->error_callback.data = data;
 }
 
-secp256k1_scratch_space* secp256k1_scratch_space_create(const secp256k1_context* ctx, size_t max_size) {
+static secp256k1_scratch_space* secp256k1_scratch_space_create(const secp256k1_context* ctx, size_t max_size) {
     VERIFY_CHECK(ctx != NULL);
     return secp256k1_scratch_create(&ctx->error_callback, max_size);
 }
 
-void secp256k1_scratch_space_destroy(const secp256k1_context *ctx, secp256k1_scratch_space* scratch) {
+static void secp256k1_scratch_space_destroy(const secp256k1_context *ctx, secp256k1_scratch_space* scratch) {
     VERIFY_CHECK(ctx != NULL);
     secp256k1_scratch_destroy(&ctx->error_callback, scratch);
 }


### PR DESCRIPTION
We had already merged this in #1305, but it was reverted before a release (#1311) because this change is not backwards compatible but at the time we only wanted to make a patch release in order to fix an actual issue.

Due to the musig module, the next release will increment the version number from 0.5.x to 0.6.0, so it would be a good time to remove the scratch space from the API.