### PR TITLE
ci: Update macOS image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,9 +612,9 @@ jobs:
         if: ${{ always() }}
 
   x86_64-macos-native:
-    name: "x86_64: macOS Monterey, Valgrind"
+    name: "x86_64: macOS Ventura, Valgrind"
     # See: https://github.com/actions/runner-images#available-images.
-    runs-on: macos-12
+    runs-on: macos-13
 
     env:
       CC: 'clang'


### PR DESCRIPTION
The macOS 12 GHA image has been deprecated since 2024-10-07. See: https://github.com/actions/runner-images/issues/10721.

Draft for now as `./libtool --mode=execute valgrind --error-exitcode=42 ./ctime_tests` fails.