### PR TITLE
util: Remove unused (u)int64_t formatting macros

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -192,14 +192,6 @@ static SECP256K1_INLINE void *checked_malloc(const secp256k1_callback* cb, size_
 # endif
 #endif
 
-#if defined(_WIN32)
-# define I64FORMAT "I64d"
-# define I64uFORMAT "I64u"
-#else
-# define I64FORMAT "lld"
-# define I64uFORMAT "llu"
-#endif
-
 #if defined(__GNUC__)
 # define SECP256K1_GNUC_EXT __extension__
 #else


### PR DESCRIPTION
We should anyway prefer to use the predefined macros from <inttypes.h>.

If I haven't missed anything, this removes the last OS-specific #if, leaving us only with compiler-specific #if(def)s.