### PR TITLE
schnorrsig: clear out masked secret key in BIP-340 nonce function

### DIFF
--- a/src/modules/schnorrsig/main_impl.h
+++ b/src/modules/schnorrsig/main_impl.h
@@ -94,6 +94,8 @@ static int nonce_function_bip340(unsigned char *nonce32, const unsigned char *ms
     secp256k1_sha256_write(&sha, msg, msglen);
     secp256k1_sha256_finalize(&sha, nonce32);
     secp256k1_sha256_clear(&sha);
+    secp256k1_memclear(masked_key, sizeof(masked_key));
+
     return 1;
 }
 


### PR DESCRIPTION
Considering that the secret key can be determined from `masked_key` if the passed auxiliary data is known (which is optional and set to all-zeros if not explicitly provided, see `ZERO_MASK`), it seems reasonable to clear it from the stack.