### PR TITLE
include: remove WARN_UNUSED_RESULT for functions always returning 1

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -707,7 +707,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_negate(
  *  Args:   ctx:        pointer to a context object
  *  In/Out: pubkey:     pointer to the public key to be negated.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_negate(
+SECP256K1_API int secp256k1_ec_pubkey_negate(
     const secp256k1_context *ctx,
     secp256k1_pubkey *pubkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
@@ -857,7 +857,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_combine(
  *           msg: pointer to an array containing the message
  *        msglen: length of the message array
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_tagged_sha256(
+SECP256K1_API int secp256k1_tagged_sha256(
     const secp256k1_context *ctx,
     unsigned char *hash32,
     const unsigned char *tag,

--- a/include/secp256k1_extrakeys.h
+++ b/include/secp256k1_extrakeys.h
@@ -90,7 +90,7 @@ SECP256K1_API int secp256k1_xonly_pubkey_cmp(
  *                     the negation of the pubkey and set to 0 otherwise.
  *  In:        pubkey: pointer to a public key that is converted.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_xonly_pubkey_from_pubkey(
+SECP256K1_API int secp256k1_xonly_pubkey_from_pubkey(
     const secp256k1_context *ctx,
     secp256k1_xonly_pubkey *xonly_pubkey,
     int *pk_parity,
@@ -179,7 +179,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_keypair_create(
  *  Out: seckey: pointer to a 32-byte buffer for the secret key.
  *  In: keypair: pointer to a keypair.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_keypair_sec(
+SECP256K1_API int secp256k1_keypair_sec(
     const secp256k1_context *ctx,
     unsigned char *seckey,
     const secp256k1_keypair *keypair
@@ -192,7 +192,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_keypair_sec(
  *  Out: pubkey: pointer to a pubkey object, set to the keypair public key.
  *  In: keypair: pointer to a keypair.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_keypair_pub(
+SECP256K1_API int secp256k1_keypair_pub(
     const secp256k1_context *ctx,
     secp256k1_pubkey *pubkey,
     const secp256k1_keypair *keypair
@@ -211,7 +211,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_keypair_pub(
  *               pk_parity argument of secp256k1_xonly_pubkey_from_pubkey.
  *  In: keypair: pointer to a keypair.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_keypair_xonly_pub(
+SECP256K1_API int secp256k1_keypair_xonly_pub(
     const secp256k1_context *ctx,
     secp256k1_xonly_pubkey *pubkey,
     int *pk_parity,


### PR DESCRIPTION
This makes the usage of the atribute consistent. In the musig and ellswift module, functions that return 1 always already don't have the WARN_UNUSED_RESULT attribute. In secp256k1.h and the extrakeys module, this has only been the case partially.

In all cases where this was removed, the function only returns 0 if the illegal callback has been called.

Fixes #1379