### PR TITLE
tests: update wycheproof files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ We strongly recommend updating to 0.3.1 if you use or plan to use Clang >=14 to 
  - Fix "constant-timeness" issue with Clang >=14 that could leave applications using libsecp256k1 vulnerable to a timing side-channel attack. The fix avoids secret-dependent control flow and secret-dependent memory accesses in conditional moves of memory objects when libsecp256k1 is compiled with Clang >=14.
 
 #### Added
-  - Added tests against [Project Wycheproof's](https://github.com/google/wycheproof/) set of ECDSA test vectors (Bitcoin "low-S" variant), a fixed set of test cases designed to trigger various edge cases.
+  - Added tests against [Project Wycheproof's](https://github.com/C2SP/wycheproof/) set of ECDSA test vectors (Bitcoin "low-S" variant), a fixed set of test cases designed to trigger various edge cases.
 
 #### Changed
  - Increased minimum required CMake version to 3.13. CMake builds remain experimental.

--- a/src/wycheproof/WYCHEPROOF_COPYING
+++ b/src/wycheproof/WYCHEPROOF_COPYING
@@ -1,12 +1,12 @@
 * The file `ecdsa_secp256k1_sha256_bitcoin_test.json` in this directory
-  comes from Google's project Wycheproof with git commit
-  `b063b4aedae951c69df014cd25fa6d69ae9e8cb9`, see
-  https://github.com/google/wycheproof/blob/b063b4aedae951c69df014cd25fa6d69ae9e8cb9/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
+  comes from project Wycheproof with git commit
+  `df4e933efef449fc88af0c06e028d425d84a9495`, see
+  https://github.com/C2SP/wycheproof/blob/df4e933efef449fc88af0c06e028d425d84a9495/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
 
 * The file `ecdh_secp256k1_test.json` in this directory
-  comes from Google's project Wycheproof with git commit
-  `d9f6ec7d8bd8c96da05368999094e4a75ba5cb3d`, see
-  https://github.com/google/wycheproof/blob/d9f6ec7d8bd8c96da05368999094e4a75ba5cb3d/testvectors_v1/ecdh_secp256k1_test.json
+  comes from project Wycheproof with git commit
+  `df4e933efef449fc88af0c06e028d425d84a9495`, see
+  https://github.com/C2SP/wycheproof/blob/df4e933efef449fc88af0c06e028d425d84a9495/testvectors_v1/ecdh_secp256k1_test.json
 
 * The file `ecdsa_secp256k1_sha256_bitcoin_test.h` is generated from
   `ecdsa_secp256k1_sha256_bitcoin_test.json` using the script

--- a/src/wycheproof/ecdh_secp256k1_test.json
+++ b/src/wycheproof/ecdh_secp256k1_test.json
@@ -1,7 +1,6 @@
 {
   "algorithm" : "ECDH",
   "schema" : "ecdh_test_schema.json",
-  "generatorVersion" : "0.9rc5",
   "numberOfTests" : 752,
   "header" : [
     "Test vectors of type EcdhTest are intended for",
@@ -124,6 +123,10 @@
   "testGroups" : [
     {
       "type" : "EcdhTest",
+      "source" : {
+        "name" : "google-wycheproof",
+        "version" : "0.9rc5"
+      },
       "curve" : "secp256k1",
       "encoding" : "asn",
       "tests" : [

--- a/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
+++ b/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
@@ -10,7 +10,7 @@
   "notes" : {
     "ArithmeticError" : {
       "bugType" : "EDGE_CASE",
-      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
       "cves" : [
         "CVE-2017-18146"
       ]
@@ -95,7 +95,7 @@
     },
     "SignatureMalleabilityBitcoin" : {
       "bugType" : "SIGNATURE_MALLEABILITY",
-      "description" : "\"BitCoins\"-curves are curves where signature malleability can be a serious issue. An implementation should only accept a signature s where s < n/2. If an implementation is not meant for uses cases that require signature malleability then this implemenation should be tested with another set of test vectors.",
+      "description" : "\"BitCoins\"-curves are curves where signature malleability can be a serious issue. An implementation should only accept a signature s where s < n/2. If an implementation is not meant for uses cases that require signature malleability then this implementation should be tested with another set of test vectors.",
       "effect" : "In bitcoin exchanges, it may be used to make a double deposits or double withdrawals",
       "links" : [
         "https://en.bitcoin.it/wiki/Transaction_malleability",


### PR DESCRIPTION
Wycheproof ownership was recently moved to C2SP (https://github.com/C2SP/wycheproof). This PR updates all references to the new URL and bumps to the latest version of the vector files.

This commit does not change the content of processed .h testvector files. To test:
```
make clean-testvectors testvectors
```

See: https://github.com/bitcoin-core/secp256k1/pull/1492#discussion_r1572443456