### PR TITLE
Assert field magnitude at control-flow join

### DIFF
--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -373,6 +373,8 @@ static int secp256k1_ecmult_const_xonly(secp256k1_fe* r, const secp256k1_fe *n, 
         }
     }
 
+    SECP256K1_FE_VERIFY_MAGNITUDE(&g, 2);
+
     /* Compute base point P = (n*g, g^2), the effective affine version of (n*g, g^2, v), which has
      * corresponding affine X coordinate n/d. */
     secp256k1_fe_mul(&p.x, &g, n);


### PR DESCRIPTION
As I was re-reading the xonly method I noticed that the author had taken some care about the magnitude of `g` in each branch. It's probably worth documenting magnitude assumptions when control flows join like this.

Actually I would even prefer a new field method (perhaps `_fe_join`) that calls  SECP256K1_FE_VERIFY_MAGNITUDE, and then _sets the magnitude to that value_. That would be more in line with the static analysis view of magnitudes that I recall being discussed, though I have not been following closely lately.