### PR TITLE
build: Add SECP256K1_NO_EXPORTS option to avoid default visibility for static builds

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -132,7 +132,7 @@ typedef int (*secp256k1_nonce_function)(
 #  if defined(DLL_EXPORT) || defined(SECP256K1_DLL_EXPORT)
     /* Building libsecp256k1 as a DLL.
      * 1. If using Libtool, it defines DLL_EXPORT automatically.
-     * 2. In other cases, SECP256K1_DLL_EXPORT must be defined. */
+     * 2. If using CMake, it defines SECP256K1_DLL_EXPORT automatically. */
 #   define SECP256K1_API extern __declspec (dllexport)
 #  else
     /* Building libsecp256k1 as a static library on Windows.
@@ -153,7 +153,7 @@ typedef int (*secp256k1_nonce_function)(
 #endif
 #ifndef SECP256K1_API
 /* All cases not captured by the Windows-specific logic. */
-# if defined(__GNUC__) && (__GNUC__ >= 4) && defined(SECP256K1_BUILD)
+# if defined(__GNUC__) && (__GNUC__ >= 4) && defined(SECP256K1_BUILD) && !defined(SECP256K1_NO_EXPORTS)
    /* Building libsecp256k1 using GCC or compatible. */
 #  define SECP256K1_API extern __attribute__ ((visibility ("default")))
 # else


### PR DESCRIPTION
Yep, yet another visiblity PR :)

Noticed this when building libbitcoinkernel for Linux. Core needs a way to link a static secp into a (shared or static) kernel without exporting the secp symbols.

autotools defines `DLL_EXPORT` for dll builds. CMake mimics this behavior and defines `SECP256K1_DLL_EXPORT`.

This means that currently Windows builds only export their symbols for shared libraries, and all other platforms export for shared AND static.

Unfortunately, there's no way to make autotools define a special variable when building for other platforms.

CMake could define a variable for shared lib builds on all platforms, which the header could then use to decide whether or not to export symbols, but that would introduce a behavioral difference between the build-systems.

Instead, provide an escape hatch via `SECP256K1_NO_EXPORTS` which can be used when building secp for non-Windows targets when exports are not desired (when building a static lib).