### PR TITLE
cmake: Bump minimum required CMake version to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 #=============================
 # Project / Package metadata
@@ -14,17 +14,6 @@ project(libsecp256k1
 )
 enable_testing()
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-
-if(CMAKE_VERSION VERSION_LESS 3.21)
-  # Emulates CMake 3.21+ behavior.
-  if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    set(PROJECT_IS_TOP_LEVEL ON)
-    set(${PROJECT_NAME}_IS_TOP_LEVEL ON)
-  else()
-    set(PROJECT_IS_TOP_LEVEL OFF)
-    set(${PROJECT_NAME}_IS_TOP_LEVEL OFF)
-  endif()
-endif()
 
 # The library version is based on libtool versioning of the ABI. The set of
 # rules for updating the version can be found here:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,4 @@
 {
-  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0}, 
   "version": 3,
   "configurePresets": [
     {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,20 +48,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     VERSION ${${PROJECT_NAME}_soversion}.${${PROJECT_NAME}_LIB_VERSION_AGE}.${${PROJECT_NAME}_LIB_VERSION_REVISION}
   )
 elseif(APPLE)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-    math(EXPR ${PROJECT_NAME}_compatibility_version "${${PROJECT_NAME}_LIB_VERSION_CURRENT} + 1")
-    set_target_properties(secp256k1 PROPERTIES
-      MACHO_COMPATIBILITY_VERSION ${${PROJECT_NAME}_compatibility_version}
-      MACHO_CURRENT_VERSION ${${PROJECT_NAME}_compatibility_version}.${${PROJECT_NAME}_LIB_VERSION_REVISION}
-    )
-    unset(${PROJECT_NAME}_compatibility_version)
-  elseif(BUILD_SHARED_LIBS)
-    message(WARNING
-      "The 'compatibility version' and 'current version' values of the DYLIB "
-      "will diverge from the values set by the GNU Libtool. To ensure "
-      "compatibility, it is recommended to upgrade CMake to at least version 3.17."
-    )
-  endif()
+  math(EXPR ${PROJECT_NAME}_compatibility_version "${${PROJECT_NAME}_LIB_VERSION_CURRENT} + 1")
+  set_target_properties(secp256k1 PROPERTIES
+    MACHO_COMPATIBILITY_VERSION ${${PROJECT_NAME}_compatibility_version}
+    MACHO_CURRENT_VERSION ${${PROJECT_NAME}_compatibility_version}.${${PROJECT_NAME}_LIB_VERSION_REVISION}
+  )
+  unset(${PROJECT_NAME}_compatibility_version)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(${PROJECT_NAME}_windows "secp256k1")
   if(MSVC)


### PR DESCRIPTION
Ubuntu 20.04 LTS has reached the end of standard support. There no longer appear to be compelling reasons to maintain compatibility with CMake 3.16.
The new suggested minimum, CMake 3.22, is shipped with Ubuntu 22.04 LTS, which is supported until April 2027.

This PR also introduces new CMake policies, from CMP0098 to CMP0128. Some of these may warrant the reviewers' attention:
- [CMP0099: Link properties are transitive over private dependencies of static libraries.](https://cmake.org/cmake/help/latest/policy/CMP0099.html)
- [CMP0117: MSVC RTTI flag /GR is not added to CMAKE_CXX_FLAGS by default.](https://cmake.org/cmake/help/latest/policy/CMP0117.html)
- [CMP0126: set(CACHE) does not remove a normal variable of the same name.](https://cmake.org/cmake/help/latest/policy/CMP0126.html)
- [CMP0128: Selection of language standard and extension flags improved.](https://cmake.org/cmake/help/latest/policy/CMP0128.html)