### PR TITLE
doc: Promote "Building with CMake" to standard procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Building with Autotools
 
 To compile optional modules (such as Schnorr signatures), you need to run `./configure` with additional flags (such as `--enable-module-schnorrsig`). Run `./configure --help` to see the full list of available flags.
 
-Building with CMake (experimental)
-----------------------------------
+Building with CMake
+-------------------
 
 To maintain a pristine source tree, CMake encourages to perform an out-of-source build by using a separate dedicated build tree.
 


### PR DESCRIPTION
The CMake-based build system has demonstrated its maturity through its use in Bitcoin Core 29.0.