### PR TITLE
cmake: support the use of launchers in ctest -S scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project(libsecp256k1
   LANGUAGES C
 )
 enable_testing()
+include(CTestUseLaunchers) # Allow users to set CTEST_USE_LAUNCHERS in custom `ctest -S` scripts.
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # The library version is based on libtool versioning of the ABI. The set of


### PR DESCRIPTION
When `CTEST_USE_LAUNCHERS` is set to `ON` in a `ctest -S` script, the configure step fails with the error message:

```
CMake Error:
  CTEST_USE_LAUNCHERS is enabled, but the RULE_LAUNCH_COMPILE global property
  is not defined.

  Did you forget to include(CTest) in the toplevel CMakeLists.txt ?
```

However, `include(CTest)` produces unwanted clutter. `include(CTestUseLaunchers)` is a more lightweight alternative.

To reproduce the issue, run the following script with and without the PR applied.

```cmake
#!/usr/bin/env -S ctest -VV -S

set(CTEST_SOURCE_DIRECTORY "/path/to/secp256k1")
set(CTEST_BINARY_DIRECTORY "/path/to/secp256k1-build")

set(CTEST_CMAKE_GENERATOR "Ninja")
set(CTEST_USE_LAUNCHERS ON)

ctest_empty_binary_directory(${CTEST_BINARY_DIRECTORY})
ctest_start("Experimental")
ctest_configure()
ctest_build()
```
