### PR TITLE
cmake: Avoid contaminating parent project's cache with `BUILD_SHARED_LIBS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,8 @@ set(CMAKE_C_EXTENSIONS OFF)
 #=============================
 # Configurable options
 #=============================
-option(BUILD_SHARED_LIBS "Build shared libraries." ON)
-option(SECP256K1_DISABLE_SHARED "Disable shared library. Overrides BUILD_SHARED_LIBS." OFF)
-if(SECP256K1_DISABLE_SHARED)
-  set(BUILD_SHARED_LIBS OFF)
+if(libsecp256k1_IS_TOP_LEVEL)
+  option(BUILD_SHARED_LIBS "Build shared libraries." ON)
 endif()
 
 option(SECP256K1_INSTALL "Enable installation." ${PROJECT_IS_TOP_LEVEL})


### PR DESCRIPTION
The CMake cache is global in scope. Therefore, setting the standard cache variable `BUILD_SHARED_LIBS` can inadvertently affect the behavior of a parent project.

Consider configuring Bitcoin Core without explicit setting `BUILD_SHARED_LIBS`:
```
$ cmake -B build -DBUILD_KERNEL_LIB=ON
```

According to CMake’s documentation, this should configure `libbitcoinkernel` as `STATIC`.
However, that's not the case:
```
$ cmake --build build -t libbitcoinkernel
[143/143] Linking CXX shared library lib/libbitcoinkernel.so
```

This PR:
1. Sets the `BUILD_SHARED_LIBS` cache variable only when `libsecp256k1` is the top-level project.
2. Removes the `SECP256K1_DISABLE_SHARED` cache variable. This enables parent projects that include libsecp256k1 as a subproject to rely solely on standard CMake variables for configuring the library type.  During integration into a parent project, the static library can be forced as demonstrated [here](https://github.com/bitcoin-core/minisketch/pull/75#issuecomment-2984025132).