### PR TITLE
cmake: configure libsecp256k1.pc during install

### DIFF
--- a/cmake/GeneratePkgConfigFile.cmake
+++ b/cmake/GeneratePkgConfigFile.cmake
@@ -1,8 +1,12 @@
 function(generate_pkg_config_file in_file)
-  set(prefix ${CMAKE_INSTALL_PREFIX})
+  set(prefix "@CMAKE_INSTALL_PREFIX@")
   set(exec_prefix \${prefix})
   set(libdir \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
   set(includedir \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
   set(PACKAGE_VERSION ${PROJECT_VERSION})
-  configure_file(${in_file} ${PROJECT_NAME}.pc @ONLY)
+  configure_file(${in_file} ${PROJECT_NAME}.pc.in @ONLY)
+  install(CODE "configure_file(
+  \"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc.in\"
+  \"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc\"
+  @ONLY)" ALL_COMPONENTS)
 endfunction()


### PR DESCRIPTION
When installing to a given prefix, make sure that the .pc file contains that prefix rather than the value of `CMAKE_INSTALL_PREFIX` that the project was configured with.