### PR TITLE
Revert "cmake: configure libsecp256k1.pc during install"

### DIFF
--- a/cmake/GeneratePkgConfigFile.cmake
+++ b/cmake/GeneratePkgConfigFile.cmake
@@ -1,12 +1,8 @@
 function(generate_pkg_config_file in_file)
-  set(prefix "@CMAKE_INSTALL_PREFIX@")
+  set(prefix ${CMAKE_INSTALL_PREFIX})
   set(exec_prefix \${prefix})
   set(libdir \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
   set(includedir \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
   set(PACKAGE_VERSION ${PROJECT_VERSION})
-  configure_file(${in_file} ${PROJECT_NAME}.pc.in @ONLY)
-  install(CODE "configure_file(
-  \"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc.in\"
-  \"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc\"
-  @ONLY)" ALL_COMPONENTS)
+  configure_file(${in_file} ${PROJECT_NAME}.pc @ONLY)
 endfunction()


### PR DESCRIPTION
This reverts commit 7106dce6fd410043fc297139c6307cb6016d2a7b.

This causes a regression for packaging, as the generated `.pc` file will contain the location that was used to build the package archive.