### PR TITLE
musig/test: Remove dead code

### DIFF
--- a/src/modules/musig/tests_impl.h
+++ b/src/modules/musig/tests_impl.h
@@ -927,12 +927,9 @@ static void musig_test_vectors_signverify(void) {
         CHECK(secp256k1_musig_nonce_process(CTX, &session, &aggnonce, vector->msgs[c->msg_index], &keyagg_cache));
 
         expected = c->error != MUSIG_SECNONCE;
+        CHECK(!expected);
         musig_test_set_secnonce(&secnonce, vector->secnonces[c->secnonce_index], &pubkey);
-        if (expected) {
-            CHECK(secp256k1_musig_partial_sign(CTX, &partial_sig, &secnonce, &keypair, &keyagg_cache, &session));
-        } else {
-            CHECK_ILLEGAL(CTX, secp256k1_musig_partial_sign(CTX, &partial_sig, &secnonce, &keypair, &keyagg_cache, &session));
-        }
+        CHECK_ILLEGAL(CTX, secp256k1_musig_partial_sign(CTX, &partial_sig, &secnonce, &keypair, &keyagg_cache, &session));
     }
     for (i = 0; i < sizeof(vector->verify_fail_case)/sizeof(vector->verify_fail_case[0]); i++) {
         const struct musig_verify_fail_error_case *c = &vector->verify_fail_case[i];


### PR DESCRIPTION
This avoids a compiler warning on clang-snapshot about &keypair being uninitialized:
https://github.com/bitcoin-core/secp256k1/actions/runs/16415924817/job/46383320423#step:3:996