### PR TITLE
ci: pin the lief version in linux-debian.Dockerfile

### DIFF
--- a/ci/linux-debian.Dockerfile
+++ b/ci/linux-debian.Dockerfile
@@ -80,4 +80,4 @@ RUN \
 ENV VIRTUAL_ENV=/root/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install lief
+RUN pip install lief==0.16.6


### PR DESCRIPTION
#1359 introduced a new script (`tools/symbol-check.py`), which is meant to be run in CI and catch symbol visibility issues. The script depends on lief (https://lief.re/), in its python incarnation.

On 2025-03-10, 8ed1d83d92d1 installed lief in `linux-debian.Dockerfile` via `pip install lief`, without pinning its revision. This would introduce a covert dependency on time in a CI run: the lief version would slowly drift as new versions (potentially breaking) would be released.

At the time the latest lief version was 0.16.4, released on 2025-02-23 (source: https://pypi.org/project/lief/#history).
The latest version as of today is 0.16.6, which is also the version the CI pipeline has been using.

This commit pins the version to 0.16.6, so that future upgrades to the library will need to be explicit.