### PR TITLE
test: update wycheproof test vectors

### DIFF
--- a/src/wycheproof/WYCHEPROOF_COPYING
+++ b/src/wycheproof/WYCHEPROOF_COPYING
@@ -1,7 +1,7 @@
 * The file `ecdsa_secp256k1_sha256_bitcoin_test.json` in this directory
   comes from project Wycheproof with git commit
-  `1f32ea7bb6cc5bd111cbd5507456b255dc8337c3`, see
-  https://github.com/C2SP/wycheproof/blob/1f32ea7bb6cc5bd111cbd5507456b255dc8337c3/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
+  `7ae4532f417575ced2b1cbbabed81a7fecfaef5d`, see
+  https://github.com/C2SP/wycheproof/blob/7ae4532f417575ced2b1cbbabed81a7fecfaef5d/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json
 
 * The file `ecdh_secp256k1_test.json` in this directory
   comes from project Wycheproof with git commit

--- a/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
+++ b/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
@@ -95,7 +95,7 @@
     },
     "SignatureMalleabilityBitcoin" : {
       "bugType" : "SIGNATURE_MALLEABILITY",
-      "description" : "Signature malleability can be a serious issue in Bitcoin. An implementation should only accept a signature s where s < n/2. If an implementation is not meant for use cases that require signature malleability then this implementation should be tested with another set of test vectors.",
+      "description" : "Signature malleability can be a serious issue in Bitcoin. An implementation should only accept a signature s where s < n/2. If an implementation is meant for use cases that tolerate signature malleability then this implementation should not be tested with this set of test vectors.",
       "effect" : "In Bitcoin exchanges, it may be used to make a double deposits or double withdrawals",
       "links" : [
         "https://en.bitcoin.it/wiki/Transaction_malleability",


### PR DESCRIPTION
Pull in updated test vectors. This update is done as a follow-up to #1711.