### PR TITLE
tests: refactor tagged hash verification

### DIFF
--- a/src/modules/ellswift/tests_impl.h
+++ b/src/modules/ellswift/tests_impl.h
@@ -405,31 +405,22 @@ void run_ellswift_tests(void) {
 
     /* Test hash initializers. */
     {
-        secp256k1_sha256 sha, sha_optimized;
-        static const unsigned char encode_tag[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'e', 'n', 'c', 'o', 'd', 'e'};
-        static const unsigned char create_tag[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'c', 'r', 'e', 'a', 't', 'e'};
-        static const unsigned char bip324_tag[] = {'b', 'i', 'p', '3', '2', '4', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'x', 'o', 'n', 'l', 'y', '_', 'e', 'c', 'd', 'h'};
-
-        /* Check that hash initialized by
-         * secp256k1_ellswift_sha256_init_encode has the expected
-         * state. */
-        secp256k1_sha256_initialize_tagged(&sha, encode_tag, sizeof(encode_tag));
-        secp256k1_ellswift_sha256_init_encode(&sha_optimized);
-        test_sha256_eq(&sha, &sha_optimized);
-
-        /* Check that hash initialized by
-         * secp256k1_ellswift_sha256_init_create has the expected
-         * state. */
-        secp256k1_sha256_initialize_tagged(&sha, create_tag, sizeof(create_tag));
-        secp256k1_ellswift_sha256_init_create(&sha_optimized);
-        test_sha256_eq(&sha, &sha_optimized);
-
-        /* Check that hash initialized by
-         * secp256k1_ellswift_sha256_init_bip324 has the expected
-         * state. */
-        secp256k1_sha256_initialize_tagged(&sha, bip324_tag, sizeof(bip324_tag));
-        secp256k1_ellswift_sha256_init_bip324(&sha_optimized);
-        test_sha256_eq(&sha, &sha_optimized);
+        secp256k1_sha256 sha_optimized;
+        {
+            unsigned char tag[] = "secp256k1_ellswift_encode";
+            secp256k1_ellswift_sha256_init_encode(&sha_optimized);
+            sha256_tag_test_internal(&sha_optimized, (unsigned char*)tag, sizeof(tag) - 1);
+        }
+        {
+            unsigned char tag[] = "secp256k1_ellswift_create";
+            secp256k1_ellswift_sha256_init_create(&sha_optimized);
+            sha256_tag_test_internal(&sha_optimized, (unsigned char*)tag, sizeof(tag) - 1);
+        }
+        {
+            unsigned char tag[] = "bip324_ellswift_xonly_ecdh";
+            secp256k1_ellswift_sha256_init_bip324(&sha_optimized);
+            sha256_tag_test_internal(&sha_optimized, (unsigned char*)tag, sizeof(tag) - 1);
+        }
     }
 }
 

--- a/src/modules/musig/tests_impl.h
+++ b/src/modules/musig/tests_impl.h
@@ -548,12 +548,6 @@ static void musig_nonce_test(void) {
     }
 }
 
-static void sha256_tag_test_internal(secp256k1_sha256 *sha_tagged, unsigned char *tag, size_t taglen) {
-    secp256k1_sha256 sha;
-    secp256k1_sha256_initialize_tagged(&sha, tag, taglen);
-    test_sha256_eq(&sha, sha_tagged);
-}
-
 /* Checks that the initialized tagged hashes have the expected
  * state. */
 static void sha256_tag_test(void) {

--- a/src/modules/schnorrsig/tests_impl.h
+++ b/src/modules/schnorrsig/tests_impl.h
@@ -21,11 +21,8 @@ static void nonce_function_bip340_bitflip(unsigned char **args, size_t n_flip, s
 }
 
 static void run_nonce_function_bip340_tests(void) {
-    unsigned char tag[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'n', 'o', 'n', 'c', 'e'};
-    unsigned char aux_tag[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'a', 'u', 'x'};
     unsigned char algo[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'n', 'o', 'n', 'c', 'e'};
     size_t algolen = sizeof(algo);
-    secp256k1_sha256 sha;
     secp256k1_sha256 sha_optimized;
     unsigned char nonce[32], nonce_z[32];
     unsigned char msg[32];
@@ -36,19 +33,17 @@ static void run_nonce_function_bip340_tests(void) {
     unsigned char *args[5];
     int i;
 
-    /* Check that hash initialized by
-     * secp256k1_nonce_function_bip340_sha256_tagged has the expected
-     * state. */
-    secp256k1_sha256_initialize_tagged(&sha, tag, sizeof(tag));
-    secp256k1_nonce_function_bip340_sha256_tagged(&sha_optimized);
-    test_sha256_eq(&sha, &sha_optimized);
-
-   /* Check that hash initialized by
-    * secp256k1_nonce_function_bip340_sha256_tagged_aux has the expected
-    * state. */
-    secp256k1_sha256_initialize_tagged(&sha, aux_tag, sizeof(aux_tag));
-    secp256k1_nonce_function_bip340_sha256_tagged_aux(&sha_optimized);
-    test_sha256_eq(&sha, &sha_optimized);
+    /* Check that the initialized tagged hashes have the expected state */
+    {
+        unsigned char tag[] = "BIP0340/nonce";
+        secp256k1_nonce_function_bip340_sha256_tagged(&sha_optimized);
+        sha256_tag_test_internal(&sha_optimized, tag, sizeof(tag) - 1);
+    }
+    {
+        unsigned char tag[] = "BIP0340/aux";
+        secp256k1_nonce_function_bip340_sha256_tagged_aux(&sha_optimized);
+        sha256_tag_test_internal(&sha_optimized, tag, sizeof(tag) - 1);
+    }
 
     testrand256(msg);
     testrand256(key);
@@ -158,13 +153,11 @@ static void test_schnorrsig_api(void) {
 /* Checks that hash initialized by secp256k1_schnorrsig_sha256_tagged has the
  * expected state. */
 static void test_schnorrsig_sha256_tagged(void) {
-    unsigned char tag[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'c', 'h', 'a', 'l', 'l', 'e', 'n', 'g', 'e'};
-    secp256k1_sha256 sha;
+    unsigned char tag[] = "BIP0340/challenge";
     secp256k1_sha256 sha_optimized;
 
-    secp256k1_sha256_initialize_tagged(&sha, (unsigned char *) tag, sizeof(tag));
     secp256k1_schnorrsig_sha256_tagged(&sha_optimized);
-    test_sha256_eq(&sha, &sha_optimized);
+    sha256_tag_test_internal(&sha_optimized, tag, sizeof(tag) - 1);
 }
 
 /* Helper function for schnorrsig_bip_vectors

--- a/src/tests.c
+++ b/src/tests.c
@@ -609,6 +609,13 @@ static void test_sha256_eq(const secp256k1_sha256 *sha1, const secp256k1_sha256 
     CHECK(sha1->bytes == sha2->bytes);
     CHECK(secp256k1_memcmp_var(sha1->s, sha2->s, sizeof(sha1->s)) == 0);
 }
+/* Convenience function for using test_sha256_eq to verify the correctness of a
+ * tagged hash midstate. This function is used by some module tests. */
+static void sha256_tag_test_internal(secp256k1_sha256 *sha_tagged, unsigned char *tag, size_t taglen) {
+    secp256k1_sha256 sha;
+    secp256k1_sha256_initialize_tagged(&sha, tag, taglen);
+    test_sha256_eq(&sha, sha_tagged);
+}
 
 static void run_hmac_sha256_tests(void) {
     static const char *keys[6] = {


### PR DESCRIPTION
Opened in response to https://github.com/bitcoin-core/secp256k1/pull/1698#discussion_r2269449070

---

We use tagged hashes in `modules/musig`, `modules/schnorrsig`, `modules/ellswift`, and the proposed `modules/silentpayments`. In looking for inspiration on how to add tagged hash midstate verification for https://github.com/bitcoin-core/secp256k1/pull/1698, it seemed like a good opportunity to DRY up the code across all of the modules.

I chose the convention used in the musig module as this seemed the most readable to me as a reviewer, and also allows for easily grepping for the string values. Since the tags are normally specified as strings in the BIPs, using the string values in the tests seems preferable to specifying the tags character by character (as was done in the schnorrsig and ellswift modules).

If its deemed too invasive to refactor the existing modules in this PR, I'm happy to drop the refactor commits for the ellswift and schnorrsig modules. All I need for https://github.com/bitcoin-core/secp256k1/pull/1698 is the first commit which moves the utility function out of the musig module to make it available to use in the silent payments module.