### PR TITLE
schnorrsig: Securely clear buf containing k or its negation

### DIFF
--- a/src/modules/schnorrsig/main_impl.h
+++ b/src/modules/schnorrsig/main_impl.h
@@ -139,7 +139,7 @@ static int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsi
     secp256k1_gej rj;
     secp256k1_ge pk;
     secp256k1_ge r;
-    unsigned char buf[32] = { 0 };
+    unsigned char nonce32[32] = { 0 };
     unsigned char pk_buf[32];
     unsigned char seckey[32];
     int ret = 1;
@@ -164,8 +164,8 @@ static int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsi
 
     secp256k1_scalar_get_b32(seckey, &sk);
     secp256k1_fe_get_b32(pk_buf, &pk.x);
-    ret &= !!noncefp(buf, msg, msglen, seckey, pk_buf, bip340_algo, sizeof(bip340_algo), ndata);
-    secp256k1_scalar_set_b32(&k, buf, NULL);
+    ret &= !!noncefp(nonce32, msg, msglen, seckey, pk_buf, bip340_algo, sizeof(bip340_algo), ndata);
+    secp256k1_scalar_set_b32(&k, nonce32, NULL);
     ret &= !secp256k1_scalar_is_zero(&k);
     secp256k1_scalar_cmov(&k, &secp256k1_scalar_one, !ret);
 
@@ -191,6 +191,7 @@ static int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsi
     secp256k1_scalar_clear(&k);
     secp256k1_scalar_clear(&sk);
     secp256k1_memclear(seckey, sizeof(seckey));
+    secp256k1_memclear(nonce32, sizeof(nonce32));
     secp256k1_gej_clear(&rj);
 
     return ret;


### PR DESCRIPTION
Follow-up to #1579. `buf` still holds the nonce or its negation, so ought to be cleared. 