### PR TITLE
doc: mention ctx requirement for `_ellswift_create` (not secp256k1_context_static)

### DIFF
--- a/include/secp256k1_ellswift.h
+++ b/include/secp256k1_ellswift.h
@@ -130,7 +130,7 @@ SECP256K1_API int secp256k1_ellswift_decode(
  *
  *  Returns: 1: secret was valid, public key was stored.
  *           0: secret was invalid, try again.
- *  Args:    ctx:        pointer to a context object
+ *  Args:    ctx:        pointer to a context object (not secp256k1_context_static)
  *  Out:     ell64:      pointer to a 64-byte array to receive the ElligatorSwift
  *                       public key
  *  In:      seckey32:   pointer to a 32-byte secret key


### PR DESCRIPTION
Public functions that require a context for generator point multiplication (i.e. `ctx->ecmult_gen_ctx` is built) usually denote this in the API header by mentioning to not use `secp256k1_context_static`, so add this for `_ellswift_create` as well. This seems the only instance where this is missing currently, see
```
$ git grep ecmult_gen_context_is_built
$ git grep ctx:.*context_static
```
(note that in the musig and schnorr modules, two public functions for nonce generation / signing map to a single internal function where the context requirement is checked).

Noted while reviewing #1698.