### PR TITLE
check-abi: remove support for obsolete CMake library output location (src/libsecp256k1.so)

### DIFF
--- a/tools/check-abi.sh
+++ b/tools/check-abi.sh
@@ -49,14 +49,7 @@ checkout_and_build() {
         -DSECP256K1_BUILD_CTIME_TESTS=OFF \
         -DSECP256K1_BUILD_EXAMPLES=OFF
     cmake --build . -j "$(nproc)"
-    # FIXME: Just set LIBPATH to lib/libsecp256k1.so once version 0.6.0 is
-    # released.
-    if [ -f "src/libsecp256k1.so" ]; then
-        LIBPATH="src/libsecp256k1.so"
-    else
-        LIBPATH="lib/libsecp256k1.so"
-    fi
-    abi-dumper $LIBPATH -o ABI.dump -lver "$2" -public-headers ../include/
+    abi-dumper lib/libsecp256k1.so -o ABI.dump -lver "$2" -public-headers ../include/
     cd "$_orig_dir"
 }
 


### PR DESCRIPTION
The CMake library output location was changed from "src/" to "lib/" in PR #1553, supporting the old location (presumably done to avoid having users to reconfigure existing CMake builds for a temporary transition window) shouldn't be necessary anymore.