### PR TITLE
doc: update release notes version to latest v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Implementation details
 Obtaining and verifying
 -----------------------
 
-The git tag for each release (e.g. `v0.6.0`) is GPG-signed by one of the maintainers.
+The git tag for each release (e.g. `v0.7.0`) is GPG-signed by one of the maintainers.
 For a fully verified build of this project, it is recommended to obtain this repository
 via git, obtain the GPG keys of the signing maintainer(s), and then verify the release
 tag's signature using git.
@@ -81,11 +81,11 @@ This can be done with the following steps:
     ```
 4. Check out the latest release tag, e.g. 
     ```
-    git checkout v0.6.0
+    git checkout v0.7.0
     ```
 5. Use git to verify the GPG signature: 
    ```
-   % git tag -v v0.6.0 | grep -C 3 'Good signature'
+   % git tag -v v0.7.0 | grep -C 3 'Good signature'
 
    gpg: Signature made Mon 04 Nov 2024 12:14:44 PM EST
    gpg:                using RSA key 4BBB845A6F5A65A69DFAEC234861DBF262123605


### PR DESCRIPTION
While reading the docs I noticed the latest isn't shown in the docs.