### PR TITLE
Fix headers in `testrand_impl.h`

### DIFF
--- a/src/testrand_impl.h
+++ b/src/testrand_impl.h
@@ -10,9 +10,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "testrand.h"
-#include "hash.h"
+#include "hash_impl.h"
 #include "util.h"
 
 static uint64_t secp256k1_test_state[4];


### PR DESCRIPTION
While reviewing https://github.com/bitcoin-core/secp256k1/pull/1734 and [suggesting](https://github.com/bitcoin-core/secp256k1/pull/1734#discussion_r2340384653) keeping the new test miniframework as a separate translation unit, I noticed a couple of issues with the headers included in `testrand_impl.h`. In my [approach](https://github.com/hebasto/secp256k1/commits/pr1734/0911.2c.alt/), these lead to compiler warnings and linker errors. This PR fixes them.

These changes are reasonable on their own.