### PR TITLE
bench: improve context creation in ECDH benchmark

### DIFF
--- a/src/modules/ecdh/bench_impl.h
+++ b/src/modules/ecdh/bench_impl.h
@@ -10,7 +10,7 @@
 #include "../../../include/secp256k1_ecdh.h"
 
 typedef struct {
-    secp256k1_context *ctx;
+    const secp256k1_context *ctx;
     secp256k1_pubkey point;
     unsigned char scalar[32];
 } bench_ecdh_data;
@@ -46,12 +46,9 @@ static void run_ecdh_bench(int iters, int argc, char** argv) {
     bench_ecdh_data data;
     int d = argc == 1;
 
-    /* create a context with no capabilities */
-    data.ctx = secp256k1_context_create(SECP256K1_FLAGS_TYPE_CONTEXT);
+    data.ctx = secp256k1_context_static;
 
     if (d || have_flag(argc, argv, "ecdh")) run_benchmark("ecdh", bench_ecdh, bench_ecdh_setup, NULL, &data, 10, iters);
-
-    secp256k1_context_destroy(data.ctx);
 }
 
 #endif /* SECP256K1_MODULE_ECDH_BENCH_H */


### PR DESCRIPTION
Calling `secp256k1_context_create` with `SECP256K1_FLAGS_TYPE_CONTEXT` seems to be confusing and not strictly API-compliant, as the only allowed (non-deprecated) value is `SECP256K1_CONTEXT_NONE`, even if the former happens to map to the latter currently.

Fix this by not dynamically creating a context in the first place and switch to using the static context, as it is sufficient for this benchmark and presumably matches what the "no capabilities" comment intended back then.

Alternatives are:
* keep the signing context and only fix the name, i.e. s/_FLAGS_TYPE_CONTEXT/_CONTEXT_NONE/
* use `secp256k1_context_static` everywhere directly and get rid of the `ctx` field in the `bench_ecdh_data` struct (less flexible for future changes, deviates from other bench structures)

Found while reviewing #1698, see https://github.com/bitcoin-core/secp256k1/pull/1698#discussion_r2350395913.