### PR TITLE
build: Fix warnings in x86_64 assembly check

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -3,7 +3,7 @@ AC_DEFUN([SECP_X86_64_ASM_CHECK],[
 AC_MSG_CHECKING(for x86_64 assembly availability)
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   #include <stdint.h>]],[[
-  uint64_t a = 11, tmp;
+  uint64_t a = 11, tmp = 0;
   __asm__ __volatile__("movq \@S|@0x100000000,%1; mulq %%rsi" : "+a"(a) : "S"(tmp) : "cc", "%rdx");
   ]])], [has_x86_64_asm=yes], [has_x86_64_asm=no])
 AC_MSG_RESULT([$has_x86_64_asm])

--- a/cmake/CheckX86_64Assembly.cmake
+++ b/cmake/CheckX86_64Assembly.cmake
@@ -4,10 +4,11 @@ function(check_x86_64_assembly)
   check_c_source_compiles("
     #include <stdint.h>
 
-    int main()
+    int main(void)
     {
-      uint64_t a = 11, tmp;
+      uint64_t a = 11, tmp = 0;
       __asm__ __volatile__(\"movq $0x100000000,%1; mulq %%rsi\" : \"+a\"(a) : \"S\"(tmp) : \"cc\", \"%rdx\");
+      return 0;
     }
   " HAVE_X86_64_ASM)
   set(HAVE_X86_64_ASM ${HAVE_X86_64_ASM} PARENT_SCOPE)


### PR DESCRIPTION
On the master branch @ 10dab907e73ba984deb813e20f6e3fc9ec359a17, the x86_64 assembly check in both the Autotools and CMake build systems can fail depending on externally provided flags. For example:
```
$ env CFLAGS="-Wall -Werror" ./configure --with-asm=x86_64
<snip>
checking for x86_64 assembly availability... no
configure: error: x86_64 assembly requested but not available
```
or
```
$ env CFLAGS="-Wall -Werror" cmake -B build -DSECP256K1_ASM=x86_64
<snip>
-- Performing Test HAVE_X86_64_ASM
-- Performing Test HAVE_X86_64_ASM - Failed
CMake Error at CMakeLists.txt:111 (message):
  x86_64 assembly requested but not available.


-- Configuring incomplete, errors occurred!
```

The same issue occurs in CI jobs that build on Windows using clang-cl.

This PR fixes both build systems.