### PR TITLE
ci: Switch to macOS 15 Sequoia Intel-based image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,9 +429,8 @@ jobs:
       - *PRINT_LOGS
 
   x86_64-macos-native:
-    name: "x86_64: macOS Ventura, Valgrind"
-    # See: https://github.com/actions/runner-images#available-images.
-    runs-on: macos-13
+    name: "x86_64: macOS Sequoia, Valgrind"
+    runs-on: macos-15-intel
 
     env:
       CC: 'clang'


### PR DESCRIPTION
This is an alternative to https://github.com/bitcoin-core/secp256k1/pull/1755.

More details from the GHA developers:
> Apple has discontinued support for the x86_64 (Intel) architecture going forward. GitHub will no longer support this architecture on macOS after the macOS 15 runner image is retired in Fall 2027.