### PR TITLE
bench: Use `ALIGNMENT` macro instead of hardcoded value

### DIFF
--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -334,7 +334,7 @@ int main(int argc, char **argv) {
     }
 
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
-    scratch_size = secp256k1_strauss_scratch_size(POINTS) + STRAUSS_SCRATCH_OBJECTS*16;
+    scratch_size = secp256k1_strauss_scratch_size(POINTS) + STRAUSS_SCRATCH_OBJECTS*ALIGNMENT;
     if (!have_flag(argc, argv, "simple")) {
         data.scratch = secp256k1_scratch_space_create(data.ctx, scratch_size);
     } else {


### PR DESCRIPTION
This PR brings consistency with the rest of the code and appears more correct.