### PR TITLE
ci: Use Python virtual environment in "x86_64-macos-native" job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,9 +469,14 @@ jobs:
         env: ${{ matrix.env_vars }}
         run: ./ci/ci.sh
 
-      - name: Symbol check
+      - &SYMBOL_CHECK_MACOS
+        name: Symbol check
+        env:
+          VIRTUAL_ENV: '${{ github.workspace }}/venv'
         run: |
           python3 --version
+          python3 -m venv $VIRTUAL_ENV
+          export PATH="$VIRTUAL_ENV/bin:$PATH"
           python3 -m pip install lief
           python3 ./tools/symbol-check.py .libs/libsecp256k1.dylib
 
@@ -512,17 +517,7 @@ jobs:
           ln -s $(brew --prefix gcc)/bin/gcc-?? /usr/local/bin/gcc
 
       - *CI_SCRIPT_ON_HOST
-
-      - name: Symbol check
-        env:
-          VIRTUAL_ENV: '${{ github.workspace }}/venv'
-        run: |
-          python3 --version
-          python3 -m venv $VIRTUAL_ENV
-          export PATH="$VIRTUAL_ENV/bin:$PATH"
-          python3 -m pip install lief
-          python3 ./tools/symbol-check.py .libs/libsecp256k1.dylib
-
+      - *SYMBOL_CHECK_MACOS
       - *PRINT_LOGS
 
   win64-native:


### PR DESCRIPTION
Fixes https://github.com/bitcoin-core/secp256k1/issues/1768.

This PR explicitly sets up a virtual environment instead of using `uv`, as suggested [here](https://github.com/bitcoin-core/secp256k1/issues/1768#issue-3599176194), for the following reasons:
1. It does not require granting a third-party action access to the repository.
2. This approach is already used in other parts of the CI framework (it’s unclear why it was missed in https://github.com/bitcoin-core/secp256k1/pull/1359 in the first place).