### PR TITLE
doc/bench: Added cmake build options to bench error messages

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
 #ifndef ENABLE_MODULE_ECDH
     if (have_flag(argc, argv, "ecdh")) {
         fprintf(stderr, "./bench: ECDH module not enabled.\n");
-        fprintf(stderr, "Use ./configure --enable-module-ecdh.\n\n");
+        fprintf(stderr, "See README.md for configuration instructions.\n\n");
         return EXIT_FAILURE;
     }
 #endif
@@ -213,7 +213,7 @@ int main(int argc, char** argv) {
 #ifndef ENABLE_MODULE_RECOVERY
     if (have_flag(argc, argv, "recover") || have_flag(argc, argv, "ecdsa_recover")) {
         fprintf(stderr, "./bench: Public key recovery module not enabled.\n");
-        fprintf(stderr, "Use ./configure --enable-module-recovery.\n\n");
+        fprintf(stderr, "See README.md for configuration instructions.\n\n");
         return EXIT_FAILURE;
     }
 #endif
@@ -221,7 +221,7 @@ int main(int argc, char** argv) {
 #ifndef ENABLE_MODULE_SCHNORRSIG
     if (have_flag(argc, argv, "schnorrsig") || have_flag(argc, argv, "schnorrsig_sign") || have_flag(argc, argv, "schnorrsig_verify")) {
         fprintf(stderr, "./bench: Schnorr signatures module not enabled.\n");
-        fprintf(stderr, "Use ./configure --enable-module-schnorrsig.\n\n");
+        fprintf(stderr, "See README.md for configuration instructions.\n\n");
         return EXIT_FAILURE;
     }
 #endif
@@ -231,7 +231,7 @@ int main(int argc, char** argv) {
         have_flag(argc, argv, "encode") || have_flag(argc, argv, "decode") || have_flag(argc, argv, "ellswift_keygen") ||
         have_flag(argc, argv, "ellswift_ecdh")) {
         fprintf(stderr, "./bench: ElligatorSwift module not enabled.\n");
-        fprintf(stderr, "Use ./configure --enable-module-ellswift.\n\n");
+        fprintf(stderr, "See README.md for configuration instructions.\n\n");
         return EXIT_FAILURE;
     }
 #endif


### PR DESCRIPTION
## Motivation
I wanted to try and run the benchmarking scripts and I noticed the recovery benchmark in `bench.c`. I wanted to run but I was using `cmake` and the error message telling me to use `./configure -enable-module-recovery` wasn't sufficient.

I figure rather than forcing users to look into the `CMakeLists.txt` file or anywhere else we should add this to the output

## Solution
I appended to the message to include the `-DSECP256K1_ENABLE_MODULE_...=ON` in the message.