### PR TITLE
Copy the 's' parameter of _gej_rescale to avoid aliasing issues

### DIFF
--- a/src/group.h
+++ b/src/group.h
@@ -175,8 +175,8 @@ static void secp256k1_gej_cmov(secp256k1_gej *r, const secp256k1_gej *a, int fla
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time.  Both *r and *a must be initialized.*/
 static void secp256k1_ge_storage_cmov(secp256k1_ge_storage *r, const secp256k1_ge_storage *a, int flag);
 
-/** Rescale a jacobian point by b which must be non-zero. Constant-time. */
-static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *b);
+/** Rescale a jacobian point by s which must be non-zero. Constant-time. */
+static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *s);
 
 /** Convert a group element that is not infinity to a 64-byte array. The output
  *  array is platform-dependent. */

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -860,16 +860,17 @@ static void secp256k1_gej_add_ge(secp256k1_gej *r, const secp256k1_gej *a, const
 
 static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *s) {
     /* Operations: 4 mul, 1 sqr */
-    secp256k1_fe zz;
+    secp256k1_fe z, zz;
     SECP256K1_GEJ_VERIFY(r);
     SECP256K1_FE_VERIFY(s);
     VERIFY_CHECK(!secp256k1_fe_normalizes_to_zero_var(s));
 
-    secp256k1_fe_sqr(&zz, s);
+    z = *s;
+    secp256k1_fe_sqr(&zz, &z);
     secp256k1_fe_mul(&r->x, &r->x, &zz);                /* r->x *= s^2 */
     secp256k1_fe_mul(&r->y, &r->y, &zz);
-    secp256k1_fe_mul(&r->y, &r->y, s);                  /* r->y *= s^3 */
-    secp256k1_fe_mul(&r->z, &r->z, s);                  /* r->z *= s   */
+    secp256k1_fe_mul(&r->y, &r->y, &z);                 /* r->y *= s^3 */
+    secp256k1_fe_mul(&r->z, &r->z, &z);                 /* r->z *= s   */
 
     SECP256K1_GEJ_VERIFY(r);
 }


### PR DESCRIPTION
There doesn't appear to be any reason why a caller of `_gej_rescale` couldn't pass an `s` that aliases one of the fields of `r`. In case it aliased `r->y` or `r->z`, at least a `VERIFY_CHECK` in `_fe_mul` could catch the problem. However if `r->x` were aliased, in general an invalid result would be silently produced, due to `s` being read after `r->x` is written.

This PR proposes simply copying `s` to a local at the start of the method. (Also updates the group.h method decl so that the parameter names match).