### PR TITLE
test: split monolithic ellswift test into independent cases

### DIFF
--- a/src/modules/ellswift/tests_impl.h
+++ b/src/modules/ellswift/tests_impl.h
@@ -177,9 +177,9 @@ static int ellswift_xdh_hash_x32(unsigned char *output, const unsigned char *x32
     return 1;
 }
 
-void run_ellswift_tests(void) {
-    int i = 0;
-    /* Test vectors. */
+/* Run the test vectors for ellswift encoding */
+void ellswift_encoding_test_vectors_tests(void) {
+    int i;
     for (i = 0; (unsigned)i < sizeof(ellswift_xswiftec_inv_tests) / sizeof(ellswift_xswiftec_inv_tests[0]); ++i) {
         const struct ellswift_xswiftec_inv_test *testcase = &ellswift_xswiftec_inv_tests[i];
         int c;
@@ -195,6 +195,11 @@ void run_ellswift_tests(void) {
             }
         }
     }
+}
+
+/* Run the test vectors for ellswift decoding */
+void ellswift_decoding_test_vectors_tests(void) {
+    int i;
     for (i = 0; (unsigned)i < sizeof(ellswift_decode_tests) / sizeof(ellswift_decode_tests[0]); ++i) {
         const struct ellswift_decode_test *testcase = &ellswift_decode_tests[i];
         secp256k1_pubkey pubkey;
@@ -207,6 +212,11 @@ void run_ellswift_tests(void) {
         CHECK(fe_equal(&testcase->x, &ge.x));
         CHECK(secp256k1_fe_is_odd(&ge.y) == testcase->odd_y);
     }
+}
+
+/* Run the test vectors for ellswift expected xdh BIP324 shared secrets */
+void ellswift_xdh_test_vectors_tests(void) {
+    int i;
     for (i = 0; (unsigned)i < sizeof(ellswift_xdh_tests_bip324) / sizeof(ellswift_xdh_tests_bip324[0]); ++i) {
         const struct ellswift_xdh_test *test = &ellswift_xdh_tests_bip324[i];
         unsigned char shared_secret[32];
@@ -223,7 +233,11 @@ void run_ellswift_tests(void) {
         CHECK(ret);
         CHECK(secp256k1_memcmp_var(shared_secret, test->shared_secret, 32) == 0);
     }
-    /* Verify that secp256k1_ellswift_encode + decode roundtrips. */
+}
+
+/* Verify that secp256k1_ellswift_encode + decode roundtrips */
+void ellswift_encode_decode_roundtrip_tests(void) {
+    int i;
     for (i = 0; i < 1000 * COUNT; i++) {
         unsigned char rnd32[32];
         unsigned char ell64[64];
@@ -240,7 +254,11 @@ void run_ellswift_tests(void) {
         /* Compare with original. */
         CHECK(secp256k1_ge_eq_var(&g, &g2));
     }
-    /* Verify the behavior of secp256k1_ellswift_create */
+}
+
+/* Verify the behavior of secp256k1_ellswift_create */
+void ellswift_create_tests(void) {
+    int i;
     for (i = 0; i < 400 * COUNT; i++) {
         unsigned char auxrnd32[32], sec32[32];
         secp256k1_scalar sec;
@@ -262,7 +280,11 @@ void run_ellswift_tests(void) {
         secp256k1_ecmult(&res, NULL, &secp256k1_scalar_zero, &sec);
         CHECK(secp256k1_gej_eq_ge_var(&res, &dec));
     }
-    /* Verify that secp256k1_ellswift_xdh computes the right shared X coordinate. */
+}
+
+/* Verify that secp256k1_ellswift_xdh computes the right shared X coordinate */
+void ellswift_compute_shared_secret_tests(void) {
+    int i;
     for (i = 0; i < 800 * COUNT; i++) {
         unsigned char ell64[64], sec32[32], share32[32];
         secp256k1_scalar sec;
@@ -293,6 +315,10 @@ void run_ellswift_tests(void) {
         /* Compare. */
         CHECK(fe_equal(&res.x, &share_x));
     }
+}
+
+void ellswift_xdh_correctness_tests(void) {
+    int i;
     /* Verify the joint behavior of secp256k1_ellswift_xdh */
     for (i = 0; i < 200 * COUNT; i++) {
         unsigned char auxrnd32a[32], auxrnd32b[32], auxrnd32a_bad[32], auxrnd32b_bad[32];
@@ -403,41 +429,47 @@ void run_ellswift_tests(void) {
             CHECK(secp256k1_memcmp_var(share32_bad, share32b, 32) != 0);
         }
     }
+}
 
-    /* Test hash initializers. */
-    {
-        secp256k1_sha256 sha_optimized;
-        /* "secp256k1_ellswift_encode" */
-        static const unsigned char encode_tag[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'e', 'n', 'c', 'o', 'd', 'e'};
-        /* "secp256k1_ellswift_create" */
-        static const unsigned char create_tag[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'c', 'r', 'e', 'a', 't', 'e'};
-        /* "bip324_ellswift_xonly_ecdh" */
-        static const unsigned char bip324_tag[] = {'b', 'i', 'p', '3', '2', '4', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'x', 'o', 'n', 'l', 'y', '_', 'e', 'c', 'd', 'h'};
+/* Test hash initializers */
+void ellswift_hash_init_tests(void) {
+    secp256k1_sha256 sha_optimized;
+    /* "secp256k1_ellswift_encode" */
+    static const unsigned char encode_tag[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'e', 'n', 'c', 'o', 'd', 'e'};
+    /* "secp256k1_ellswift_create" */
+    static const unsigned char create_tag[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'c', 'r', 'e', 'a', 't', 'e'};
+    /* "bip324_ellswift_xonly_ecdh" */
+    static const unsigned char bip324_tag[] = {'b', 'i', 'p', '3', '2', '4', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'x', 'o', 'n', 'l', 'y', '_', 'e', 'c', 'd', 'h'};
 
-        /* Check that hash initialized by
-         * secp256k1_ellswift_sha256_init_encode has the expected
-         * state. */
-        secp256k1_ellswift_sha256_init_encode(&sha_optimized);
-        test_sha256_tag_midstate(&sha_optimized, encode_tag, sizeof(encode_tag));
+    /* Check that hash initialized by
+     * secp256k1_ellswift_sha256_init_encode has the expected
+     * state. */
+    secp256k1_ellswift_sha256_init_encode(&sha_optimized);
+    test_sha256_tag_midstate(&sha_optimized, encode_tag, sizeof(encode_tag));
 
-        /* Check that hash initialized by
-         * secp256k1_ellswift_sha256_init_create has the expected
-         * state. */
-        secp256k1_ellswift_sha256_init_create(&sha_optimized);
-        test_sha256_tag_midstate(&sha_optimized, create_tag, sizeof(create_tag));
+    /* Check that hash initialized by
+     * secp256k1_ellswift_sha256_init_create has the expected
+     * state. */
+    secp256k1_ellswift_sha256_init_create(&sha_optimized);
+    test_sha256_tag_midstate(&sha_optimized, create_tag, sizeof(create_tag));
 
-        /* Check that hash initialized by
-         * secp256k1_ellswift_sha256_init_bip324 has the expected
-         * state. */
-        secp256k1_ellswift_sha256_init_bip324(&sha_optimized);
-        test_sha256_tag_midstate(&sha_optimized, bip324_tag, sizeof(bip324_tag));
-    }
+    /* Check that hash initialized by
+     * secp256k1_ellswift_sha256_init_bip324 has the expected
+     * state. */
+    secp256k1_ellswift_sha256_init_bip324(&sha_optimized);
+    test_sha256_tag_midstate(&sha_optimized, bip324_tag, sizeof(bip324_tag));
 }
 
 /* --- Test registry --- */
-/* TODO: subdivide test in cases */
 static const struct tf_test_entry tests_ellswift[] = {
-    CASE(ellswift_tests),
+    CASE1(ellswift_encoding_test_vectors_tests),
+    CASE1(ellswift_decoding_test_vectors_tests),
+    CASE1(ellswift_xdh_test_vectors_tests),
+    CASE1(ellswift_encode_decode_roundtrip_tests),
+    CASE1(ellswift_create_tests),
+    CASE1(ellswift_compute_shared_secret_tests),
+    CASE1(ellswift_xdh_correctness_tests),
+    CASE1(ellswift_hash_init_tests),
 };
 
 #endif


### PR DESCRIPTION
No behavior changes.

Refactors the previously monolithic ElligatorSwift test into isolated,
independent test cases. Doing so allows the test suite to execute
these cases in parallel rather than sequentially.

Overall, I'm seeing 35-40% tests time reduction locally.

This is quite useful for Debug builds with no optimizations,
which are noticeably slow.

####  Local Debug-build Results (7 jobs):

- master: 138.0 seconds.
- this PR: 89.3 seconds.
   (~1.55× speedup, ~35% reduction)

####  Local Release-build Results (7 jobs):

- master: 9.5 seconds.
- this PR: 5.9 seconds.
   (~1.61× speedup, ~38% reduction)

####  rp5 Release-build results (5 jobs):
- master: 39 seconds.
- this PR: 24 seconds.
  (~1.62× speedup, ~38% reduction)