### PR TITLE
doc/bench: added help text for SECP256K1_BENCH_ITERS env var for bench_ecmult

### DIFF
--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -19,8 +19,11 @@
 
 #define POINTS 32768
 
-static void help(char **argv) {
+static void help(char **argv, int default_iters) {
     printf("Benchmark EC multiplication algorithms\n");
+    printf("\n");
+    printf("The default number of iterations for each benchmark is %d. This can be\n", default_iters);
+    printf("customized using the SECP256K1_BENCH_ITERS environment variable.\n");
     printf("\n");
     printf("Usage: %s <help|pippenger_wnaf|strauss_wnaf|simple>\n", argv[0]);
     printf("The output shows the number of multiplied and summed points right after the\n");
@@ -308,7 +311,8 @@ int main(int argc, char **argv) {
     int i, p;
     size_t scratch_size;
 
-    int iters = get_iters(10000);
+    int default_iters = 10000;
+    int iters = get_iters(default_iters);
 
     data.ecmult_multi = secp256k1_ecmult_multi_var;
 
@@ -316,7 +320,7 @@ int main(int argc, char **argv) {
         if(have_flag(argc, argv, "-h")
            || have_flag(argc, argv, "--help")
            || have_flag(argc, argv, "help")) {
-            help(argv);
+            help(argv, default_iters);
             return EXIT_SUCCESS;
         } else if(have_flag(argc, argv, "pippenger_wnaf")) {
             printf("Using pippenger_wnaf:\n");
@@ -328,7 +332,7 @@ int main(int argc, char **argv) {
             printf("Using simple algorithm:\n");
         } else {
             fprintf(stderr, "%s: unrecognized argument '%s'.\n\n", argv[0], argv[1]);
-            help(argv);
+            help(argv, default_iters);
             return EXIT_FAILURE;
         }
     }
@@ -381,6 +385,8 @@ int main(int argc, char **argv) {
                 run_ecmult_multi_bench(&data, i << p, 1, iters);
             }
         }
+    } else {
+        printf("Skipping some benchmarks due to SECP256K1_BENCH_ITERS <= 2\n");
     }
 
     if (data.scratch != NULL) {


### PR DESCRIPTION
## Description
I noticed that in both `bench` and `bench_internal` there was a help text mentioning to the users that you could use `SECP256K1_BENCH_ITERS` to customize the amount of iterations for each benchmark, but `bench_ecmult` did not have this text so I added it in.

There is a caveat that if `SECP256K1_BENCH_ITERS` is less than 3, then `run_ecmult_multi_bench` will not run. Should I add that to the help text?

---

### Before
```
$ ./build/bin/bench_ecmult -h
Benchmark EC multiplication algorithms

Usage: ./build/bin/bench_ecmult <help|pippenger_wnaf|strauss_wnaf|simple>
The output shows the number of multiplied and summed points right after the
function name. The letter 'g' indicates that one of the points is the generator.
The benchmarks are divided by the number of points.

default (ecmult_multi): picks pippenger_wnaf or strauss_wnaf depending on the
                        batch size
pippenger_wnaf:         for all batch sizes
strauss_wnaf:           for all batch sizes
simple:                 multiply and sum each point individually
```
### After
```
$ ./build/bin/bench_ecmult -h
Benchmark EC multiplication algorithms

The default number of iterations for each benchmark is 10000. This can be
customized using the SECP256K1_BENCH_ITERS environment variable.

Usage: ./build/bin/bench_ecmult <help|pippenger_wnaf|strauss_wnaf|simple>
The output shows the number of multiplied and summed points right after the
function name. The letter 'g' indicates that one of the points is the generator.
The benchmarks are divided by the number of points.

default (ecmult_multi): picks pippenger_wnaf or strauss_wnaf depending on the
                        batch size
pippenger_wnaf:         for all batch sizes
strauss_wnaf:           for all batch sizes
simple:                 multiply and sum each point individually
```