### PR TITLE
bench: fail early if user inputs invalid value for SECP256K1_BENCH_ITERS

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -177,8 +177,6 @@ int main(int argc, char** argv) {
     bench_data data;
 
     int d = argc == 1;
-    int default_iters = 20000;
-    int iters = get_iters(default_iters);
 
     /* Check for invalid user arguments */
     char* valid_args[] = {"ecdsa", "verify", "ecdsa_verify", "sign", "ecdsa_sign", "ecdh", "recover",
@@ -187,6 +185,13 @@ int main(int argc, char** argv) {
                          "ellswift_decode", "ellswift_keygen", "ellswift_ecdh"};
     size_t valid_args_size = sizeof(valid_args)/sizeof(valid_args[0]);
     int invalid_args = have_invalid_args(argc, argv, valid_args, valid_args_size);
+
+    int default_iters = 20000;
+    int iters = get_iters(default_iters);
+    if (iters == 0) {
+        help(default_iters);
+        return EXIT_FAILURE;
+    }
 
     if (argc > 1) {
         if (have_flag(argc, argv, "-h")

--- a/src/bench.h
+++ b/src/bench.h
@@ -150,7 +150,13 @@ static int have_invalid_args(int argc, char** argv, char** valid_args, size_t n)
 static int get_iters(int default_iters) {
     char* env = getenv("SECP256K1_BENCH_ITERS");
     if (env) {
-        return strtol(env, NULL, 0);
+        char* endptr;
+        long int iters = strtol(env, &endptr, 0);
+        if (*endptr != '\0' || iters <= 0) {
+            printf("Error: Value of SECP256K1_BENCH_ITERS is not a positive integer: %s\n\n", env);
+            return 0;
+        }
+        return iters;
     } else {
         return default_iters;
     }

--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -313,6 +313,10 @@ int main(int argc, char **argv) {
 
     int default_iters = 10000;
     int iters = get_iters(default_iters);
+    if (iters == 0) {
+        help(argv, default_iters);
+        return EXIT_FAILURE;
+    }
 
     data.ecmult_multi = secp256k1_ecmult_multi_var;
 

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -385,9 +385,13 @@ static void bench_context(void* arg, int iters) {
 
 int main(int argc, char **argv) {
     bench_inv data;
+    int d = argc == 1; /* default */
     int default_iters = 20000;
     int iters = get_iters(default_iters);
-    int d = argc == 1; /* default */
+    if (iters == 0) {
+        help(default_iters);
+        return EXIT_FAILURE;
+    }
 
     if (argc > 1) {
         if (have_flag(argc, argv, "-h")


### PR DESCRIPTION
### Description
Motivated by https://github.com/bitcoin-core/secp256k1/pull/1793#issuecomment-3719488071

In this change, the `get_iters` function was updated to print an error message and then return 0. 

In the functions that use `get_iters` they print the help text and then EXIT_FAILURE

### Before
```
secp256k1 $ SECP256K1_BENCH_ITERS=abc ./build/bin/bench

Benchmark                     ,    Min(us)    ,    Avg(us)    ,    Max(us)

Floating point exception (core dumped)
```
### After
```
secp256k1 $ SECP256K1_BENCH_ITERS=abc ./build/bin/bench

Invalid value for SECP256K1_BENCH_ITERS must be a positive integer: abc

Benchmarks the following algorithms:
    - ECDSA signing/verification
    - ECDH key exchange (optional module)
    - Schnorr signatures (optional module)
    - ElligatorSwift (optional module)

The default number of iterations for each benchmark is 20000. This can be
customized using the SECP256K1_BENCH_ITERS environment variable.

Usage: ./bench [args]
By default, all benchmarks will be run.
args:
    help              : display this help and exit
    ecdsa             : all ECDSA algorithms--sign, verify, recovery (if enabled)
    ecdsa_sign        : ECDSA siging algorithm
    ecdsa_verify      : ECDSA verification algorithm
    ec                : all EC public key algorithms (keygen)
    ec_keygen         : EC public key generation
    ecdh              : ECDH key exchange algorithm
    schnorrsig        : all Schnorr signature algorithms (sign, verify)
    schnorrsig_sign   : Schnorr sigining algorithm
    schnorrsig_verify : Schnorr verification algorithm
    ellswift          : all ElligatorSwift benchmarks (encode, decode, keygen, ecdh)
    ellswift_encode   : ElligatorSwift encoding
    ellswift_decode   : ElligatorSwift decoding
    ellswift_keygen   : ElligatorSwift key generation
    ellswift_ecdh     : ECDH on ElligatorSwift keys
```