### PR TITLE
sage: verify Eisenstein integer connection for GLV constants

### DIFF
--- a/sage/gen_split_lambda_constants.sage
+++ b/sage/gen_split_lambda_constants.sage
@@ -81,6 +81,15 @@ assert (A1 + A2)/2 < sqrt(N)
 assert B1 < sqrt(N)
 assert B2 < sqrt(N)
 
+# Verify connection to Eisenstein integers Z[w] where w = (-1 + sqrt(-3))/2.
+# The group order N factors as N = pi * conj(pi) in Z[w], where pi = A - B*w
+# is an Eisenstein prime with norm A^2 + A*B + B^2. The GLV endomorphism
+# eigenvalue LAMBDA equals B/A mod N, which is the image of w^2 under the
+# isomorphism Z[w]/(pi) -> Z/NZ (since w -> A/B and (A/B)^2 = B/A in Z/NZ).
+A_EIS, B_EIS = -B1, A1
+assert A_EIS**2 + A_EIS*B_EIS + B_EIS**2 == N
+assert Z(B_EIS / A_EIS) == LAMBDA
+
 G1 = round((2**384)*B2/N)
 G2 = round((2**384)*(-B1)/N)
 


### PR DESCRIPTION
## Summary

Add assertions to `gen_split_lambda_constants.sage` to verify that the GLV decomposition constants arise from the Eisenstein integer factorization of the group order N.

Specifically:
- `N = a^2 + a*b + b^2` (norm equation in Z[ω])
- `λ = b/a mod N` (eigenvalue from Z[ω]/(π) ≅ Z/NZ isomorphism)

This addresses the suggestion in #1798 to document/verify the algebraic origin of these constants in the sage script rather than C comments.

## Details

The group order N factors as N = π·π̄ in the Eisenstein integers Z[ω], where:
- ω = (-1 + √-3)/2 is a primitive cube root of unity
- π = a - b·ω is an Eisenstein prime with norm N(π) = a² + ab + b²

The GLV constants (A1, B1) correspond to the Eisenstein factors (b, -a), and the endomorphism eigenvalue λ arises naturally as the image of ω under the quotient map Z[ω] → Z[ω]/(π) ≅ Z/NZ.

Closes #1798