### PR TITLE
doc: add ctime_tests usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ In "Developer Command Prompt for VS 2022":
     >cmake -B build -T ClangCL
     >cmake --build build --config RelWithDebInfo
 
+Constant-time tests
+-------------------
+
+This library comes with constant-time tests to verify that secret data does not leak through timing side channels. These tests require Valgrind.
+
+Autotools:
+
+    $ libtool --mode=execute valgrind ./ctime_tests
+
+CMake:
+
+    $ valgrind ./build/bin/ctime_tests
+
 Usage examples
 -----------
 Usage examples can be found in the [examples](examples) directory. To compile them you need to configure with `--enable-examples`.

--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -49,7 +49,7 @@ int main(void) {
 
     if (!SECP256K1_CHECKMEM_RUNNING()) {
         fprintf(stderr, "This test can only usefully be run inside valgrind because it was not compiled under msan.\n");
-        fprintf(stderr, "Usage: libtool --mode=execute valgrind ./ctime_tests\n");
+        fprintf(stderr, "See README.md for usage instructions.\n");
         return EXIT_FAILURE;
     }
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_DECLASSIFY);


### PR DESCRIPTION
## Motivation

When building with CMake and running `ctime_tests`, users see a message suggesting `libtool`, which is Autotools-specific:

### Before
```
$ ./build/bin/ctime_tests
This test can only usefully be run inside valgrind because it was not compiled under msan.
Usage: libtool --mode=execute valgrind ./ctime_tests
```

This is confusing for CMake users since they don't have libtool. Reported in #1697.

## Solution

Following the approach in #1778, replace the build-system-specific command with a pointer to README.md and document both methods there.

### After
```
$ ./build/bin/ctime_tests
This test can only usefully be run inside valgrind because it was not compiled under msan.
See README.md for usage instructions.
```

The README now includes instructions for both build systems.

Fixes #1697