### PR TITLE
test: show both CMake and Autotools usage for ctime_tests

### DIFF
--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -49,7 +49,7 @@ int main(void) {
 
     if (!SECP256K1_CHECKMEM_RUNNING()) {
         fprintf(stderr, "This test can only usefully be run inside valgrind because it was not compiled under msan.\n");
-        fprintf(stderr, "Usage: libtool --mode=execute valgrind ./ctime_tests\n");
+        fprintf(stderr, "Usage: valgrind ./ctime_tests (or with Autotools: libtool --mode=execute valgrind ./ctime_tests)\n");
         return EXIT_FAILURE;
     }
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_DECLASSIFY);


### PR DESCRIPTION
When building with CMake and running `ctime_tests` outside valgrind, users see:

```
Usage: libtool --mode=execute valgrind ./ctime_tests
```

CMake users don't have libtool. Show both commands.

### Before
```
$ ./build/bin/ctime_tests
This test can only usefully be run inside valgrind because it was not compiled under msan.
Usage: libtool --mode=execute valgrind ./ctime_tests
```

### After
```
$ ./build/bin/ctime_tests
This test can only usefully be run inside valgrind because it was not compiled under msan.
Usage: valgrind ./ctime_tests (or with Autotools: libtool --mode=execute valgrind ./ctime_tests)
```

Fixes #1697