### PR TITLE
Verify non-null data arg in ellswift xdh_hash_function_prefix

### DIFF
--- a/src/modules/ellswift/main_impl.h
+++ b/src/modules/ellswift/main_impl.h
@@ -496,6 +496,7 @@ int secp256k1_ellswift_decode(const secp256k1_context *ctx, secp256k1_pubkey *pu
 
 static int ellswift_xdh_hash_function_prefix(unsigned char *output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
     secp256k1_sha256 sha;
+    VERIFY_CHECK(data != NULL);
 
     secp256k1_sha256_initialize(&sha);
     secp256k1_sha256_write(&sha, data, 64);


### PR DESCRIPTION
The `secp256k1_ellswift_xdh` API has a `data` arg that is optional for one
of the hash functions (unused) but required for the other.

This adds a simple check to provide a clear error instead of crashing
due to an out-of-bounds memory access when the user mistakenly provides
data=NULL and selects the `xdh_hash_function_prefix()` function.

Note: Open to improving the arg description in the API as well. I'm just adding
this check because a better error would have saved me a few minutes.