### PR TITLE
bench: Update help functions in bench and bench_internal

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -12,7 +12,7 @@
 #include "util.h"
 #include "bench.h"
 
-static void help(int default_iters) {
+static void help(const char *executable_path, int default_iters) {
     printf("Benchmarks the following algorithms:\n");
     printf("    - ECDSA signing/verification\n");
 
@@ -36,7 +36,7 @@ static void help(int default_iters) {
     printf("The default number of iterations for each benchmark is %d. This can be\n", default_iters);
     printf("customized using the SECP256K1_BENCH_ITERS environment variable.\n");
     printf("\n");
-    printf("Usage: ./bench [args]\n");
+    printf("Usage: %s [args]\n", executable_path);
     printf("By default, all benchmarks will be run.\n");
     printf("args:\n");
     printf("    help              : display this help and exit\n");
@@ -189,7 +189,7 @@ int main(int argc, char** argv) {
     int default_iters = 20000;
     int iters = get_iters(default_iters);
     if (iters == 0) {
-        help(default_iters);
+        help(argv[0], default_iters);
         return EXIT_FAILURE;
     }
 
@@ -197,11 +197,11 @@ int main(int argc, char** argv) {
         if (have_flag(argc, argv, "-h")
            || have_flag(argc, argv, "--help")
            || have_flag(argc, argv, "help")) {
-            help(default_iters);
+            help(argv[0], default_iters);
             return EXIT_SUCCESS;
         } else if (invalid_args) {
             fprintf(stderr, "./bench: unrecognized argument.\n\n");
-            help(default_iters);
+            help(argv[0], default_iters);
             return EXIT_FAILURE;
         }
     }

--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -19,13 +19,13 @@
 
 #define POINTS 32768
 
-static void help(char **argv, int default_iters) {
+static void help(const char *executable_path, int default_iters) {
     printf("Benchmark EC multiplication algorithms\n");
     printf("\n");
     printf("The default number of iterations for each benchmark is %d. This can be\n", default_iters);
     printf("customized using the SECP256K1_BENCH_ITERS environment variable.\n");
     printf("\n");
-    printf("Usage: %s <help|pippenger_wnaf|strauss_wnaf|simple>\n", argv[0]);
+    printf("Usage: %s [args]\n", executable_path);
     printf("The output shows the number of multiplied and summed points right after the\n");
     printf("function name. The letter 'g' indicates that one of the points is the generator.\n");
     printf("The benchmarks are divided by the number of points.\n");
@@ -314,7 +314,7 @@ int main(int argc, char **argv) {
     int default_iters = 10000;
     int iters = get_iters(default_iters);
     if (iters == 0) {
-        help(argv, default_iters);
+        help(argv[0], default_iters);
         return EXIT_FAILURE;
     }
 
@@ -324,7 +324,7 @@ int main(int argc, char **argv) {
         if(have_flag(argc, argv, "-h")
            || have_flag(argc, argv, "--help")
            || have_flag(argc, argv, "help")) {
-            help(argv, default_iters);
+            help(argv[0], default_iters);
             return EXIT_SUCCESS;
         } else if(have_flag(argc, argv, "pippenger_wnaf")) {
             printf("Using pippenger_wnaf:\n");
@@ -336,7 +336,7 @@ int main(int argc, char **argv) {
             printf("Using simple algorithm:\n");
         } else {
             fprintf(stderr, "%s: unrecognized argument '%s'.\n\n", argv[0], argv[1]);
-            help(argv, default_iters);
+            help(argv[0], default_iters);
             return EXIT_FAILURE;
         }
     }

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -18,13 +18,13 @@
 #include "ecmult_impl.h"
 #include "bench.h"
 
-static void help(int default_iters) {
+static void help(const char *executable_path, int default_iters) {
     printf("Benchmarks various internal routines.\n");
     printf("\n");
     printf("The default number of iterations for each benchmark is %d. This can be\n", default_iters);
     printf("customized using the SECP256K1_BENCH_ITERS environment variable.\n");
     printf("\n");
-    printf("Usage: ./bench_internal [args]\n");
+    printf("Usage: %s [args]\n", executable_path);
     printf("By default, all benchmarks will be run.\n");
     printf("args:\n");
     printf("    help       : display this help and exit\n");
@@ -389,7 +389,7 @@ int main(int argc, char **argv) {
     int default_iters = 20000;
     int iters = get_iters(default_iters);
     if (iters == 0) {
-        help(default_iters);
+        help(argv[0], default_iters);
         return EXIT_FAILURE;
     }
 
@@ -397,7 +397,7 @@ int main(int argc, char **argv) {
         if (have_flag(argc, argv, "-h")
            || have_flag(argc, argv, "--help")
            || have_flag(argc, argv, "help")) {
-            help(default_iters);
+            help(argv[0], default_iters);
             return EXIT_SUCCESS;
         }
     }


### PR DESCRIPTION
### Motivation
This change is motivated by https://github.com/bitcoin-core/secp256k1/pull/1793#pullrequestreview-3644885897

> While aligning implementation across all benchmarks, argv could be passed to the help() in bench.c and bench_internal.c.

### Description

In the `bench` and `bench_internal` `help` functions `argv` was not being passed. In this change, we pass in argv and use it in the help text.