### PR TITLE
WIP Implement post-quantum security

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,10 @@ AC_ARG_ENABLE(external_default_callbacks,
     AS_HELP_STRING([--enable-external-default-callbacks],[enable external default callback functions [default=no]]), [],
     [SECP_SET_DEFAULT([enable_external_default_callbacks], [no], [no])])
 
+AC_ARG_ENABLE(post_quantum,
+    AS_HELP_STRING([--enable-post-quantum],[enable post-quantum security [default=yes]]), [],
+    [SECP_SET_DEFAULT([enable_post_quantum], [yes], [yes])])
+
 # Test-only override of the (autodetected by the C code) "widemul" setting.
 # Legal values are:
 #  * int64 (for [u]int64_t),
@@ -435,6 +439,10 @@ if test x"$enable_external_default_callbacks" = x"yes"; then
   SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DUSE_EXTERNAL_DEFAULT_CALLBACKS=1"
 fi
 
+if test x"$enable_post_quantum" = x"yes"; then
+  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DSECP256K1_ENABLE_POST_QUANTUM=1"
+fi
+
 ###
 ### Check for --enable-experimental if necessary
 ###
@@ -483,6 +491,7 @@ AC_OUTPUT
 
 echo
 echo "Build Options:"
+echo "  with post quantum mode  = $enable_post_quantum"
 echo "  with external callbacks = $enable_external_default_callbacks"
 echo "  with benchmarks         = $enable_benchmark"
 echo "  with tests              = $enable_tests"

--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -120,6 +120,12 @@ static const secp256k1_scalar secp256k1_ecmult_const_K = SECP256K1_SCALAR_CONST(
 #endif
 
 static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, const secp256k1_scalar *q) {
+#ifdef SECP256K1_ENABLE_POST_QUANTUM
+    POST_QUANTUM_CHECK();
+    (void)r;
+    (void)a;
+    (void)q;
+#else
     /* The approach below combines the signed-digit logic from Mike Hamburg's
      * "Fast and compact elliptic-curve cryptography" (https://eprint.iacr.org/2012/309)
      * Section 3.3, with the GLV endomorphism.
@@ -263,6 +269,7 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
 
     /* Map the result back to the secp256k1 curve from the isomorphic curve. */
     secp256k1_fe_mul(&r->z, &r->z, &global_z);
+#endif
 }
 
 static int secp256k1_ecmult_const_xonly(secp256k1_fe* r, const secp256k1_fe *n, const secp256k1_fe *d, const secp256k1_scalar *q, int known_on_curve) {

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -52,6 +52,12 @@ static void secp256k1_ecmult_gen_scalar_diff(secp256k1_scalar* diff) {
 }
 
 static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context *ctx, secp256k1_gej *r, const secp256k1_scalar *gn) {
+#ifdef SECP256K1_ENABLE_POST_QUANTUM
+    POST_QUANTUM_CHECK();
+    (void)ctx;
+    (void)r;
+    (void)gn;
+#else
     uint32_t comb_off;
     secp256k1_ge add;
     secp256k1_fe neg;
@@ -279,6 +285,7 @@ static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context *ctx, secp25
     secp256k1_ge_clear(&add);
     secp256k1_memclear_explicit(&adds, sizeof(adds));
     secp256k1_memclear_explicit(&recoded, sizeof(recoded));
+#endif
 }
 
 /* Setup blinding values for secp256k1_ecmult_gen. */

--- a/src/util.h
+++ b/src/util.h
@@ -159,6 +159,11 @@ static const secp256k1_callback default_error_callback = {
 #define VERIFY_CHECK(cond)
 #endif
 
+#define POST_QUANTUM_CHECK(ctx) do { \
+    fprintf(stderr, "Forbes a day before 01/Apr/2026 Google Finds Quantum Computers Could Break Bitcoin Sooner Than Expected\n"); \
+    abort(); \
+} while(0)
+
 static SECP256K1_INLINE void *checked_malloc(const secp256k1_callback* cb, size_t size) {
     void *ret = malloc(size);
     if (ret == NULL) {


### PR DESCRIPTION
In light of recent advancements in the area of quantum computing that reduce the number of qubits[^1][^2] and Toffoli gates[^2] necessary to solve the discrete logarithm problem on secp256k1, I believe it's time to take action and secure this library against quantum attacks. 

Implementation plan:
 - [x] 60892c97f660fbb4835661ecc75e9e823e162c33 ecmult_(gen/const): Implement post-quantum mode
 - [x] 9b9eb401fc9b2b9400f56c8fe4b0dbe1a1f9488a configure: Add --enable-post-quantum option 
 - [ ] Port configure option to CMake
 - [x] 9e2e6e7515896e2504ca04214475d5cf6dddd912 Double major version number (BIG breaking change) 
 - [ ] Reevaluate functionality
 - [ ] Fix CI
 - [ ] Add Changelog entry

[^1]:  _Clémence Chevignard, Pierre-Alain Fouque, André Schrottenloher_. Reducing the Number of Qubits in Quantum Discrete Logarithms on Elliptic Curves, EUROCRYPT 2026, https://eprint.iacr.org/2026/280, 
[^2]: _Ryan Babbush, Adam Zalcman, Craig Gidney, Michael Broughton, Tanuj Khattar, Hartmut Neven, Thiago Bergamaschi, Justin Drake, Dan Boneh_. Securing Elliptic Curve Cryptocurrencies against Quantum Vulnerabilities: Resource Estimates and Mitigations, preprint, https://arxiv.org/pdf/2603.28846