### PR TITLE
optimize pubkey tweaking by using vartime jacobian->affine conversion (~10% speedup)

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -43,8 +43,10 @@ static void help(const char *executable_path, int default_iters) {
     printf("    ecdsa             : all ECDSA algorithms--sign, verify, recovery (if enabled)\n");
     printf("    ecdsa_sign        : ECDSA siging algorithm\n");
     printf("    ecdsa_verify      : ECDSA verification algorithm\n");
-    printf("    ec                : all EC public key algorithms (keygen)\n");
+    printf("    ec                : all EC public key algorithms (keygen, tweak)\n");
     printf("    ec_keygen         : EC public key generation\n");
+    printf("    ec_pk_tweak_add   : EC public key additive tweaking\n");
+    printf("    ec_pk_tweak_mul   : EC public key multiplicative tweaking\n");
 
 #ifdef ENABLE_MODULE_RECOVERY
     printf("    ecdsa_recover     : ECDSA public key recovery algorithm\n");
@@ -79,6 +81,8 @@ typedef struct {
     size_t siglen;
     unsigned char pubkey[33];
     size_t pubkeylen;
+    secp256k1_pubkey tweaked_pubkey;
+    unsigned char tweak[32];
 } bench_data;
 
 static void bench_verify(void* arg, int iters) {
@@ -153,6 +157,44 @@ static void bench_keygen_run(void *arg, int iters) {
     }
 }
 
+static void bench_tweak_setup(void* arg) {
+    int i;
+    bench_data *data = (bench_data*)arg;
+    unsigned char seckey_one[32] = {0};
+
+    /* set starting pubkey to the generator point */
+    seckey_one[31] = 1;
+    CHECK(secp256k1_ec_pubkey_create(data->ctx, &data->tweaked_pubkey, seckey_one));
+    for (i = 0; i < 32; i++) {
+        data->tweak[i] = i + 129;
+    }
+}
+
+static void bench_pubkey_tweak_add(void *arg, int iters) {
+    int i;
+    bench_data *data = (bench_data*)arg;
+
+    for (i = 0; i < iters; i++) {
+        unsigned char pub33[33];
+        size_t len = 33;
+        CHECK(secp256k1_ec_pubkey_tweak_add(data->ctx, &data->tweaked_pubkey, data->tweak));
+        CHECK(secp256k1_ec_pubkey_serialize(data->ctx, pub33, &len, &data->tweaked_pubkey, SECP256K1_EC_COMPRESSED));
+        memcpy(data->tweak, pub33 + 1, 32);
+    }
+}
+
+static void bench_pubkey_tweak_mul(void *arg, int iters) {
+    int i;
+    bench_data *data = (bench_data*)arg;
+
+    for (i = 0; i < iters; i++) {
+        unsigned char pub33[33];
+        size_t len = 33;
+        CHECK(secp256k1_ec_pubkey_tweak_mul(data->ctx, &data->tweaked_pubkey, data->tweak));
+        CHECK(secp256k1_ec_pubkey_serialize(data->ctx, pub33, &len, &data->tweaked_pubkey, SECP256K1_EC_COMPRESSED));
+        memcpy(data->tweak, pub33 + 1, 32);
+    }
+}
 
 #ifdef ENABLE_MODULE_ECDH
 # include "modules/ecdh/bench_impl.h"
@@ -181,8 +223,8 @@ int main(int argc, char** argv) {
     /* Check for invalid user arguments */
     char* valid_args[] = {"ecdsa", "verify", "ecdsa_verify", "sign", "ecdsa_sign", "ecdh", "recover",
                          "ecdsa_recover", "schnorrsig", "schnorrsig_verify", "schnorrsig_sign", "ec",
-                         "keygen", "ec_keygen", "ellswift", "encode", "ellswift_encode", "decode",
-                         "ellswift_decode", "ellswift_keygen", "ellswift_ecdh"};
+                         "keygen", "ec_keygen", "tweak", "ec_pk_tweak_add", "ec_pk_tweak_mul", "ellswift", "encode",
+                         "ellswift_encode", "decode", "ellswift_decode", "ellswift_keygen", "ellswift_ecdh"};
     int invalid_args = have_invalid_args(argc, argv, valid_args, ARRAY_SIZE(valid_args));
 
     int default_iters = 20000;
@@ -261,6 +303,8 @@ int main(int argc, char** argv) {
 
     if (d || have_flag(argc, argv, "ecdsa") || have_flag(argc, argv, "sign") || have_flag(argc, argv, "ecdsa_sign")) run_benchmark("ecdsa_sign", bench_sign_run, bench_sign_setup, NULL, &data, 10, iters);
     if (d || have_flag(argc, argv, "ec") || have_flag(argc, argv, "keygen") || have_flag(argc, argv, "ec_keygen")) run_benchmark("ec_keygen", bench_keygen_run, bench_keygen_setup, NULL, &data, 10, iters);
+    if (d || have_flag(argc, argv, "ec") || have_flag(argc, argv, "tweak") || have_flag(argc, argv, "ec_pk_tweak_add")) run_benchmark("ec_pk_tweak_add", bench_pubkey_tweak_add, bench_tweak_setup, NULL, &data, 10, iters);
+    if (d || have_flag(argc, argv, "ec") || have_flag(argc, argv, "tweak") || have_flag(argc, argv, "ec_pk_tweak_mul")) run_benchmark("ec_pk_tweak_mul", bench_pubkey_tweak_mul, bench_tweak_setup, NULL, &data, 10, iters);
 
     secp256k1_context_destroy(data.ctx);
 

--- a/src/eckey_impl.h
+++ b/src/eckey_impl.h
@@ -67,7 +67,7 @@ static int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_s
     if (secp256k1_gej_is_infinity(&pt)) {
         return 0;
     }
-    secp256k1_ge_set_gej(key, &pt);
+    secp256k1_ge_set_gej_var(key, &pt);
     return 1;
 }
 
@@ -87,7 +87,7 @@ static int secp256k1_eckey_pubkey_tweak_mul(secp256k1_ge *key, const secp256k1_s
 
     secp256k1_gej_set_ge(&pt, key);
     secp256k1_ecmult(&pt, &pt, tweak, NULL);
-    secp256k1_ge_set_gej(key, &pt);
+    secp256k1_ge_set_gej_var(key, &pt);
     return 1;
 }
 


### PR DESCRIPTION
This PR has a very similar theme and motivation as #1843, but is significantly simpler.

Tweaks are not considered sensitive data, and the point multiplications are not performed in constant-time either, so we can use the variable-time variant for converting to affine coordinates (ge_set_gej_var) as well to improve the performance. On my arm64 machine, this shows a ~10% speedup for both the additive and multiplicative public key tweaking API functions:

master branch
```
$ ./build/bin/bench tweak
Benchmark                     ,    Min(us)    ,    Avg(us)    ,    Max(us)

ec_pk_tweak_add               ,    16.3       ,    16.4       ,    16.7
ec_pk_tweak_mul               ,    19.7       ,    19.8       ,    19.8
```

PR branch
```
$ ./build/bin/bench tweak
Benchmark                     ,    Min(us)    ,    Avg(us)    ,    Max(us)

ec_pk_tweak_add               ,    14.6       ,    14.7       ,    14.9
ec_pk_tweak_mul               ,    18.1       ,    18.1       ,    18.2
```

The reduced execution time roughly matches the difference between `fe_inv` and `fe_inv_var` (see internal benchmarks), ~1.6 us on my machine.

Note that the improved code path for additive tweaking (function `secp256k1_eckey_pubkey_tweak_add`) is also used in the following API functions, so they should all benefit from it:
* [`secp256k1_xonly_pubkey_tweak_add`](https://github.com/bitcoin-core/secp256k1/blob/7262adb4b40074201fb30847035a82b8d742f350/src/modules/extrakeys/main_impl.h#L128)
* [`secp256k1_xonly_pubkey_tweak_add_check`](https://github.com/bitcoin-core/secp256k1/blob/7262adb4b40074201fb30847035a82b8d742f350/src/modules/extrakeys/main_impl.h#L145) (this one is used for [verifying P2TR script path spends in Bitcoin Core](https://github.com/bitcoin/bitcoin/blob/a7c30da1f6fc2eebd7514dd032fbb54940d467de/src/pubkey.cpp#L257-L263) and thus consensus-critical, see BIP341)
* [`secp256k1_keypair_xonly_tweak_add`](https://github.com/bitcoin-core/secp256k1/blob/7262adb4b40074201fb30847035a82b8d742f350/src/modules/extrakeys/main_impl.h#L274)
* [`secp256k1_musig_pubkey_{ec,xonly}_tweak_add`](https://github.com/bitcoin-core/secp256k1/blob/7262adb4b40074201fb30847035a82b8d742f350/src/modules/musig/keyagg_impl.h#L255)
* [`secp256k1_silentpayments_recipient_scan_outputs`](https://github.com/theStack/secp256k1/blob/67873086e33bc7a36134178bf09ae6a88f3cabf7/src/modules/silentpayments/main_impl.h#L655) in PR #1765
