### PR TITLE
ci: Replace `ilammy/msvc-dev-cmd` with manual MSVC setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,11 +604,10 @@ jobs:
     steps:
       - *CHECKOUT
 
-      - name: Add cl.exe to PATH
-        uses: ilammy/msvc-dev-cmd@v1
-
       - name: C++ (public headers)
+        shell: cmd
         run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cl.exe -c -WX -TP include/*.h
 
   cxx_fpermissive_debian:


### PR DESCRIPTION
The `ilammy/msvc-dev-cmd` repository seems [abandoned](https://github.com/ilammy/msvc-dev-cmd/issues/103) and should be considered unsafe.

This PR updates the workflow to load the MSVC environment variables directly via [`vcvars64.bat`](https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line).

For reference, the Bitcoin Core project removed `ilammy/msvc-dev-cmd` in https://github.com/bitcoin/bitcoin/pull/32513.

**Note for Maintainers:** Once this PR is merged and other PRs are rebased on top of it, the `ilammy/msvc-dev-cmd` action should be removed from the "Action permission" settings in this repository.