### PR TITLE
musig: always clear out secret key in `secp256k1_musig_nonce_gen_counter`

### DIFF
--- a/src/modules/musig/session_impl.h
+++ b/src/modules/musig/session_impl.h
@@ -483,11 +483,9 @@ int secp256k1_musig_nonce_gen_counter(const secp256k1_context* ctx, secp256k1_mu
     (void) ret;
 #endif
 
-    if (!secp256k1_musig_nonce_gen_internal(ctx, secnonce, pubnonce, buf, seckey, &pubkey, msg32, keyagg_cache, extra_input32)) {
-        return 0;
-    }
+    ret = secp256k1_musig_nonce_gen_internal(ctx, secnonce, pubnonce, buf, seckey, &pubkey, msg32, keyagg_cache, extra_input32);
     secp256k1_memclear_explicit(seckey, sizeof(seckey));
-    return 1;
+    return ret;
 }
 
 static int secp256k1_musig_sum_pubnonces(const secp256k1_context* ctx, secp256k1_gej *summed_pubnonces, const secp256k1_musig_pubnonce * const* pubnonces, size_t n_pubnonces) {


### PR DESCRIPTION
Even though `secp256k1_musig_nonce_gen_internal` can currently only fail if the surrounding API function is misused (invalid `keypair` or `keyagg_cache` parameters, making the corresponding [seckey validation](https://github.com/bitcoin-core/secp256k1/blob/c1a9e4fe6471478dba9c5ef61105b9c5213c6bf1/src/modules/musig/session_impl.h#L391) or [pubkey](https://github.com/bitcoin-core/secp256k1/blob/c1a9e4fe6471478dba9c5ef61105b9c5213c6bf1/src/modules/musig/session_impl.h#L404)/[keyaggcache](https://github.com/bitcoin-core/secp256k1/blob/c1a9e4fe6471478dba9c5ef61105b9c5213c6bf1/src/modules/musig/session_impl.h#L397) load calls fail), clearing out the stack memory holding the secret key as well in this case seems reasonable to follow best practices.

The issue was reported off-band by l0rinc (thanks!), in the course of analyzing the secp repository with AI tooling.