### PR TITLE
doc: correct API docs for ECDSA signing out-params (s/array/signature object/)

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -687,7 +687,7 @@ SECP256K1_API const secp256k1_nonce_function secp256k1_nonce_function_default;
  *  Returns: 1: signature created
  *           0: the nonce generation function failed, or the secret key was invalid.
  *  Args:    ctx:       pointer to a context object (not secp256k1_context_static).
- *  Out:     sig:       pointer to an array where the signature will be placed.
+ *  Out:     sig:       pointer to a signature object.
  *  In:      msghash32: the 32-byte message hash being signed.
  *           seckey:    pointer to a 32-byte secret key.
  *           noncefp:   pointer to a nonce generation function. If NULL,

--- a/include/secp256k1_recovery.h
+++ b/include/secp256k1_recovery.h
@@ -73,7 +73,7 @@ SECP256K1_API int secp256k1_ecdsa_recoverable_signature_serialize_compact(
  *  Returns: 1: signature created
  *           0: the nonce generation function failed, or the secret key was invalid.
  *  Args:    ctx:       pointer to a context object (not secp256k1_context_static).
- *  Out:     sig:       pointer to an array where the signature will be placed.
+ *  Out:     sig:       pointer to a signature object.
  *  In:      msghash32: the 32-byte message hash being signed.
  *           seckey:    pointer to a 32-byte secret key.
  *           noncefp:   pointer to a nonce generation function. If NULL,


### PR DESCRIPTION
This PR is a late follow-up to https://github.com/bitcoin-core/secp256k1/pull/282, adapting the signature out param description to the API change.

This is currently a minimum-diff based on existing API doc descriptions in the touched header files (for e.g. `_ecdsa_signature_parse_{compact,der}`, `_ecdsa_recoverable_signature_parse_compact`). For more consistency across modules, one could adopt the wording used in the musig module, e.g. "pointer to a structure to store the created signature".