### PR TITLE
bench: add internal benchmark for `secp256k1_fe_normalize_var`

### DIFF
--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -194,6 +194,17 @@ static void bench_field_normalize(void* arg, int iters) {
     }
 }
 
+static void bench_field_normalize_var(void* arg, int iters) {
+    int i;
+    bench_inv *data = (bench_inv*)arg;
+
+    /* Note that this benchmark measures the optimistic path. The worst-case path with the final
+       reduction is very unlikely to be needed, so this is representative of the common case. */
+    for (i = 0; i < iters; i++) {
+        secp256k1_fe_normalize_var(&data->fe[0]);
+    }
+}
+
 static void bench_field_normalize_weak(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
@@ -421,6 +432,7 @@ int main(int argc, char **argv) {
 
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "half")) run_benchmark("field_half", bench_field_half, bench_setup, NULL, &data, 10, iters*100);
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize", bench_field_normalize, bench_setup, NULL, &data, 10, iters*100);
+    if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize_var", bench_field_normalize_var, bench_setup, NULL, &data, 10, iters*100);
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize_weak", bench_field_normalize_weak, bench_setup, NULL, &data, 10, iters*100);
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "sqr")) run_benchmark("field_sqr", bench_field_sqr, bench_setup, NULL, &data, 10, iters*10);
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "mul")) run_benchmark("field_mul", bench_field_mul, bench_setup, NULL, &data, 10, iters*10);


### PR DESCRIPTION
While addressing the review suggestion https://github.com/bitcoin-core/secp256k1/pull/1765#discussion_r3238616034 ([b10c mirror link](https://mirror.b10c.me/bitcoin-core-secp256k1/1765/#discussion_r3238616034)), I noticed that we don't have an internal benchmark for the variable-time variant of `_fe_normalize` yet, so this PR adds one. IIUC it's fine to repeatedly apply the operation on the same (already normalized at latest after the first loop iteration) field element for benchmarking purposes and don't put in an effort to reach the [final reduction code path](https://github.com/bitcoin-core/secp256k1/blob/b11340b3ce2afac1b6ffda4ce5828c30621d2917/src/field_5x52_impl.h#L120-L132), considering how extremely unlikely it is to reach it in practice.

Results on my machine:
```
$ ./build/bin/bench_internal normalize
Benchmark                     ,    Min(us)    ,    Avg(us)    ,    Max(us)    

field_normalize               ,     0.0103    ,     0.0106    ,     0.0128 
field_normalize_var           ,     0.00545   ,     0.00546   ,     0.00547
field_normalize_weak          ,     0.00352   ,     0.00354   ,     0.00363
```