### PR TITLE
 ci: Add armhf valgrind to matrix 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,9 @@ jobs:
             binary_arch: armhf
             env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'auto', VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf' }
           - runner: ubuntu-24.04-arm
+            binary_arch: armhf
+            env_vars: { CC: 'clang --target=arm-linux-gnueabihf -isystem /usr/arm-linux-gnueabihf/include', HOST: 'arm-linux-gnueabihf', ASM: 'auto', VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf' }
+          - runner: ubuntu-24.04-arm
             binary_arch: arm64
             env_vars: { CC: 'clang',                                      ASM: 'auto' }
           - runner: ubuntu-latest
@@ -316,6 +319,9 @@ jobs:
           - runner: ubuntu-24.04-arm
             binary_arch: armhf
             env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2, VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf' }
+          - runner: ubuntu-24.04-arm
+            binary_arch: armhf
+            env_vars: { CC: 'clang --target=arm-linux-gnueabihf -isystem /usr/arm-linux-gnueabihf/include', HOST: 'arm-linux-gnueabihf', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2, VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf' }
           - runner: ubuntu-24.04-arm
             binary_arch: arm64
             env_vars: { CC: 'clang',                                      ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
             env_vars: { CC: 'i686-linux-gnu-gcc', HOST: 'i686-linux-gnu', ASM: 'auto' }
           - runner: ubuntu-24.04-arm
             binary_arch: armhf
-            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'auto' }
+            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'auto', VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf valgrind-dbg:armhf' }
           - runner: ubuntu-24.04-arm
             binary_arch: arm64
             env_vars: { CC: 'clang',                                      ASM: 'auto' }
@@ -315,7 +315,7 @@ jobs:
             env_vars: { CC: 'i686-linux-gnu-gcc', HOST: 'i686-linux-gnu', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }
           - runner: ubuntu-24.04-arm
             binary_arch: armhf
-            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }
+            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2, VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf valgrind-dbg:armhf' }
           - runner: ubuntu-24.04-arm
             binary_arch: arm64
             env_vars: { CC: 'clang',                                      ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,9 @@ jobs:
             binary_arch: i686
             env_vars: { CC: 'i686-linux-gnu-gcc', HOST: 'i686-linux-gnu', ASM: 'auto' }
           - runner: ubuntu-24.04-arm
+            binary_arch: armhf
+            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'auto' }
+          - runner: ubuntu-24.04-arm
             binary_arch: arm64
             env_vars: { CC: 'clang',                                      ASM: 'auto' }
           - runner: ubuntu-latest
@@ -310,6 +313,9 @@ jobs:
           - runner: ubuntu-latest
             binary_arch: i686
             env_vars: { CC: 'i686-linux-gnu-gcc', HOST: 'i686-linux-gnu', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }
+          - runner: ubuntu-24.04-arm
+            binary_arch: armhf
+            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }
           - runner: ubuntu-24.04-arm
             binary_arch: arm64
             env_vars: { CC: 'clang',                                      ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
             env_vars: { CC: 'i686-linux-gnu-gcc', HOST: 'i686-linux-gnu', ASM: 'auto' }
           - runner: ubuntu-24.04-arm
             binary_arch: armhf
-            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'auto', VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf valgrind-dbg:armhf' }
+            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'auto', VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf' }
           - runner: ubuntu-24.04-arm
             binary_arch: arm64
             env_vars: { CC: 'clang',                                      ASM: 'auto' }
@@ -315,7 +315,7 @@ jobs:
             env_vars: { CC: 'i686-linux-gnu-gcc', HOST: 'i686-linux-gnu', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }
           - runner: ubuntu-24.04-arm
             binary_arch: armhf
-            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2, VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf valgrind-dbg:armhf' }
+            env_vars: { CC: 'arm-linux-gnueabihf-gcc', HOST: 'arm-linux-gnueabihf', ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2, VALGRIND_EXTRA_PACKAGES: 'valgrind:armhf' }
           - runner: ubuntu-24.04-arm
             binary_arch: arm64
             env_vars: { CC: 'clang',                                      ASM: 'no', ECMULTGENKB: 2, ECMULTWINDOW: 2 }

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -13,6 +13,7 @@ print_environment() {
     # does not rely on bash.
     for var in WERROR_CFLAGS MAKEFLAGS BUILD \
             ECMULTWINDOW ECMULTGENKB ASM WIDEMUL WITH_VALGRIND EXTRAFLAGS \
+            VALGRIND_EXTRA_PACKAGES \
             EXPERIMENTAL ECDH RECOVERY EXTRAKEYS MUSIG SCHNORRSIG ELLSWIFT \
             SECP256K1_TEST_ITERS BENCH SECP256K1_BENCH_ITERS CTIMETESTS SYMBOL_CHECK \
             EXAMPLES \
@@ -44,6 +45,13 @@ esac
 if [ -n "${CC+x}" ]; then
     # The MSVC compiler "cl" doesn't understand "-v"
     $CC -v || true
+fi
+if [ -n "${VALGRIND_EXTRA_PACKAGES+x}" ]; then
+    # Install an architecture-specific Valgrind build when the job requests it.
+    # This is used for armhf memcheck jobs on arm64 runners.
+    # shellcheck disable=SC2086
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y $VALGRIND_EXTRA_PACKAGES
 fi
 if [ "$WITH_VALGRIND" = "yes" ]; then
     valgrind --version


### PR DESCRIPTION
This is a hacky rebase of https://github.com/bitcoin-core/secp256k1/pull/1433 to add valgrind coverage on armhf for gcc and clang.

However, as explained in https://github.com/bitcoin-core/secp256k1/issues/1856, it doesn't work, due to `Source and destination overlap in memcpy`.

