### PR TITLE
cmake: Emulate Libtool's behavior on NetBSD and OpenBSD

### DIFF
--- a/cmake/SetLibtoolAbiVersion.cmake
+++ b/cmake/SetLibtoolAbiVersion.cmake
@@ -1,0 +1,28 @@
+# This emulates Libtool to make sure Libtool and CMake agree on the ABI version,
+# see below "Calculate the version variables" in autotools-aux/ltmain.sh.
+function(set_libtool_abi_version target current revision age)
+  math(EXPR _soversion "${current} - ${age}")
+  set_target_properties(${target} PROPERTIES
+    SOVERSION ${_soversion}
+  )
+  if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|FreeBSD)$")
+    set_target_properties(${target} PROPERTIES
+      VERSION ${_soversion}.${age}.${revision}
+    )
+  elseif(APPLE)
+    math(EXPR _compatibility "${current} + 1")
+    set_target_properties(${target} PROPERTIES
+      MACHO_COMPATIBILITY_VERSION ${_compatibility}
+      MACHO_CURRENT_VERSION ${_compatibility}.${revision}
+    )
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(_windows_name "secp256k1")
+    if(MSVC)
+      set(_windows_name "${PROJECT_NAME}")
+    endif()
+    set_target_properties(${target} PROPERTIES
+      ARCHIVE_OUTPUT_NAME "${_windows_name}"
+      RUNTIME_OUTPUT_NAME "${_windows_name}-${_soversion}"
+    )
+  endif()
+endfunction()

--- a/cmake/SetLibtoolAbiVersion.cmake
+++ b/cmake/SetLibtoolAbiVersion.cmake
@@ -1,28 +1,45 @@
-# This emulates Libtool to make sure Libtool and CMake agree on the ABI version,
-# see below "Calculate the version variables" in autotools-aux/ltmain.sh.
+#[=[
+This emulates Libtool to make sure Libtool and CMake agree on
+the ABI version and file naming for shared libraries.
+
+The `version_type` variable is set in `libtool.m4` (installed
+by autoreconf into autotools-aux/m4/).
+For the `major` and `versuffix` variables, see below "Calculate
+the version variables" in `ltmain.sh` (installed by autoreconf
+into autotools-aux/).
+]=]
 function(set_libtool_abi_version target current revision age)
-  math(EXPR _soversion "${current} - ${age}")
-  set_target_properties(${target} PROPERTIES
-    SOVERSION ${_soversion}
-  )
   if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|FreeBSD)$")
+    # version_type = linux | freebsd-elf
+    # major = $current - $age
+    # versuffix = $major.$age.$revision
+    math(EXPR _major "${current} - ${age}")
     set_target_properties(${target} PROPERTIES
-      VERSION ${_soversion}.${age}.${revision}
+      SOVERSION ${_major}
+      VERSION ${_major}.${age}.${revision}
     )
   elseif(APPLE)
+    # version_type = darwin
+    # major = $current - $age
+    math(EXPR _major "${current} - ${age}")
     math(EXPR _compatibility "${current} + 1")
     set_target_properties(${target} PROPERTIES
+      SOVERSION ${_major}
       MACHO_COMPATIBILITY_VERSION ${_compatibility}
       MACHO_CURRENT_VERSION ${_compatibility}.${revision}
     )
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # version_type = windows
+    # major = $current - $age
+    # versuffix = $major
+    math(EXPR _major "${current} - ${age}")
     set(_windows_name "secp256k1")
     if(MSVC)
       set(_windows_name "${PROJECT_NAME}")
     endif()
     set_target_properties(${target} PROPERTIES
       ARCHIVE_OUTPUT_NAME "${_windows_name}"
-      RUNTIME_OUTPUT_NAME "${_windows_name}-${_soversion}"
+      RUNTIME_OUTPUT_NAME "${_windows_name}-${_major}"
     )
   endif()
 endfunction()

--- a/cmake/SetLibtoolAbiVersion.cmake
+++ b/cmake/SetLibtoolAbiVersion.cmake
@@ -26,6 +26,14 @@ function(set_libtool_abi_version target current revision age)
       SOVERSION ${current}
       VERSION ${current}.${revision}
     )
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+    # version_type = sunos
+    # major = $current
+    # versuffix = $current.$revision
+    set_target_properties(${target} PROPERTIES
+      # OpenBSD has no `soname_spec` defined in `libtool.m4`.
+      VERSION ${current}.${revision}
+    )
   elseif(APPLE)
     # version_type = darwin
     # major = $current - $age

--- a/cmake/SetLibtoolAbiVersion.cmake
+++ b/cmake/SetLibtoolAbiVersion.cmake
@@ -18,6 +18,14 @@ function(set_libtool_abi_version target current revision age)
       SOVERSION ${_major}
       VERSION ${_major}.${age}.${revision}
     )
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
+    # version_type = sunos
+    # major = $current
+    # versuffix = $current.$revision
+    set_target_properties(${target} PROPERTIES
+      SOVERSION ${current}
+      VERSION ${current}.${revision}
+    )
   elseif(APPLE)
     # version_type = darwin
     # major = $current - $age

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,35 +94,12 @@ set_target_properties(secp256k1_objs PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "$<TARGET_PROPERTY:secp256k1,INTERFACE_INCLUDE_DIRECTORIES>"
 )
 
-# This emulates Libtool to make sure Libtool and CMake agree on the ABI version,
-# see below "Calculate the version variables" in autotools-aux/ltmain.sh.
-math(EXPR ${PROJECT_NAME}_soversion "${${PROJECT_NAME}_LIB_VERSION_CURRENT} - ${${PROJECT_NAME}_LIB_VERSION_AGE}")
-set_target_properties(secp256k1 PROPERTIES
-  SOVERSION ${${PROJECT_NAME}_soversion}
+include(SetLibtoolAbiVersion)
+set_libtool_abi_version(secp256k1
+  ${${PROJECT_NAME}_LIB_VERSION_CURRENT}
+  ${${PROJECT_NAME}_LIB_VERSION_REVISION}
+  ${${PROJECT_NAME}_LIB_VERSION_AGE}
 )
-if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|FreeBSD)$")
-  set_target_properties(secp256k1 PROPERTIES
-    VERSION ${${PROJECT_NAME}_soversion}.${${PROJECT_NAME}_LIB_VERSION_AGE}.${${PROJECT_NAME}_LIB_VERSION_REVISION}
-  )
-elseif(APPLE)
-  math(EXPR ${PROJECT_NAME}_compatibility_version "${${PROJECT_NAME}_LIB_VERSION_CURRENT} + 1")
-  set_target_properties(secp256k1 PROPERTIES
-    MACHO_COMPATIBILITY_VERSION ${${PROJECT_NAME}_compatibility_version}
-    MACHO_CURRENT_VERSION ${${PROJECT_NAME}_compatibility_version}.${${PROJECT_NAME}_LIB_VERSION_REVISION}
-  )
-  unset(${PROJECT_NAME}_compatibility_version)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  set(${PROJECT_NAME}_windows "secp256k1")
-  if(MSVC)
-    set(${PROJECT_NAME}_windows "${PROJECT_NAME}")
-  endif()
-  set_target_properties(secp256k1 PROPERTIES
-    ARCHIVE_OUTPUT_NAME "${${PROJECT_NAME}_windows}"
-    RUNTIME_OUTPUT_NAME "${${PROJECT_NAME}_windows}-${${PROJECT_NAME}_soversion}"
-  )
-  unset(${PROJECT_NAME}_windows)
-endif()
-unset(${PROJECT_NAME}_soversion)
 
 if(SECP256K1_BUILD_BENCHMARK)
   add_executable(bench bench.c)


### PR DESCRIPTION
This is a continuation of https://github.com/bitcoin-core/secp256k1/pull/1685.

Additionally, the logic has been factored out into its own module and the documentation has been also improved.