### PR TITLE
ellswift: don't declassify or leave sk in sha256 buffer

### DIFF
--- a/src/modules/ellswift/main_impl.h
+++ b/src/modules/ellswift/main_impl.h
@@ -449,12 +449,13 @@ int secp256k1_ellswift_create(const secp256k1_context *ctx, unsigned char *ell64
     secp256k1_fe_normalize_var(&p.x);
     secp256k1_fe_normalize_var(&p.y);
 
-    /* Set up hasher state. The used RNG is H(privkey || "\x00"*32 [|| auxrnd32] || cnt++),
+    /* Set up hasher state. The used RNG is H(seckey32 || "\x00"*32 [|| auxrnd32] || cnt++),
      * using BIP340 tagged hash with tag "secp256k1_ellswift_create". */
     secp256k1_ellswift_sha256_init_create(&hash);
     secp256k1_sha256_write(secp256k1_get_hash_context(ctx), &hash, seckey32, 32);
     secp256k1_sha256_write(secp256k1_get_hash_context(ctx), &hash, zero32, sizeof(zero32));
-    secp256k1_declassify(ctx, &hash, sizeof(hash)); /* private key is hashed now */
+    /* Declassify only hash state. seckey32 has been hashed, but copy remains in the hash buffer */
+    secp256k1_declassify(ctx, &hash.s, sizeof(hash.s));
     if (auxrnd32) secp256k1_sha256_write(secp256k1_get_hash_context(ctx), &hash, auxrnd32, 32);
 
     /* Compute ElligatorSwift encoding and construct output. */
@@ -463,6 +464,7 @@ int secp256k1_ellswift_create(const secp256k1_context *ctx, unsigned char *ell64
 
     secp256k1_memczero(ell64, 64, !ret);
     secp256k1_scalar_clear(&seckey_scalar);
+    secp256k1_sha256_clear(&hash);
 
     return ret;
 }


### PR DESCRIPTION
`secp256k1_ellswift_create` assumes sha256 clears the data in its buffer
after hashing it, which is not the case. So we shouldn't declassify the whole
struct, only the hash result. We should also clear it at the end, so the sk
doesn't linger on the stack when no aux rnd is given.

On master, can add the following diff and run the tests to see sk sitting
in the buffer.
```diff
diff --git a/src/modules/ellswift/main_impl.h b/src/modules/ellswift/main_impl.h
--- a/src/modules/ellswift/main_impl.h	
+++ b/src/modules/ellswift/main_impl.h	
@@ -461,6 +461,9 @@
     secp256k1_ellswift_elligatorswift_var(ctx, ell64, &t, &p, &hash); /* puts u in ell64[0..32] */
     secp256k1_fe_get_b32(ell64 + 32, &t); /* puts t in ell64[32..64] */
 
+    /* DEMO: fail because sk sits in the buffer */
+    if (!auxrnd32) VERIFY_CHECK(memcmp(hash.buf, seckey32, 32) != 0);
     secp256k1_memczero(ell64, 64, !ret);
```