### PR TITLE
test: enable -Wunused-function in test suite (Fix #1831)

### DIFF
--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -40,6 +40,11 @@
 #include "../include/secp256k1_ellswift.h"
 #endif
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wunused-function"
+#endif
+
 static void run_tests(secp256k1_context *ctx, unsigned char *key);
 
 int main(void) {
@@ -265,3 +270,7 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
 
 #endif
 }
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif

--- a/src/tests.c
+++ b/src/tests.c
@@ -37,6 +37,11 @@
 #include "int128_impl.h"
 #endif
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wunused-function"
+#endif
+
 #define CONDITIONAL_TEST(cnt, nam) if (COUNT < (cnt)) { printf("Skipping %s (iteration count too low)\n", nam); } else
 
 static secp256k1_context *CTX = NULL;
@@ -8091,3 +8096,7 @@ int main(int argc, char **argv) {
     if (tf_init(&tf, argc, argv) != 0) return EXIT_FAILURE;
     return tf_run(&tf);
 }
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -31,6 +31,11 @@
 #include "testutil.h"
 #include "util.h"
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wunused-function"
+#endif
+
 static int count = 2;
 
 static uint32_t num_cores = 1;
@@ -467,3 +472,7 @@ int main(int argc, char** argv) {
     printf("no problems found\n");
     return EXIT_SUCCESS;
 }
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif

--- a/src/unit_test.c
+++ b/src/unit_test.c
@@ -17,6 +17,11 @@
 #include "testrand.h"
 #include "tests_common.h"
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wunused-function"
+#endif
+
 #define UNUSED(x) (void)(x)
 
 /* Number of times certain tests will run */
@@ -477,3 +482,7 @@ static int tf_run(struct tf_framework* tf) {
 
     return status;
 }
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION

This PR addresses issue #1831 by enabling the `-Wunused-function` compiler warning within the test suite. 

Currently, `-Wno-unused-function` is passed globally to disable warnings about unused functions, making it too easy to write a test case but forget to actually call it. To catch untested helper functions safely, this PR uses GCC/Clang pragmas scoped strictly to the body of the test files.

### Changes Made:
- Added `#pragma GCC diagnostic warning "-Wunused-function"` directly after the `#include` statements in `src/tests.c`, `src/tests_exhaustive.c`, `src/ctime_tests.c`, and `src/unit_test.c`. 
Fixes #1831 
