### PR TITLE
test: musig: fix dead "aggnonce encodes two points at infinity" check

### DIFF
--- a/src/modules/musig/tests_impl.h
+++ b/src/modules/musig/tests_impl.h
@@ -374,7 +374,7 @@ static void musig_api_tests(void) {
         secp256k1_ge aggnonce_pt[2];
         secp256k1_musig_aggnonce_load(CTX, aggnonce_pt, &aggnonce);
         for (i = 0; i < 2; i++) {
-            secp256k1_ge_is_infinity(&aggnonce_pt[i]);
+            CHECK(secp256k1_ge_is_infinity(&aggnonce_pt[i]) == 1);
         }
     }
     CHECK(secp256k1_musig_nonce_agg(CTX, &aggnonce, pubnonce_ptr, 2) == 1);


### PR DESCRIPTION
Due to the missing `CHECK` around, the return values were discarded and nothing was actually checked here.

(Fwiw I prompted two AI models (MiniMax M3 and Opus 4.8) to find more similar instances in tests with bare statements that miss a surrounding `CHECK` in tests, and both didn't find any.)