### PR TITLE
ci: Add CI job to build on Debian Wheezy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,38 @@ jobs:
       - *CI_SCRIPT_IN_DOCKER
       - *PRINT_LOGS
 
+  x86_64_debian_wheezy:
+    name: "x86_64: Linux (Debian Wheezy)"
+    runs-on: ubuntu-latest
+
+    env:
+      ASM: 'auto'
+      WITH_VALGRIND: 'no'
+      ECDH: 'yes'
+      RECOVERY: 'yes'
+      EXTRAKEYS: 'yes'
+      SCHNORRSIG: 'yes'
+      MUSIG: 'yes'
+      ELLSWIFT: 'yes'
+      CTIMETESTS: 'no'
+      # On Linux, the examples include <sys/random.h>, which was
+      # added in glibc 2.25, while Debian 7 ships glibc 2.13.
+      EXAMPLES: 'no'
+      CC: 'gcc'
+      CFLAGS: '-Wno-error=missing-braces -Wno-error=missing-field-initializers -Wno-error=shadow -Wno-error=unused-function'
+
+    steps:
+      - *CHECKOUT
+
+      - name: CI script
+        uses: ./.github/actions/run-in-docker-action
+        with:
+          dockerfile: ./ci/linux-debian7.Dockerfile
+          scope: ${{ runner.arch }}
+          command: ./ci/ci.sh
+
+      - *PRINT_LOGS
+
   valgrind_debian:
     name: "Valgrind ${{ matrix.configuration.binary_arch }} (memcheck)"
     runs-on: ${{ matrix.configuration.runner }}

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -5,7 +5,7 @@ set -eux
 export LC_ALL=C
 
 # Print commit and relevant CI environment to allow reproducing the job outside of CI.
-git show --no-patch
+git show -s
 print_environment() {
     # Turn off -x because it messes up the output
     set +x
@@ -93,16 +93,20 @@ file .libs/* || true
 
 if [ "$SYMBOL_CHECK" = "yes" ]
 then
-    python3 --version
-    case "$HOST" in
-        *mingw*)
-            ls -l .libs
-            python3 ./tools/symbol-check.py .libs/libsecp256k1-*.dll
-            ;;
-        *)
-            python3 ./tools/symbol-check.py .libs/libsecp256k1.so
-            ;;
-    esac
+    if command -v python3 >/dev/null 2>&1; then
+        python3 --version
+        case "$HOST" in
+            *mingw*)
+                ls -l .libs
+                python3 ./tools/symbol-check.py .libs/libsecp256k1-*.dll
+                ;;
+            *)
+                python3 ./tools/symbol-check.py .libs/libsecp256k1.so
+                ;;
+        esac
+    else
+        echo "python3 not found, skipping symbol check."
+    fi
 fi
 
 # This tells `make check` to wrap test invocations.
@@ -138,8 +142,14 @@ fi
 # Rebuild precomputed files (if not cross-compiling).
 if [ -z "$HOST" ]
 then
-    make clean-precomp clean-testvectors
-    make precomp testvectors
+    make clean-precomp
+    make precomp
+    if command -v python3 >/dev/null 2>&1; then
+        make clean-testvectors
+        make testvectors
+    else
+        echo "python3 not found, skipping rebuild test vectors."
+    fi
 fi
 
 # Check that no repo files have been modified by the build.

--- a/ci/linux-debian7.Dockerfile
+++ b/ci/linux-debian7.Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/debian/eol:wheezy
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /root
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    git \
+    autoconf automake libtool make \
+    gcc && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
It is widely expected that libsecp256k1, which requires only C89 and `<stdint.h>`, can be built with any toolchain that meets those requirements, including old and ancient ones.

This PR introduces a CI job that builds on Debian Wheezy, which could serve as a baseline for such expectations.

Wheezy is the earliest Debian release that ships all Autotools components with supported versions (Autoconf>=[2.60](https://github.com/bitcoin-core/secp256k1/blob/aea86bc3509f3ceb5c047fe6567bf8910f72a728/configure.ac#L1), Automake>=[1.11.2](https://github.com/bitcoin-core/secp256k1/blob/aea86bc3509f3ceb5c047fe6567bf8910f72a728/configure.ac#L26-L27)). This allows us to reuse our testing script with minimal adjustments.

~The exact compiler version, GCC 4.4, was chosen to be able to catch issues like [this](https://github.com/bitcoin-core/secp256k1/pull/1865#pullrequestreview-4486484699) one.~

This PR also raises the following questions:
1. There are some warnings that are excluded from errors:https://github.com/bitcoin-core/secp256k1/blob/5362c070b7682840e4f258a31cc4ef606c39a02f/.github/workflows/ci.yml#L307
    Do we want to improve code hygiene and fix them?

2. This branch exposes an example issue with compatibility with retro Linux systems:https://github.com/bitcoin-core/secp256k1/blob/5362c070b7682840e4f258a31cc4ef606c39a02f/.github/workflows/ci.yml#L303-L305
    Do we want to fix it?

3. The test script runs `make testvectors` only if not cross-compiling. But it seems it should run fine even when cross-compiling as it uses Python scripts.