### PR TITLE
Minimum recommended toolchain - document and test it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,34 @@ jobs:
       - *CI_SCRIPT_IN_DOCKER
       - *PRINT_LOGS
 
+  x86_64_debian_oldold:
+    name: "x86_64: Linux (Debian oldoldstable)"
+    runs-on: ubuntu-latest
+
+    env:
+      ASM: 'auto'
+      WITH_VALGRIND: 'no'
+      ECDH: 'yes'
+      RECOVERY: 'yes'
+      EXTRAKEYS: 'yes'
+      SCHNORRSIG: 'yes'
+      MUSIG: 'yes'
+      ELLSWIFT: 'yes'
+      CTIMETESTS: 'no'
+      CC: 'gcc'
+
+    steps:
+      - *CHECKOUT
+
+      - name: CI script
+        uses: ./.github/actions/run-in-docker-action
+        with:
+          dockerfile: ./ci/linux-debian-oldold.Dockerfile
+          scope: ${{ runner.arch }}
+          command: ./ci/ci.sh
+
+      - *PRINT_LOGS
+
   valgrind_debian:
     name: "Valgrind ${{ matrix.configuration.binary_arch }} (memcheck)"
     runs-on: ${{ matrix.configuration.runner }}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Implementation details
   * No runtime heap allocation.
   * Extensive testing infrastructure.
   * Structured to facilitate review and analysis.
-  * Intended to be portable to any system with a C89 compiler and uint64_t support.
   * No use of floating types.
   * Expose only higher level interfaces to minimize the API surface and improve application security. ("Be difficult to use insecurely.")
 * Field operations
@@ -97,8 +96,15 @@ This can be done with the following steps:
         Subkey fingerprint: 4BBB 845A 6F5A 65A6 9DFA  EC23 4861 DBF2 6212 3605
    ```
 
-Building with Autotools
------------------------
+## Building from source
+
+The project is intended to be portable to any system with a C89/C90-compatible toolchain.
+Additionally, the C standard library must provide the `<stdint.h>` header.
+
+Toolchains older than the default one shipped in the current Debian "oldoldstable" release
+are not tested and are not recommended for building the project.
+
+### Building with Autotools
 
     $ ./autogen.sh       # Generate a ./configure script
     $ ./configure        # Generate a build system
@@ -108,12 +114,11 @@ Building with Autotools
 
 To compile optional modules (such as Schnorr signatures), you need to run `./configure` with additional flags (such as `--enable-module-schnorrsig`). Run `./configure --help` to see the full list of available flags.
 
-Building with CMake
--------------------
+### Building with CMake
 
 To maintain a pristine source tree, CMake encourages to perform an out-of-source build by using a separate dedicated build tree.
 
-### Building on POSIX systems
+#### Building on POSIX systems
 
     $ cmake -B build              # Generate a build system in subdirectory "build"
     $ cmake --build build         # Run the actual build process
@@ -122,7 +127,7 @@ To maintain a pristine source tree, CMake encourages to perform an out-of-source
 
 To compile optional modules (such as Schnorr signatures), you need to run `cmake` with additional flags (such as `-DSECP256K1_ENABLE_MODULE_SCHNORRSIG=ON`). Run `cmake -B build -LH` or `ccmake -B build` to see the full list of available flags.
 
-### Cross compiling
+#### Cross compiling
 
 To alleviate issues with cross compiling, preconfigured toolchain files are available in the `cmake` directory.
 For example, to cross compile for Windows:
@@ -133,7 +138,7 @@ To cross compile for Android with [NDK](https://developer.android.com/ndk/guides
 
     $ cmake -B build -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake" -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=28
 
-### Building on Windows
+#### Building on Windows
 
 The following example assumes Visual Studio 2022. Using clang-cl is recommended.
 

--- a/ci/linux-debian-oldold.Dockerfile
+++ b/ci/linux-debian-oldold.Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:oldoldstable-slim
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /root
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    git \
+    autoconf automake libtool make \
+    gcc \
+    python3-full && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/root/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip install lief


### PR DESCRIPTION
This PR:

1. Establishes clear boundaries for the project's recommended build and testing environments.

2. Adds a CI job that tests the project's minimum recommended build environment.

This is useful for reviewing changes like https://github.com/bitcoin-core/secp256k1/pull/1865 or https://github.com/bitcoin-core/secp256k1/pull/1869.

---

For the context:

- from https://github.com/bitcoin-core/secp256k1/pull/1871#issuecomment-4729692574:
  > ... Wheezy is just ancient. Do you think a Docker image that depends on a generic Debian oldoldstable image could do the job? (Does such an image exist?) This would at least save us from bumping the version regularly.

