### PR TITLE
Add SECP256K1_WARN_UNUSED_RESULT to all relevant static int functions

### DIFF
--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -135,7 +135,7 @@ static void bench_ecmult_const_xonly(void* arg, int iters) {
         const secp256k1_ge* pubkey = &data->pubkeys[(data->offset1+i) % POINTS];
         const secp256k1_scalar* scalar = &data->scalars[(data->offset2+i) % POINTS];
         int known_on_curve = 1;
-        secp256k1_ecmult_const_xonly(&data->output_xonly[i], &pubkey->x, NULL, scalar, known_on_curve);
+        { int _r_ = secp256k1_ecmult_const_xonly(&data->output_xonly[i], &pubkey->x, NULL, scalar, known_on_curve); (void)_r_; }
     }
 }
 

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -88,10 +88,10 @@ static void bench_setup(void* arg) {
 
     secp256k1_scalar_set_b32(&data->scalar[0], init[0], NULL);
     secp256k1_scalar_set_b32(&data->scalar[1], init[1], NULL);
-    secp256k1_fe_set_b32_limit(&data->fe[0], init[0]);
-    secp256k1_fe_set_b32_limit(&data->fe[1], init[1]);
-    secp256k1_fe_set_b32_limit(&data->fe[2], init[2]);
-    secp256k1_fe_set_b32_limit(&data->fe[3], init[3]);
+    { int _r_ = secp256k1_fe_set_b32_limit(&data->fe[0], init[0]); (void)_r_; }
+    { int _r_ = secp256k1_fe_set_b32_limit(&data->fe[1], init[1]); (void)_r_; }
+    { int _r_ = secp256k1_fe_set_b32_limit(&data->fe[2], init[2]); (void)_r_; }
+    { int _r_ = secp256k1_fe_set_b32_limit(&data->fe[3], init[3]); (void)_r_; }
     CHECK(secp256k1_ge_set_xo_var(&data->ge[0], &data->fe[0], 0));
     CHECK(secp256k1_ge_set_xo_var(&data->ge[1], &data->fe[1], 1));
     secp256k1_gej_set_ge(&data->gej[0], &data->ge[0]);

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -13,9 +13,9 @@
 #include "group.h"
 #include "ecmult.h"
 
-static int secp256k1_ecdsa_sig_parse(secp256k1_scalar *r, secp256k1_scalar *s, const unsigned char *sig, size_t size);
-static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar *r, const secp256k1_scalar *s);
-static int secp256k1_ecdsa_sig_verify(const secp256k1_scalar* r, const secp256k1_scalar* s, const secp256k1_ge *pubkey, const secp256k1_scalar *message);
-static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar* r, secp256k1_scalar* s, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_parse(secp256k1_scalar *r, secp256k1_scalar *s, const unsigned char *sig, size_t size);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar *r, const secp256k1_scalar *s);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_verify(const secp256k1_scalar* r, const secp256k1_scalar* s, const secp256k1_ge *pubkey, const secp256k1_scalar *message);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar* r, secp256k1_scalar* s, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid);
 
 #endif /* SECP256K1_ECDSA_H */

--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -33,7 +33,7 @@ static const secp256k1_fe secp256k1_ecdsa_const_p_minus_order = SECP256K1_FE_CON
     0, 0, 0, 1, 0x45512319UL, 0x50B75FC4UL, 0x402DA172UL, 0x2FC9BAEEUL
 );
 
-static int secp256k1_der_read_len(size_t *len, const unsigned char **sigp, const unsigned char *sigend) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_der_read_len(size_t *len, const unsigned char **sigp, const unsigned char *sigend) {
     size_t lenleft;
     unsigned char b1;
     VERIFY_CHECK(len != NULL);
@@ -87,7 +87,7 @@ static int secp256k1_der_read_len(size_t *len, const unsigned char **sigp, const
     return 1;
 }
 
-static int secp256k1_der_parse_integer(secp256k1_scalar *r, const unsigned char **sig, const unsigned char *sigend) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_der_parse_integer(secp256k1_scalar *r, const unsigned char **sig, const unsigned char *sigend) {
     int overflow = 0;
     unsigned char ra[32] = {0};
     size_t rlen;
@@ -138,7 +138,7 @@ static int secp256k1_der_parse_integer(secp256k1_scalar *r, const unsigned char 
     return 1;
 }
 
-static int secp256k1_ecdsa_sig_parse(secp256k1_scalar *rr, secp256k1_scalar *rs, const unsigned char *sig, size_t size) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_parse(secp256k1_scalar *rr, secp256k1_scalar *rs, const unsigned char *sig, size_t size) {
     const unsigned char *sigend = sig + size;
     size_t rlen;
     if (sig == sigend || *(sig++) != 0x30) {
@@ -168,7 +168,7 @@ static int secp256k1_ecdsa_sig_parse(secp256k1_scalar *rr, secp256k1_scalar *rs,
     return 1;
 }
 
-static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar* ar, const secp256k1_scalar* as) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar* ar, const secp256k1_scalar* as) {
     unsigned char r[33] = {0}, s[33] = {0};
     unsigned char *rp = r, *sp = s;
     size_t lenR = 33, lenS = 33;
@@ -192,7 +192,7 @@ static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const
     return 1;
 }
 
-static int secp256k1_ecdsa_sig_verify(const secp256k1_scalar *sigr, const secp256k1_scalar *sigs, const secp256k1_ge *pubkey, const secp256k1_scalar *message) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_verify(const secp256k1_scalar *sigr, const secp256k1_scalar *sigs, const secp256k1_ge *pubkey, const secp256k1_scalar *message) {
     unsigned char c[32];
     secp256k1_scalar sn, u1, u2;
 #if !defined(EXHAUSTIVE_TEST_ORDER)
@@ -271,7 +271,7 @@ static int secp256k1_ecdsa_sig_verify(const secp256k1_scalar *sigr, const secp25
 #endif
 }
 
-static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid) {
     unsigned char b[32];
     secp256k1_ge r;
     secp256k1_scalar n;

--- a/src/eckey.h
+++ b/src/eckey.h
@@ -14,15 +14,15 @@
 #include "ecmult.h"
 #include "ecmult_gen.h"
 
-static int secp256k1_eckey_pubkey_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_pubkey_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size);
 /** Serialize a group element (that is not allowed to be infinity) to a compressed public key (33 bytes). */
 static void secp256k1_eckey_pubkey_serialize33(secp256k1_ge *elem, unsigned char *pub33);
 /** Serialize a group element (that is not allowed to be infinity) to an uncompressed public key (65 bytes). */
 static void secp256k1_eckey_pubkey_serialize65(secp256k1_ge *elem, unsigned char *pub65);
 
-static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak);
-static int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_scalar *tweak);
-static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak);
-static int secp256k1_eckey_pubkey_tweak_mul(secp256k1_ge *key, const secp256k1_scalar *tweak);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_scalar *tweak);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_pubkey_tweak_mul(secp256k1_ge *key, const secp256k1_scalar *tweak);
 
 #endif /* SECP256K1_ECKEY_H */

--- a/src/eckey_impl.h
+++ b/src/eckey_impl.h
@@ -15,7 +15,7 @@
 #include "group.h"
 #include "ecmult_gen.h"
 
-static int secp256k1_eckey_pubkey_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_pubkey_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size) {
     if (size == 33 && (pub[0] == SECP256K1_TAG_PUBKEY_EVEN || pub[0] == SECP256K1_TAG_PUBKEY_ODD)) {
         secp256k1_fe x;
         return secp256k1_fe_set_b32_limit(&x, pub+1) && secp256k1_ge_set_xo_var(elem, &x, pub[0] == SECP256K1_TAG_PUBKEY_ODD);
@@ -54,12 +54,12 @@ static void secp256k1_eckey_pubkey_serialize65(secp256k1_ge *elem, unsigned char
     secp256k1_fe_get_b32(&pub65[33], &elem->y);
 }
 
-static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
     secp256k1_scalar_add(key, key, tweak);
     return !secp256k1_scalar_is_zero(key);
 }
 
-static int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_scalar *tweak) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_scalar *tweak) {
     secp256k1_gej pt;
     secp256k1_gej_set_ge(&pt, key);
     secp256k1_ecmult(&pt, &pt, &secp256k1_scalar_one, tweak);
@@ -71,7 +71,7 @@ static int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_s
     return 1;
 }
 
-static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
     int ret;
     ret = !secp256k1_scalar_is_zero(tweak);
 
@@ -79,7 +79,7 @@ static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp25
     return ret;
 }
 
-static int secp256k1_eckey_pubkey_tweak_mul(secp256k1_ge *key, const secp256k1_scalar *tweak) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_eckey_pubkey_tweak_mul(secp256k1_ge *key, const secp256k1_scalar *tweak) {
     secp256k1_gej pt;
     if (secp256k1_scalar_is_zero(tweak)) {
         return 0;

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -59,6 +59,6 @@ typedef int (secp256k1_ecmult_multi_callback)(secp256k1_scalar *sc, secp256k1_ge
  *          0 if there is not enough scratch space for a single point or
  *          callback returns 0
  */
-static int secp256k1_ecmult_multi_var(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_multi_var(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n);
 
 #endif /* SECP256K1_ECMULT_H */

--- a/src/ecmult_const.h
+++ b/src/ecmult_const.h
@@ -27,7 +27,7 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
  *
  * Constant time in the value of q, but not any other inputs.
  */
-static int secp256k1_ecmult_const_xonly(
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_const_xonly(
     secp256k1_fe *r,
     const secp256k1_fe *n,
     const secp256k1_fe *d,

--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -265,7 +265,7 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
     secp256k1_fe_mul(&r->z, &r->z, &global_z);
 }
 
-static int secp256k1_ecmult_const_xonly(secp256k1_fe* r, const secp256k1_fe *n, const secp256k1_fe *d, const secp256k1_scalar *q, int known_on_curve) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_const_xonly(secp256k1_fe* r, const secp256k1_fe *n, const secp256k1_fe *d, const secp256k1_scalar *q, int known_on_curve) {
 
     /* This algorithm is a generalization of Peter Dettman's technique for
      * avoiding the square root in a random-basepoint x-only multiplication

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -159,7 +159,7 @@ SECP256K1_INLINE static void secp256k1_ecmult_table_get_ge_storage(secp256k1_ge 
  *  - the number of set values in wnaf is returned. This number is at most 256, and at most one more
  *    than the number of bits in the (absolute value) of the input.
  */
-static int secp256k1_ecmult_wnaf(int *wnaf, int len, const secp256k1_scalar *a, int w) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_wnaf(int *wnaf, int len, const secp256k1_scalar *a, int w) {
     secp256k1_scalar s;
     int last_set_bit = -1;
     int bit = 0;
@@ -221,7 +221,7 @@ static int secp256k1_ecmult_wnaf(int *wnaf, int len, const secp256k1_scalar *a, 
 }
 
 /* Same as secp256k1_ecmult_wnaf, but stores to int8_t array. Requires w <= 8. */
-static int secp256k1_ecmult_wnaf_small(int8_t *wnaf, int len, const secp256k1_scalar *a, int w) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_wnaf_small(int8_t *wnaf, int len, const secp256k1_scalar *a, int w) {
     int wnaf_tmp[256];
     int ret, i;
 
@@ -379,7 +379,7 @@ static size_t secp256k1_strauss_scratch_size(size_t n_points) {
     return n_points*point_size;
 }
 
-static int secp256k1_ecmult_strauss_batch(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n_points, size_t cb_offset) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_strauss_batch(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n_points, size_t cb_offset) {
     secp256k1_gej* points;
     secp256k1_scalar* scalars;
     struct secp256k1_strauss_state state;
@@ -419,7 +419,7 @@ static int secp256k1_ecmult_strauss_batch(const secp256k1_callback* error_callba
 }
 
 /* Wrapper for secp256k1_ecmult_multi_func interface */
-static int secp256k1_ecmult_strauss_batch_single(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_strauss_batch_single(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n) {
     return secp256k1_ecmult_strauss_batch(error_callback, scratch, r, inp_g_sc, cb, cbdata, n, 0);
 }
 
@@ -434,7 +434,7 @@ static size_t secp256k1_strauss_max_points(const secp256k1_callback* error_callb
  *  - the number of words set is always WNAF_SIZE(w)
  *  - the returned skew is 0 or 1
  */
-static int secp256k1_wnaf_fixed(int *wnaf, const secp256k1_scalar *s, int w) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_wnaf_fixed(int *wnaf, const secp256k1_scalar *s, int w) {
     int skew = 0;
     int pos;
     int max_pos;
@@ -513,7 +513,7 @@ struct secp256k1_pippenger_state {
  * to the point's wnaf[i]. Second, the buckets are added together such that
  * r += 1*bucket[0] + 3*bucket[1] + 5*bucket[2] + ...
  */
-static int secp256k1_ecmult_pippenger_wnaf(secp256k1_gej *buckets, int bucket_window, struct secp256k1_pippenger_state *state, secp256k1_gej *r, const secp256k1_scalar *sc, const secp256k1_ge *pt, size_t num) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_pippenger_wnaf(secp256k1_gej *buckets, int bucket_window, struct secp256k1_pippenger_state *state, secp256k1_gej *r, const secp256k1_scalar *sc, const secp256k1_ge *pt, size_t num) {
     size_t n_wnaf = WNAF_SIZE(bucket_window+1);
     size_t np;
     size_t no = 0;
@@ -667,7 +667,7 @@ static size_t secp256k1_pippenger_scratch_size(size_t n_points, int bucket_windo
     return (sizeof(secp256k1_gej) << bucket_window) + sizeof(struct secp256k1_pippenger_state) + entries * entry_size;
 }
 
-static int secp256k1_ecmult_pippenger_batch(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n_points, size_t cb_offset) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_pippenger_batch(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n_points, size_t cb_offset) {
     const size_t scratch_checkpoint = secp256k1_scratch_checkpoint(error_callback, scratch);
     /* Use 2(n+1) with the endomorphism, when calculating batch
      * sizes. The reason for +1 is that we add the G scalar to the list of
@@ -731,7 +731,7 @@ static int secp256k1_ecmult_pippenger_batch(const secp256k1_callback* error_call
 }
 
 /* Wrapper for secp256k1_ecmult_multi_func interface */
-static int secp256k1_ecmult_pippenger_batch_single(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_pippenger_batch_single(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n) {
     return secp256k1_ecmult_pippenger_batch(error_callback, scratch, r, inp_g_sc, cb, cbdata, n, 0);
 }
 
@@ -776,7 +776,7 @@ static size_t secp256k1_pippenger_max_points(const secp256k1_callback* error_cal
 
 /* Computes ecmult_multi by simply multiplying and adding each point. Does not
  * require a scratch space */
-static int secp256k1_ecmult_multi_simple_var(secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n_points) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_multi_simple_var(secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n_points) {
     size_t point_idx;
     secp256k1_gej tmpj;
 
@@ -801,7 +801,7 @@ static int secp256k1_ecmult_multi_simple_var(secp256k1_gej *r, const secp256k1_s
 
 /* Compute the number of batches and the batch size given the maximum batch size and the
  * total number of points */
-static int secp256k1_ecmult_multi_batch_size_helper(size_t *n_batches, size_t *n_batch_points, size_t max_n_batch_points, size_t n) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_multi_batch_size_helper(size_t *n_batches, size_t *n_batch_points, size_t max_n_batch_points, size_t n) {
     if (max_n_batch_points == 0) {
         return 0;
     }
@@ -820,7 +820,7 @@ static int secp256k1_ecmult_multi_batch_size_helper(size_t *n_batches, size_t *n
 }
 
 typedef int (*secp256k1_ecmult_multi_func)(const secp256k1_callback* error_callback, secp256k1_scratch*, secp256k1_gej*, const secp256k1_scalar*, secp256k1_ecmult_multi_callback cb, void*, size_t);
-static int secp256k1_ecmult_multi_var(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_multi_var(const secp256k1_callback* error_callback, secp256k1_scratch *scratch, secp256k1_gej *r, const secp256k1_scalar *inp_g_sc, secp256k1_ecmult_multi_callback cb, void *cbdata, size_t n) {
     size_t i;
 
     int (*f)(const secp256k1_callback* error_callback, secp256k1_scratch*, secp256k1_gej*, const secp256k1_scalar*, secp256k1_ecmult_multi_callback cb, void*, size_t, size_t);

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -725,7 +725,7 @@ static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecmult_pippenger_batch(const s
         point_idx++;
     }
 
-    secp256k1_ecmult_pippenger_wnaf(buckets, bucket_window, state_space, r, scalars, points, idx);
+    { int _r_ = secp256k1_ecmult_pippenger_wnaf(buckets, bucket_window, state_space, r, scalars, points, idx); (void)_r_; }
     secp256k1_scratch_apply_checkpoint(error_callback, scratch, scratch_checkpoint);
     return 1;
 }

--- a/src/field.h
+++ b/src/field.h
@@ -128,13 +128,13 @@ static void secp256k1_fe_normalize_var(secp256k1_fe *r);
  * On input, r must be a valid field element.
  * Returns whether r = 0 (mod p).
  */
-static int secp256k1_fe_normalizes_to_zero(const secp256k1_fe *r);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_normalizes_to_zero(const secp256k1_fe *r);
 
 /** Determine whether r represents field element 0, without constant-time guarantee.
  *
  * Identical in behavior to secp256k1_normalizes_to_zero, but not constant time in r.
  */
-static int secp256k1_fe_normalizes_to_zero_var(const secp256k1_fe *r);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_normalizes_to_zero_var(const secp256k1_fe *r);
 
 /** Set a field element to an integer in range [0,0x7FFF].
  *
@@ -154,14 +154,14 @@ static void secp256k1_fe_clear(secp256k1_fe *a);
  * This behaves identical to secp256k1_normalizes_to_zero{,_var}, but requires
  * normalized input (and is much faster).
  */
-static int secp256k1_fe_is_zero(const secp256k1_fe *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_is_zero(const secp256k1_fe *a);
 
 /** Determine whether a (mod p) is odd.
  *
  * On input, a must be a valid normalized field element.
  * Returns (int(a) mod p) & 1.
  */
-static int secp256k1_fe_is_odd(const secp256k1_fe *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_is_odd(const secp256k1_fe *a);
 
 /** Determine whether two field elements are equal.
  *
@@ -169,7 +169,7 @@ static int secp256k1_fe_is_odd(const secp256k1_fe *a);
  * 1 and 31, respectively.
  * Returns a = b (mod p).
  */
-static int secp256k1_fe_equal(const secp256k1_fe *a, const secp256k1_fe *b);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_equal(const secp256k1_fe *a, const secp256k1_fe *b);
 
 /** Compare the values represented by 2 field elements, without constant-time guarantee.
  *
@@ -177,7 +177,7 @@ static int secp256k1_fe_equal(const secp256k1_fe *a, const secp256k1_fe *b);
  * Returns 1 if a > b, -1 if a < b, and 0 if a = b (comparisons are done as integers
  * in range 0..p-1).
  */
-static int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b);
 
 /** Set a field element equal to the element represented by a provided 32-byte big endian value
  * interpreted modulo p.
@@ -193,7 +193,7 @@ static void secp256k1_fe_set_b32_mod(secp256k1_fe *r, const unsigned char *a);
  * On output, r = a if (a < p), it will be normalized with magnitude 1, and 1 is returned.
  * If a >= p, 0 is returned, and r will be made invalid (and must not be used without overwriting).
  */
-static int secp256k1_fe_set_b32_limit(secp256k1_fe *r, const unsigned char *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_set_b32_limit(secp256k1_fe *r, const unsigned char *a);
 
 /** Convert a field element to 32-byte big endian byte array.
  * On input, a must be a valid normalized field element, and r a pointer to a 32-byte array.
@@ -275,7 +275,7 @@ static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a);
  * Variables r and a must not point to the same object.
  * On output, r will have magnitude 1 but will not be normalized.
  */
-static int secp256k1_fe_sqrt(secp256k1_fe * SECP256K1_RESTRICT r, const secp256k1_fe * SECP256K1_RESTRICT a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_sqrt(secp256k1_fe * SECP256K1_RESTRICT r, const secp256k1_fe * SECP256K1_RESTRICT a);
 
 /** Compute the modular inverse of a field element.
  *
@@ -338,7 +338,7 @@ static void secp256k1_fe_get_bounds(secp256k1_fe *r, int m);
  *
  * On input, a must be a valid field element.
  */
-static int secp256k1_fe_is_square_var(const secp256k1_fe *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_is_square_var(const secp256k1_fe *a);
 
 /** Check invariants on a field element (no-op unless VERIFY is enabled). */
 static void secp256k1_fe_verify(const secp256k1_fe *a);

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -175,7 +175,7 @@ static void secp256k1_fe_impl_normalize_var(secp256k1_fe *r) {
     r->n[5] = t5; r->n[6] = t6; r->n[7] = t7; r->n[8] = t8; r->n[9] = t9;
 }
 
-static int secp256k1_fe_impl_normalizes_to_zero(const secp256k1_fe *r) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_normalizes_to_zero(const secp256k1_fe *r) {
     uint32_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4],
              t5 = r->n[5], t6 = r->n[6], t7 = r->n[7], t8 = r->n[8], t9 = r->n[9];
 
@@ -204,7 +204,7 @@ static int secp256k1_fe_impl_normalizes_to_zero(const secp256k1_fe *r) {
     return (z0 == 0) | (z1 == 0x3FFFFFFUL);
 }
 
-static int secp256k1_fe_impl_normalizes_to_zero_var(const secp256k1_fe *r) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_normalizes_to_zero_var(const secp256k1_fe *r) {
     uint32_t t0, t1, t2, t3, t4, t5, t6, t7, t8, t9;
     uint32_t z0, z1;
     uint32_t x;
@@ -261,16 +261,16 @@ SECP256K1_INLINE static void secp256k1_fe_impl_set_int(secp256k1_fe *r, int a) {
     r->n[1] = r->n[2] = r->n[3] = r->n[4] = r->n[5] = r->n[6] = r->n[7] = r->n[8] = r->n[9] = 0;
 }
 
-SECP256K1_INLINE static int secp256k1_fe_impl_is_zero(const secp256k1_fe *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_zero(const secp256k1_fe *a) {
     const uint32_t *t = a->n;
     return (t[0] | t[1] | t[2] | t[3] | t[4] | t[5] | t[6] | t[7] | t[8] | t[9]) == 0;
 }
 
-SECP256K1_INLINE static int secp256k1_fe_impl_is_odd(const secp256k1_fe *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_odd(const secp256k1_fe *a) {
     return a->n[0] & 1;
 }
 
-static int secp256k1_fe_impl_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
     int i;
     for (i = 9; i >= 0; i--) {
         if (a->n[i] > b->n[i]) {
@@ -296,7 +296,7 @@ static void secp256k1_fe_impl_set_b32_mod(secp256k1_fe *r, const unsigned char *
     r->n[9] = (uint32_t)((a[2] >> 2) & 0x3f) | ((uint32_t)a[1] << 6) | ((uint32_t)a[0] << 14);
 }
 
-static int secp256k1_fe_impl_set_b32_limit(secp256k1_fe *r, const unsigned char *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_set_b32_limit(secp256k1_fe *r, const unsigned char *a) {
     secp256k1_fe_impl_set_b32_mod(r, a);
     return !((r->n[9] == 0x3FFFFFUL) & ((r->n[8] & r->n[7] & r->n[6] & r->n[5] & r->n[4] & r->n[3] & r->n[2]) == 0x3FFFFFFUL) & ((r->n[1] + 0x40UL + ((r->n[0] + 0x3D1UL) >> 26)) > 0x3FFFFFFUL));
 }
@@ -1208,7 +1208,7 @@ static void secp256k1_fe_impl_inv_var(secp256k1_fe *r, const secp256k1_fe *x) {
     secp256k1_fe_from_signed30(r, &s);
 }
 
-static int secp256k1_fe_impl_is_square_var(const secp256k1_fe *x) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_square_var(const secp256k1_fe *x) {
     secp256k1_fe tmp;
     secp256k1_modinv32_signed30 s;
     int jac, ret;

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -134,7 +134,7 @@ static void secp256k1_fe_impl_normalize_var(secp256k1_fe *r) {
     r->n[0] = t0; r->n[1] = t1; r->n[2] = t2; r->n[3] = t3; r->n[4] = t4;
 }
 
-static int secp256k1_fe_impl_normalizes_to_zero(const secp256k1_fe *r) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_normalizes_to_zero(const secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
 
     /* z0 tracks a possible raw value of 0, z1 tracks a possible raw value of P */
@@ -157,7 +157,7 @@ static int secp256k1_fe_impl_normalizes_to_zero(const secp256k1_fe *r) {
     return (z0 == 0) | (z1 == 0xFFFFFFFFFFFFFULL);
 }
 
-static int secp256k1_fe_impl_normalizes_to_zero_var(const secp256k1_fe *r) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_normalizes_to_zero_var(const secp256k1_fe *r) {
     uint64_t t0, t1, t2, t3, t4;
     uint64_t z0, z1;
     uint64_t x;
@@ -203,16 +203,16 @@ SECP256K1_INLINE static void secp256k1_fe_impl_set_int(secp256k1_fe *r, int a) {
     r->n[1] = r->n[2] = r->n[3] = r->n[4] = 0;
 }
 
-SECP256K1_INLINE static int secp256k1_fe_impl_is_zero(const secp256k1_fe *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_zero(const secp256k1_fe *a) {
     const uint64_t *t = a->n;
     return (t[0] | t[1] | t[2] | t[3] | t[4]) == 0;
 }
 
-SECP256K1_INLINE static int secp256k1_fe_impl_is_odd(const secp256k1_fe *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_odd(const secp256k1_fe *a) {
     return a->n[0] & 1;
 }
 
-static int secp256k1_fe_impl_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
     int i;
     for (i = 4; i >= 0; i--) {
         if (a->n[i] > b->n[i]) {
@@ -262,7 +262,7 @@ static void secp256k1_fe_impl_set_b32_mod(secp256k1_fe *r, const unsigned char *
             | ((uint64_t)a[0] << 40);
 }
 
-static int secp256k1_fe_impl_set_b32_limit(secp256k1_fe *r, const unsigned char *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_set_b32_limit(secp256k1_fe *r, const unsigned char *a) {
     secp256k1_fe_impl_set_b32_mod(r, a);
     return !((r->n[4] == 0x0FFFFFFFFFFFFULL) & ((r->n[3] & r->n[2] & r->n[1]) == 0xFFFFFFFFFFFFFULL) & (r->n[0] >= 0xFFFFEFFFFFC2FULL));
 }
@@ -498,7 +498,7 @@ static void secp256k1_fe_impl_inv_var(secp256k1_fe *r, const secp256k1_fe *x) {
     secp256k1_fe_from_signed62(r, &s);
 }
 
-static int secp256k1_fe_impl_is_square_var(const secp256k1_fe *x) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_square_var(const secp256k1_fe *x) {
     secp256k1_fe tmp;
     secp256k1_modinv64_signed62 s;
     int jac, ret;

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -22,7 +22,7 @@ SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe *a) {
     secp256k1_memclear_explicit(a, sizeof(secp256k1_fe));
 }
 
-SECP256K1_INLINE static int secp256k1_fe_equal(const secp256k1_fe *a, const secp256k1_fe *b) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_equal(const secp256k1_fe *a, const secp256k1_fe *b) {
     secp256k1_fe na;
     SECP256K1_FE_VERIFY(a);
     SECP256K1_FE_VERIFY(b);
@@ -34,7 +34,7 @@ SECP256K1_INLINE static int secp256k1_fe_equal(const secp256k1_fe *a, const secp
     return secp256k1_fe_normalizes_to_zero(&na);
 }
 
-static int secp256k1_fe_sqrt(secp256k1_fe * SECP256K1_RESTRICT r, const secp256k1_fe * SECP256K1_RESTRICT a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_sqrt(secp256k1_fe * SECP256K1_RESTRICT r, const secp256k1_fe * SECP256K1_RESTRICT a) {
     /** Given that p is congruent to 3 mod 4, we can compute the square root of
      *  a mod p as the (p+1)/4'th power of a.
      *
@@ -199,15 +199,15 @@ SECP256K1_INLINE static void secp256k1_fe_normalize_var(secp256k1_fe *r) {
     SECP256K1_FE_VERIFY(r);
 }
 
-static int secp256k1_fe_impl_normalizes_to_zero(const secp256k1_fe *r);
-SECP256K1_INLINE static int secp256k1_fe_normalizes_to_zero(const secp256k1_fe *r) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_normalizes_to_zero(const secp256k1_fe *r);
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_normalizes_to_zero(const secp256k1_fe *r) {
     SECP256K1_FE_VERIFY(r);
 
     return secp256k1_fe_impl_normalizes_to_zero(r);
 }
 
-static int secp256k1_fe_impl_normalizes_to_zero_var(const secp256k1_fe *r);
-SECP256K1_INLINE static int secp256k1_fe_normalizes_to_zero_var(const secp256k1_fe *r) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_normalizes_to_zero_var(const secp256k1_fe *r);
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_normalizes_to_zero_var(const secp256k1_fe *r) {
     SECP256K1_FE_VERIFY(r);
 
     return secp256k1_fe_impl_normalizes_to_zero_var(r);
@@ -236,24 +236,24 @@ SECP256K1_INLINE static void secp256k1_fe_add_int(secp256k1_fe *r, int a) {
     SECP256K1_FE_VERIFY(r);
 }
 
-static int secp256k1_fe_impl_is_zero(const secp256k1_fe *a);
-SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_zero(const secp256k1_fe *a);
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_is_zero(const secp256k1_fe *a) {
     SECP256K1_FE_VERIFY(a);
     VERIFY_CHECK(a->normalized);
 
     return secp256k1_fe_impl_is_zero(a);
 }
 
-static int secp256k1_fe_impl_is_odd(const secp256k1_fe *a);
-SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_odd(const secp256k1_fe *a);
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_is_odd(const secp256k1_fe *a) {
     SECP256K1_FE_VERIFY(a);
     VERIFY_CHECK(a->normalized);
 
     return secp256k1_fe_impl_is_odd(a);
 }
 
-static int secp256k1_fe_impl_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b);
-SECP256K1_INLINE static int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b);
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
     SECP256K1_FE_VERIFY(a);
     SECP256K1_FE_VERIFY(b);
     VERIFY_CHECK(a->normalized);
@@ -271,8 +271,8 @@ SECP256K1_INLINE static void secp256k1_fe_set_b32_mod(secp256k1_fe *r, const uns
     SECP256K1_FE_VERIFY(r);
 }
 
-static int secp256k1_fe_impl_set_b32_limit(secp256k1_fe *r, const unsigned char *a);
-SECP256K1_INLINE static int secp256k1_fe_set_b32_limit(secp256k1_fe *r, const unsigned char *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_set_b32_limit(secp256k1_fe *r, const unsigned char *a);
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_set_b32_limit(secp256k1_fe *r, const unsigned char *a) {
     if (secp256k1_fe_impl_set_b32_limit(r, a)) {
         r->magnitude = 1;
         r->normalized = 1;
@@ -416,8 +416,8 @@ SECP256K1_INLINE static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256
     SECP256K1_FE_VERIFY(r);
 }
 
-static int secp256k1_fe_impl_is_square_var(const secp256k1_fe *x);
-SECP256K1_INLINE static int secp256k1_fe_is_square_var(const secp256k1_fe *x) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_impl_is_square_var(const secp256k1_fe *x);
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_fe_is_square_var(const secp256k1_fe *x) {
     int ret;
     secp256k1_fe tmp = *x, sqrt;
     SECP256K1_FE_VERIFY(x);

--- a/src/group.h
+++ b/src/group.h
@@ -57,19 +57,19 @@ static void secp256k1_ge_set_xy(secp256k1_ge *r, const secp256k1_fe *x, const se
 
 /** Set a group element (affine) equal to the point with the given X coordinate, and given oddness
  *  for Y. Return value indicates whether the result is valid. */
-static int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int odd);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int odd);
 
 /** Determine whether x is a valid X coordinate on the curve. */
-static int secp256k1_ge_x_on_curve_var(const secp256k1_fe *x);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_x_on_curve_var(const secp256k1_fe *x);
 
 /** Determine whether fraction xn/xd is a valid X coordinate on the curve (xd != 0). */
-static int secp256k1_ge_x_frac_on_curve_var(const secp256k1_fe *xn, const secp256k1_fe *xd);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_x_frac_on_curve_var(const secp256k1_fe *xn, const secp256k1_fe *xd);
 
 /** Check whether a group element is the point at infinity. */
-static int secp256k1_ge_is_infinity(const secp256k1_ge *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_is_infinity(const secp256k1_ge *a);
 
 /** Check whether a group element is valid (i.e., on the curve). */
-static int secp256k1_ge_is_valid_var(const secp256k1_ge *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_is_valid_var(const secp256k1_ge *a);
 
 /** Set r equal to the inverse of a (i.e., mirrored around the X axis) */
 static void secp256k1_ge_neg(secp256k1_ge *r, const secp256k1_ge *a);
@@ -107,7 +107,7 @@ static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a
 static void secp256k1_ge_table_set_globalz(size_t len, secp256k1_ge *a, const secp256k1_fe *zr);
 
 /** Check two group elements (affine) for equality in variable time. */
-static int secp256k1_ge_eq_var(const secp256k1_ge *a, const secp256k1_ge *b);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_eq_var(const secp256k1_ge *a, const secp256k1_ge *b);
 
 /** Set a group element (affine) equal to the point at infinity. */
 static void secp256k1_ge_set_infinity(secp256k1_ge *r);
@@ -119,20 +119,20 @@ static void secp256k1_gej_set_infinity(secp256k1_gej *r);
 static void secp256k1_gej_set_ge(secp256k1_gej *r, const secp256k1_ge *a);
 
 /** Check two group elements (jacobian) for equality in variable time. */
-static int secp256k1_gej_eq_var(const secp256k1_gej *a, const secp256k1_gej *b);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_eq_var(const secp256k1_gej *a, const secp256k1_gej *b);
 
 /** Check two group elements (jacobian and affine) for equality in variable time. */
-static int secp256k1_gej_eq_ge_var(const secp256k1_gej *a, const secp256k1_ge *b);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_eq_ge_var(const secp256k1_gej *a, const secp256k1_ge *b);
 
 /** Compare the X coordinate of a group element (jacobian).
   * The magnitude of the group element's X coordinate must not exceed 31. */
-static int secp256k1_gej_eq_x_var(const secp256k1_fe *x, const secp256k1_gej *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_eq_x_var(const secp256k1_fe *x, const secp256k1_gej *a);
 
 /** Set r equal to the inverse of a (i.e., mirrored around the X axis) */
 static void secp256k1_gej_neg(secp256k1_gej *r, const secp256k1_gej *a);
 
 /** Check whether a group element is the point at infinity. */
-static int secp256k1_gej_is_infinity(const secp256k1_gej *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_is_infinity(const secp256k1_gej *a);
 
 /** Set r equal to the double of a. Constant time. */
 static void secp256k1_gej_double(secp256k1_gej *r, const secp256k1_gej *a);
@@ -205,7 +205,7 @@ static void secp256k1_ge_from_bytes_ext(secp256k1_ge *ge, const unsigned char *d
  * (very) small subgroup, and that subgroup is what is used for all cryptographic operations. In that mode, this
  * function checks whether a point that is on the curve is in fact also in that subgroup.
  */
-static int secp256k1_ge_is_in_correct_subgroup(const secp256k1_ge* ge);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_is_in_correct_subgroup(const secp256k1_ge* ge);
 
 /** Check invariants on an affine group element (no-op unless VERIFY is enabled). */
 static void secp256k1_ge_verify(const secp256k1_ge *a);

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -140,7 +140,7 @@ static void secp256k1_ge_set_xy(secp256k1_ge *r, const secp256k1_fe *x, const se
     SECP256K1_GE_VERIFY(r);
 }
 
-static int secp256k1_ge_is_infinity(const secp256k1_ge *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_is_infinity(const secp256k1_ge *a) {
     SECP256K1_GE_VERIFY(a);
 
     return a->infinity;
@@ -344,7 +344,7 @@ static void secp256k1_ge_clear(secp256k1_ge *r) {
     secp256k1_memclear_explicit(r, sizeof(secp256k1_ge));
 }
 
-static int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int odd) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int odd) {
     secp256k1_fe x2, x3;
     int ret;
     SECP256K1_FE_VERIFY(x);
@@ -375,7 +375,7 @@ static void secp256k1_gej_set_ge(secp256k1_gej *r, const secp256k1_ge *a) {
    SECP256K1_GEJ_VERIFY(r);
 }
 
-static int secp256k1_gej_eq_var(const secp256k1_gej *a, const secp256k1_gej *b) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_eq_var(const secp256k1_gej *a, const secp256k1_gej *b) {
     secp256k1_gej tmp;
     SECP256K1_GEJ_VERIFY(b);
     SECP256K1_GEJ_VERIFY(a);
@@ -385,7 +385,7 @@ static int secp256k1_gej_eq_var(const secp256k1_gej *a, const secp256k1_gej *b) 
     return secp256k1_gej_is_infinity(&tmp);
 }
 
-static int secp256k1_gej_eq_ge_var(const secp256k1_gej *a, const secp256k1_ge *b) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_eq_ge_var(const secp256k1_gej *a, const secp256k1_ge *b) {
     secp256k1_gej tmp;
     SECP256K1_GEJ_VERIFY(a);
     SECP256K1_GE_VERIFY(b);
@@ -395,7 +395,7 @@ static int secp256k1_gej_eq_ge_var(const secp256k1_gej *a, const secp256k1_ge *b
     return secp256k1_gej_is_infinity(&tmp);
 }
 
-static int secp256k1_ge_eq_var(const secp256k1_ge *a, const secp256k1_ge *b) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_eq_var(const secp256k1_ge *a, const secp256k1_ge *b) {
     secp256k1_fe tmp;
     SECP256K1_GE_VERIFY(a);
     SECP256K1_GE_VERIFY(b);
@@ -414,7 +414,7 @@ static int secp256k1_ge_eq_var(const secp256k1_ge *a, const secp256k1_ge *b) {
     return 1;
 }
 
-static int secp256k1_gej_eq_x_var(const secp256k1_fe *x, const secp256k1_gej *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_eq_x_var(const secp256k1_fe *x, const secp256k1_gej *a) {
     secp256k1_fe r;
     SECP256K1_FE_VERIFY(x);
     SECP256K1_GEJ_VERIFY(a);
@@ -437,13 +437,13 @@ static void secp256k1_gej_neg(secp256k1_gej *r, const secp256k1_gej *a) {
     SECP256K1_GEJ_VERIFY(r);
 }
 
-static int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
     SECP256K1_GEJ_VERIFY(a);
 
     return a->infinity;
 }
 
-static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
     secp256k1_fe y2, x3;
     SECP256K1_GE_VERIFY(a);
 
@@ -923,7 +923,7 @@ static void secp256k1_ge_mul_lambda(secp256k1_ge *r, const secp256k1_ge *a) {
     SECP256K1_GE_VERIFY(r);
 }
 
-static int secp256k1_ge_is_in_correct_subgroup(const secp256k1_ge* ge) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_is_in_correct_subgroup(const secp256k1_ge* ge) {
 #ifdef EXHAUSTIVE_TEST_ORDER
     secp256k1_gej out;
     int i;
@@ -947,7 +947,7 @@ static int secp256k1_ge_is_in_correct_subgroup(const secp256k1_ge* ge) {
 #endif
 }
 
-static int secp256k1_ge_x_on_curve_var(const secp256k1_fe *x) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_x_on_curve_var(const secp256k1_fe *x) {
     secp256k1_fe c;
     secp256k1_fe_sqr(&c, x);
     secp256k1_fe_mul(&c, &c, x);
@@ -955,7 +955,7 @@ static int secp256k1_ge_x_on_curve_var(const secp256k1_fe *x) {
     return secp256k1_fe_is_square_var(&c);
 }
 
-static int secp256k1_ge_x_frac_on_curve_var(const secp256k1_fe *xn, const secp256k1_fe *xd) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ge_x_frac_on_curve_var(const secp256k1_fe *xn, const secp256k1_fe *xd) {
     /* We want to determine whether (xn/xd) is on the curve.
      *
      * (xn/xd)^3 + 7 is square <=> xd*xn^3 + 7*xd^4 is square (multiplying by xd^4, a square).

--- a/src/int128.h
+++ b/src/int128.h
@@ -45,7 +45,7 @@ static SECP256K1_INLINE void secp256k1_u128_from_u64(secp256k1_uint128 *r, uint6
 /* Tests if r is strictly less than to 2^n.
  * n must be strictly less than 128.
  */
-static SECP256K1_INLINE int secp256k1_u128_check_bits(const secp256k1_uint128 *r, unsigned int n);
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_u128_check_bits(const secp256k1_uint128 *r, unsigned int n);
 
 /* Construct an signed 128-bit value from a high and a low 64-bit value. */
 static SECP256K1_INLINE void secp256k1_i128_load(secp256k1_int128 *r, int64_t hi, uint64_t lo);
@@ -78,12 +78,12 @@ static SECP256K1_INLINE int64_t secp256k1_i128_to_i64(const secp256k1_int128 *a)
 static SECP256K1_INLINE void secp256k1_i128_from_i64(secp256k1_int128 *r, int64_t a);
 
 /* Compare two 128-bit values for equality. */
-static SECP256K1_INLINE int secp256k1_i128_eq_var(const secp256k1_int128 *a, const secp256k1_int128 *b);
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_i128_eq_var(const secp256k1_int128 *a, const secp256k1_int128 *b);
 
 /* Tests if r is equal to sign*2^n (sign must be 1 or -1).
  * n must be strictly less than 127.
  */
-static SECP256K1_INLINE int secp256k1_i128_check_pow2(const secp256k1_int128 *r, unsigned int n, int sign);
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_i128_check_pow2(const secp256k1_int128 *r, unsigned int n, int sign);
 
 #endif
 

--- a/src/int128_native_impl.h
+++ b/src/int128_native_impl.h
@@ -37,7 +37,7 @@ static SECP256K1_INLINE void secp256k1_u128_from_u64(secp256k1_uint128 *r, uint6
    *r = a;
 }
 
-static SECP256K1_INLINE int secp256k1_u128_check_bits(const secp256k1_uint128 *r, unsigned int n) {
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_u128_check_bits(const secp256k1_uint128 *r, unsigned int n) {
    VERIFY_CHECK(n < 128);
    return (*r >> n == 0);
 }
@@ -81,11 +81,11 @@ static SECP256K1_INLINE void secp256k1_i128_from_i64(secp256k1_int128 *r, int64_
    *r = a;
 }
 
-static SECP256K1_INLINE int secp256k1_i128_eq_var(const secp256k1_int128 *a, const secp256k1_int128 *b) {
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_i128_eq_var(const secp256k1_int128 *a, const secp256k1_int128 *b) {
    return *a == *b;
 }
 
-static SECP256K1_INLINE int secp256k1_i128_check_pow2(const secp256k1_int128 *r, unsigned int n, int sign) {
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_i128_check_pow2(const secp256k1_int128 *r, unsigned int n, int sign) {
    VERIFY_CHECK(n < 127);
    VERIFY_CHECK(sign == 1 || sign == -1);
    return (*r == (int128_t)((uint128_t)sign << n));

--- a/src/int128_struct_impl.h
+++ b/src/int128_struct_impl.h
@@ -103,7 +103,7 @@ static SECP256K1_INLINE void secp256k1_u128_from_u64(secp256k1_uint128 *r, uint6
    r->lo = a;
 }
 
-static SECP256K1_INLINE int secp256k1_u128_check_bits(const secp256k1_uint128 *r, unsigned int n) {
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_u128_check_bits(const secp256k1_uint128 *r, unsigned int n) {
    VERIFY_CHECK(n < 128);
    return n >= 64 ? r->hi >> (n - 64) == 0
                   : r->hi == 0 && r->lo >> n == 0;
@@ -191,11 +191,11 @@ static SECP256K1_INLINE void secp256k1_i128_from_i64(secp256k1_int128 *r, int64_
    r->lo = (uint64_t)a;
 }
 
-static SECP256K1_INLINE int secp256k1_i128_eq_var(const secp256k1_int128 *a, const secp256k1_int128 *b) {
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_i128_eq_var(const secp256k1_int128 *a, const secp256k1_int128 *b) {
    return a->hi == b->hi && a->lo == b->lo;
 }
 
-static SECP256K1_INLINE int secp256k1_i128_check_pow2(const secp256k1_int128 *r, unsigned int n, int sign) {
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_i128_check_pow2(const secp256k1_int128 *r, unsigned int n, int sign) {
     VERIFY_CHECK(n < 127);
     VERIFY_CHECK(sign == 1 || sign == -1);
     return n >= 64 ? r->hi == (uint64_t)sign << (n - 64) && r->lo == 0

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -10,7 +10,7 @@
 #include "../../../include/secp256k1_ecdh.h"
 #include "../../ecmult_const_impl.h"
 
-static int ecdh_hash_function_sha256_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char *output, const unsigned char *x32, const unsigned char *y32, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int ecdh_hash_function_sha256_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char *output, const unsigned char *x32, const unsigned char *y32, void *data) {
     unsigned char version = (y32[31] & 0x01) | 0x02;
     secp256k1_sha256 sha;
     (void)data;
@@ -24,7 +24,7 @@ static int ecdh_hash_function_sha256_impl(const secp256k1_hash_ctx *hash_ctx, un
     return 1;
 }
 
-static int ecdh_hash_function_sha256(unsigned char *output, const unsigned char *x32, const unsigned char *y32, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int ecdh_hash_function_sha256(unsigned char *output, const unsigned char *x32, const unsigned char *y32, void *data) {
     return ecdh_hash_function_sha256_impl(secp256k1_get_hash_context(secp256k1_context_static), output, x32, y32, data);
 }
 
@@ -45,7 +45,9 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const se
     ARG_CHECK(point != NULL);
     ARG_CHECK(scalar != NULL);
 
-    secp256k1_pubkey_load(ctx, &pt, point);
+    if (!secp256k1_pubkey_load(ctx, &pt, point)) {
+        return 0;
+    }
     secp256k1_scalar_set_b32(&s, scalar, &overflow);
 
     overflow |= secp256k1_scalar_is_zero(&s);

--- a/src/modules/ellswift/main_impl.h
+++ b/src/modules/ellswift/main_impl.h
@@ -143,7 +143,7 @@ static void secp256k1_ellswift_xswiftec_var(secp256k1_fe *x, const secp256k1_fe 
 static void secp256k1_ellswift_swiftec_var(secp256k1_ge *p, const secp256k1_fe *u, const secp256k1_fe *t) {
     secp256k1_fe x;
     secp256k1_ellswift_xswiftec_var(&x, u, t);
-    VERIFY_CHECK(secp256k1_ge_set_xo_var(p, &x, secp256k1_fe_is_odd(t)));
+    { int _r_ = secp256k1_ge_set_xo_var(p, &x, secp256k1_fe_is_odd(t)); (void)_r_; }
 }
 
 /* Try to complete an ElligatorSwift encoding (u, t) for X coordinate x, given u and x.
@@ -558,7 +558,7 @@ int secp256k1_ellswift_xdh(const secp256k1_context *ctx, unsigned char *output, 
     secp256k1_scalar_cmov(&s, &secp256k1_scalar_one, overflow);
 
     /* Compute shared X coordinate. */
-    (void)secp256k1_ecmult_const_xonly(&px, &xn, &xd, &s, 1);
+    { int _r_ = secp256k1_ecmult_const_xonly(&px, &xn, &xd, &s, 1); (void)_r_; }
     secp256k1_fe_normalize(&px);
     secp256k1_fe_get_b32(sx, &px);
 

--- a/src/modules/ellswift/main_impl.h
+++ b/src/modules/ellswift/main_impl.h
@@ -143,7 +143,7 @@ static void secp256k1_ellswift_xswiftec_var(secp256k1_fe *x, const secp256k1_fe 
 static void secp256k1_ellswift_swiftec_var(secp256k1_ge *p, const secp256k1_fe *u, const secp256k1_fe *t) {
     secp256k1_fe x;
     secp256k1_ellswift_xswiftec_var(&x, u, t);
-    secp256k1_ge_set_xo_var(p, &x, secp256k1_fe_is_odd(t));
+    VERIFY_CHECK(secp256k1_ge_set_xo_var(p, &x, secp256k1_fe_is_odd(t)));
 }
 
 /* Try to complete an ElligatorSwift encoding (u, t) for X coordinate x, given u and x.
@@ -165,7 +165,7 @@ static void secp256k1_ellswift_swiftec_var(secp256k1_ge *p, const secp256k1_fe *
  * encoding more closely: c=0 through c=3 match branches 1..4 in the paper, while c=4 through
  * c=7 are copies of those with an additional negation of sqrt(w).
  */
-static int secp256k1_ellswift_xswiftec_inv_var(secp256k1_fe *t, const secp256k1_fe *x_in, const secp256k1_fe *u_in, int c) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ellswift_xswiftec_inv_var(secp256k1_fe *t, const secp256k1_fe *x_in, const secp256k1_fe *u_in, int c) {
     /* The implemented algorithm is this (all arithmetic, except involving c, is mod p):
      *
      * - If (c & 2) = 0:
@@ -482,7 +482,7 @@ int secp256k1_ellswift_decode(const secp256k1_context *ctx, secp256k1_pubkey *pu
     return 1;
 }
 
-static int ellswift_xdh_hash_function_prefix_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char *output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int ellswift_xdh_hash_function_prefix_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char *output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
     secp256k1_sha256 sha;
 
     secp256k1_sha256_initialize(&sha);
@@ -496,7 +496,7 @@ static int ellswift_xdh_hash_function_prefix_impl(const secp256k1_hash_ctx *hash
     return 1;
 }
 
-static int ellswift_xdh_hash_function_prefix(unsigned char *output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int ellswift_xdh_hash_function_prefix(unsigned char *output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
     return ellswift_xdh_hash_function_prefix_impl(secp256k1_get_hash_context(secp256k1_context_static), output, x32, ell_a64, ell_b64, data);
 }
 
@@ -509,7 +509,7 @@ static void secp256k1_ellswift_sha256_init_bip324(secp256k1_sha256* hash) {
     secp256k1_sha256_initialize_midstate(hash, 64, midstate);
 }
 
-static int ellswift_xdh_hash_function_bip324_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char* output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int ellswift_xdh_hash_function_bip324_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char* output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
     secp256k1_sha256 sha;
 
     (void)data;
@@ -524,7 +524,7 @@ static int ellswift_xdh_hash_function_bip324_impl(const secp256k1_hash_ctx *hash
     return 1;
 }
 
-static int ellswift_xdh_hash_function_bip324(unsigned char* output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int ellswift_xdh_hash_function_bip324(unsigned char* output, const unsigned char *x32, const unsigned char *ell_a64, const unsigned char *ell_b64, void *data) {
     return ellswift_xdh_hash_function_bip324_impl(secp256k1_get_hash_context(secp256k1_context_static), output, x32, ell_a64, ell_b64, data);
 }
 
@@ -558,7 +558,7 @@ int secp256k1_ellswift_xdh(const secp256k1_context *ctx, unsigned char *output, 
     secp256k1_scalar_cmov(&s, &secp256k1_scalar_one, overflow);
 
     /* Compute shared X coordinate. */
-    secp256k1_ecmult_const_xonly(&px, &xn, &xd, &s, 1);
+    (void)secp256k1_ecmult_const_xonly(&px, &xn, &xd, &s, 1);
     secp256k1_fe_normalize(&px);
     secp256k1_fe_get_b32(sx, &px);
 

--- a/src/modules/ellswift/tests_exhaustive_impl.h
+++ b/src/modules/ellswift/tests_exhaustive_impl.h
@@ -31,7 +31,7 @@ static void test_exhaustive_ellswift(const secp256k1_context *ctx, const secp256
 
         /* Decode ellswift pubkey and check that it matches the precomputed group element. */
         secp256k1_ellswift_decode(ctx, &pub_decoded, ell64);
-        secp256k1_pubkey_load(ctx, &ge_decoded, &pub_decoded);
+        CHECK(secp256k1_pubkey_load(ctx, &ge_decoded, &pub_decoded));
         CHECK(secp256k1_ge_eq_var(&ge_decoded, &group[i]));
     }
 }

--- a/src/modules/ellswift/tests_impl.h
+++ b/src/modules/ellswift/tests_impl.h
@@ -308,7 +308,7 @@ void ellswift_compute_shared_secret_tests(void) {
          * because the "hasher" function we use here ignores the ell64 arguments. */
         ret = secp256k1_ellswift_xdh(CTX, share32, ell64, ell64, sec32, i & 1, &ellswift_xdh_hash_x32, NULL);
         CHECK(ret);
-        (void)secp256k1_fe_set_b32_limit(&share_x, share32); /* no overflow is possible */
+        { int _r_ = secp256k1_fe_set_b32_limit(&share_x, share32); (void)_r_; }
         SECP256K1_FE_VERIFY(&share_x);
         /* Compute seckey*pubkey directly. */
         secp256k1_ecmult(&resj, &decj, &sec, NULL);

--- a/src/modules/ellswift/tests_impl.h
+++ b/src/modules/ellswift/tests_impl.h
@@ -251,7 +251,7 @@ void ellswift_encode_decode_roundtrip_tests(void) {
         /* Convert the public key to ElligatorSwift and back. */
         secp256k1_ellswift_encode(CTX, ell64, &pubkey, rnd32);
         secp256k1_ellswift_decode(CTX, &pubkey2, ell64);
-        secp256k1_pubkey_load(CTX, &g2, &pubkey2);
+        CHECK(secp256k1_pubkey_load(CTX, &g2, &pubkey2));
         /* Compare with original. */
         CHECK(secp256k1_ge_eq_var(&g, &g2));
     }
@@ -277,7 +277,7 @@ void ellswift_create_tests(void) {
         CHECK(ret);
         /* Decode it, and compare with traditionally-computed public key. */
         secp256k1_ellswift_decode(CTX, &pub, ell64);
-        secp256k1_pubkey_load(CTX, &dec, &pub);
+        CHECK(secp256k1_pubkey_load(CTX, &dec, &pub));
         secp256k1_ecmult(&res, NULL, &secp256k1_scalar_zero, &sec);
         CHECK(secp256k1_gej_eq_ge_var(&res, &dec));
     }
@@ -301,7 +301,7 @@ void ellswift_compute_shared_secret_tests(void) {
         testrand256_test(ell64);
         testrand256_test(ell64 + 32);
         secp256k1_ellswift_decode(CTX, &pub, ell64);
-        secp256k1_pubkey_load(CTX, &dec, &pub);
+        CHECK(secp256k1_pubkey_load(CTX, &dec, &pub));
         secp256k1_gej_set_ge(&decj, &dec);
         /* Compute the X coordinate of seckey*pubkey using ellswift_xdh. Note that we
          * pass ell64 as claimed (but incorrect) encoding for sec32 here; this works

--- a/src/modules/extrakeys/main_impl.h
+++ b/src/modules/extrakeys/main_impl.h
@@ -11,7 +11,7 @@
 #include "../../../include/secp256k1_extrakeys.h"
 #include "../../util.h"
 
-static SECP256K1_INLINE int secp256k1_xonly_pubkey_load(const secp256k1_context* ctx, secp256k1_ge *ge, const secp256k1_xonly_pubkey *pubkey) {
+static SECP256K1_INLINE SECP256K1_WARN_UNUSED_RESULT int secp256k1_xonly_pubkey_load(const secp256k1_context* ctx, secp256k1_ge *ge, const secp256k1_xonly_pubkey *pubkey) {
     return secp256k1_pubkey_load(ctx, ge, (const secp256k1_pubkey *) pubkey);
 }
 
@@ -85,7 +85,7 @@ int secp256k1_xonly_pubkey_cmp(const secp256k1_context* ctx, const secp256k1_xon
 /** Keeps a group element as is if it has an even Y and otherwise negates it.
  *  y_parity is set to 0 in the former case and to 1 in the latter case.
  *  Requires that the coordinates of r are normalized. */
-static int secp256k1_extrakeys_ge_even_y(secp256k1_ge *r) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_extrakeys_ge_even_y(secp256k1_ge *r) {
     int y_parity = 0;
     VERIFY_CHECK(!secp256k1_ge_is_infinity(r));
 
@@ -159,7 +159,7 @@ static void secp256k1_keypair_save(secp256k1_keypair *keypair, const secp256k1_s
 }
 
 
-static int secp256k1_keypair_seckey_load(const secp256k1_context* ctx, secp256k1_scalar *sk, const secp256k1_keypair *keypair) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_keypair_seckey_load(const secp256k1_context* ctx, secp256k1_scalar *sk, const secp256k1_keypair *keypair) {
     int ret;
 
     ret = secp256k1_scalar_set_b32_seckey(sk, &keypair->data[0]);
@@ -173,7 +173,7 @@ static int secp256k1_keypair_seckey_load(const secp256k1_context* ctx, secp256k1
 /* Load a keypair into pk and sk (if non-NULL). This function declassifies pk
  * and ARG_CHECKs that the keypair is not invalid. It always initializes sk and
  * pk with dummy values. */
-static int secp256k1_keypair_load(const secp256k1_context* ctx, secp256k1_scalar *sk, secp256k1_ge *pk, const secp256k1_keypair *keypair) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_keypair_load(const secp256k1_context* ctx, secp256k1_scalar *sk, secp256k1_ge *pk, const secp256k1_keypair *keypair) {
     int ret;
     const secp256k1_pubkey *pubkey = (const secp256k1_pubkey *)&keypair->data[32];
 

--- a/src/modules/extrakeys/tests_impl.h
+++ b/src/modules/extrakeys/tests_impl.h
@@ -53,8 +53,8 @@ static void test_xonly_pubkey(void) {
     CHECK(secp256k1_xonly_pubkey_from_pubkey(CTX, &xonly_pk, &pk_parity, &pk) == 1);
     CHECK(secp256k1_memcmp_var(&xonly_pk, &pk, sizeof(xonly_pk)) != 0);
     CHECK(pk_parity == 1);
-    secp256k1_pubkey_load(CTX, &pk1, &pk);
-    secp256k1_pubkey_load(CTX, &pk2, (secp256k1_pubkey *) &xonly_pk);
+    CHECK(secp256k1_pubkey_load(CTX, &pk1, &pk));
+    CHECK(secp256k1_pubkey_load(CTX, &pk2, (secp256k1_pubkey *) &xonly_pk));
     CHECK(secp256k1_fe_equal(&pk1.x, &pk2.x) == 1);
     secp256k1_fe_negate(&y, &pk2.y, 1);
     CHECK(secp256k1_fe_equal(&pk1.y, &y) == 1);

--- a/src/modules/musig/keyagg.h
+++ b/src/modules/musig/keyagg.h
@@ -25,7 +25,7 @@ typedef struct {
     int parity_acc;
 } secp256k1_keyagg_cache_internal;
 
-static int secp256k1_keyagg_cache_load(const secp256k1_context* ctx, secp256k1_keyagg_cache_internal *cache_i, const secp256k1_musig_keyagg_cache *cache);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_keyagg_cache_load(const secp256k1_context* ctx, secp256k1_keyagg_cache_internal *cache_i, const secp256k1_musig_keyagg_cache *cache);
 
 static void secp256k1_musig_keyaggcoef(const secp256k1_hash_ctx *hash_ctx, secp256k1_scalar *r, const secp256k1_keyagg_cache_internal *cache_i, secp256k1_ge *pk);
 

--- a/src/modules/musig/keyagg_impl.h
+++ b/src/modules/musig/keyagg_impl.h
@@ -208,7 +208,7 @@ int secp256k1_musig_pubkey_agg(const secp256k1_context* ctx, secp256k1_xonly_pub
     }
 
     if (agg_pk != NULL) {
-        secp256k1_extrakeys_ge_even_y(&pkp);
+        { int _r_ = secp256k1_extrakeys_ge_even_y(&pkp); (void)_r_; }
         secp256k1_xonly_pubkey_save(agg_pk, &pkp);
     }
     return 1;

--- a/src/modules/musig/keyagg_impl.h
+++ b/src/modules/musig/keyagg_impl.h
@@ -43,7 +43,7 @@ static void secp256k1_keyagg_cache_save(secp256k1_musig_keyagg_cache *cache, con
     secp256k1_scalar_get_b32(ptr, &cache_i->tweak);
 }
 
-static int secp256k1_keyagg_cache_load(const secp256k1_context* ctx, secp256k1_keyagg_cache_internal *cache_i, const secp256k1_musig_keyagg_cache *cache) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_keyagg_cache_load(const secp256k1_context* ctx, secp256k1_keyagg_cache_internal *cache_i, const secp256k1_musig_keyagg_cache *cache) {
     const unsigned char *ptr = cache->data;
     ARG_CHECK(secp256k1_memcmp_var(ptr, secp256k1_musig_keyagg_cache_magic, 4) == 0);
     ptr += 4;
@@ -70,7 +70,7 @@ static void secp256k1_musig_keyagglist_sha256(secp256k1_sha256 *sha) {
 }
 
 /* Computes pks_hash = tagged_hash(pk[0], ..., pk[np-1]) */
-static int secp256k1_musig_compute_pks_hash(const secp256k1_context *ctx, unsigned char *pks_hash, const secp256k1_pubkey * const* pks, size_t np) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_compute_pks_hash(const secp256k1_context *ctx, unsigned char *pks_hash, const secp256k1_pubkey * const* pks, size_t np) {
     secp256k1_sha256 sha;
     size_t i;
 
@@ -138,7 +138,7 @@ typedef struct {
 } secp256k1_musig_pubkey_agg_ecmult_data;
 
 /* Callback for batch EC multiplication to compute keyaggcoef_0*P0 + keyaggcoef_1*P1 + ...  */
-static int secp256k1_musig_pubkey_agg_callback(secp256k1_scalar *sc, secp256k1_ge *pt, size_t idx, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_pubkey_agg_callback(secp256k1_scalar *sc, secp256k1_ge *pt, size_t idx, void *data) {
     secp256k1_musig_pubkey_agg_ecmult_data *ctx = (secp256k1_musig_pubkey_agg_ecmult_data *) data;
     int ret;
     ret = secp256k1_pubkey_load(ctx->ctx, pt, ctx->pks[idx]);
@@ -228,7 +228,7 @@ int secp256k1_musig_pubkey_get(const secp256k1_context* ctx, secp256k1_pubkey *a
     return 1;
 }
 
-static int secp256k1_musig_pubkey_tweak_add_internal(const secp256k1_context* ctx, secp256k1_pubkey *output_pubkey, secp256k1_musig_keyagg_cache *keyagg_cache, const unsigned char *tweak32, int xonly) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_pubkey_tweak_add_internal(const secp256k1_context* ctx, secp256k1_pubkey *output_pubkey, secp256k1_musig_keyagg_cache *keyagg_cache, const unsigned char *tweak32, int xonly) {
     secp256k1_keyagg_cache_internal cache_i;
     int overflow = 0;
     secp256k1_scalar tweak;

--- a/src/modules/musig/session.h
+++ b/src/modules/musig/session.h
@@ -19,6 +19,6 @@ typedef struct {
     secp256k1_scalar s_part;
 } secp256k1_musig_session_internal;
 
-static int secp256k1_musig_session_load(const secp256k1_context* ctx, secp256k1_musig_session_internal *session_i, const secp256k1_musig_session *session);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_session_load(const secp256k1_context* ctx, secp256k1_musig_session_internal *session_i, const secp256k1_musig_session *session);
 
 #endif

--- a/src/modules/musig/session_impl.h
+++ b/src/modules/musig/session_impl.h
@@ -32,7 +32,7 @@ static void secp256k1_musig_ge_serialize_ext(unsigned char *out33, secp256k1_ge*
 
 /* Outputs the point at infinity if the given byte array is all zero, otherwise
  * attempts to parse compressed point serialization. */
-static int secp256k1_musig_ge_parse_ext(secp256k1_ge* ge, const unsigned char *in33) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_ge_parse_ext(secp256k1_ge* ge, const unsigned char *in33) {
     unsigned char zeros[33] = { 0 };
 
     if (secp256k1_memcmp_var(in33, zeros, sizeof(zeros)) == 0) {
@@ -54,7 +54,7 @@ static void secp256k1_musig_secnonce_save(secp256k1_musig_secnonce *secnonce, co
     secp256k1_ge_to_bytes(&secnonce->data[68], pk);
 }
 
-static int secp256k1_musig_secnonce_load(const secp256k1_context* ctx, secp256k1_scalar *k, secp256k1_ge *pk, const secp256k1_musig_secnonce *secnonce) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_secnonce_load(const secp256k1_context* ctx, secp256k1_scalar *k, secp256k1_ge *pk, const secp256k1_musig_secnonce *secnonce) {
     int is_zero;
     ARG_CHECK(secp256k1_memcmp_var(&secnonce->data[0], secp256k1_musig_secnonce_magic, 4) == 0);
     /* We make very sure that the nonce isn't invalidated by checking the values
@@ -95,7 +95,7 @@ static void secp256k1_musig_pubnonce_save(secp256k1_musig_pubnonce* nonce, const
 
 /* Loads two group elements from a pubnonce. Returns 1 unless the nonce wasn't
  * properly initialized */
-static int secp256k1_musig_pubnonce_load(const secp256k1_context* ctx, secp256k1_ge* ges, const secp256k1_musig_pubnonce* nonce) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_pubnonce_load(const secp256k1_context* ctx, secp256k1_ge* ges, const secp256k1_musig_pubnonce* nonce) {
     int i;
 
     ARG_CHECK(secp256k1_memcmp_var(&nonce->data[0], secp256k1_musig_pubnonce_magic, 4) == 0);
@@ -115,7 +115,7 @@ static void secp256k1_musig_aggnonce_save(secp256k1_musig_aggnonce* nonce, const
     }
 }
 
-static int secp256k1_musig_aggnonce_load(const secp256k1_context* ctx, secp256k1_ge* ges, const secp256k1_musig_aggnonce* nonce) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_aggnonce_load(const secp256k1_context* ctx, secp256k1_ge* ges, const secp256k1_musig_aggnonce* nonce) {
     int i;
 
     ARG_CHECK(secp256k1_memcmp_var(&nonce->data[0], secp256k1_musig_aggnonce_magic, 4) == 0);
@@ -151,7 +151,7 @@ static void secp256k1_musig_session_save(secp256k1_musig_session *session, const
     secp256k1_scalar_get_b32(ptr, &session_i->s_part);
 }
 
-static int secp256k1_musig_session_load(const secp256k1_context* ctx, secp256k1_musig_session_internal *session_i, const secp256k1_musig_session *session) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_session_load(const secp256k1_context* ctx, secp256k1_musig_session_internal *session_i, const secp256k1_musig_session *session) {
     const unsigned char *ptr = session->data;
 
     ARG_CHECK(secp256k1_memcmp_var(ptr, secp256k1_musig_session_cache_magic, 4) == 0);
@@ -175,7 +175,7 @@ static void secp256k1_musig_partial_sig_save(secp256k1_musig_partial_sig* sig, s
     secp256k1_scalar_get_b32(&sig->data[4], s);
 }
 
-static int secp256k1_musig_partial_sig_load(const secp256k1_context* ctx, secp256k1_scalar *s, const secp256k1_musig_partial_sig* sig) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_partial_sig_load(const secp256k1_context* ctx, secp256k1_scalar *s, const secp256k1_musig_partial_sig* sig) {
     int overflow;
 
     ARG_CHECK(secp256k1_memcmp_var(&sig->data[0], secp256k1_musig_partial_sig_magic, 4) == 0);
@@ -369,7 +369,7 @@ static void secp256k1_nonce_function_musig(const secp256k1_hash_ctx *hash_ctx, s
     secp256k1_sha256_clear(&sha);
 }
 
-static int secp256k1_musig_nonce_gen_internal(const secp256k1_context* ctx, secp256k1_musig_secnonce *secnonce, secp256k1_musig_pubnonce *pubnonce, const unsigned char *input_nonce, const unsigned char *seckey, const secp256k1_pubkey *pubkey, const unsigned char *msg32, const secp256k1_musig_keyagg_cache *keyagg_cache, const unsigned char *extra_input32) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_nonce_gen_internal(const secp256k1_context* ctx, secp256k1_musig_secnonce *secnonce, secp256k1_musig_pubnonce *pubnonce, const unsigned char *input_nonce, const unsigned char *seckey, const secp256k1_pubkey *pubkey, const unsigned char *msg32, const secp256k1_musig_keyagg_cache *keyagg_cache, const unsigned char *extra_input32) {
     secp256k1_scalar k[2];
     secp256k1_ge nonce_pts[2];
     secp256k1_gej nonce_ptj[2];
@@ -488,7 +488,7 @@ int secp256k1_musig_nonce_gen_counter(const secp256k1_context* ctx, secp256k1_mu
     return ret;
 }
 
-static int secp256k1_musig_sum_pubnonces(const secp256k1_context* ctx, secp256k1_gej *summed_pubnonces, const secp256k1_musig_pubnonce * const* pubnonces, size_t n_pubnonces) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_musig_sum_pubnonces(const secp256k1_context* ctx, secp256k1_gej *summed_pubnonces, const secp256k1_musig_pubnonce * const* pubnonces, size_t n_pubnonces) {
     size_t i;
     int j;
 

--- a/src/modules/musig/tests_impl.h
+++ b/src/modules/musig/tests_impl.h
@@ -104,7 +104,7 @@ static void pubnonce_summing_to_inf(secp256k1_musig_pubnonce *pubnonce) {
         secp256k1_ge_neg(&ge[1], &ge[1]);
     }
 
-    secp256k1_musig_sum_pubnonces(CTX, summed_pubnonces, pubnonce_ptr, 2);
+    CHECK(secp256k1_musig_sum_pubnonces(CTX, summed_pubnonces, pubnonce_ptr, 2));
     CHECK(secp256k1_gej_is_infinity(&summed_pubnonces[0]));
     CHECK(secp256k1_gej_is_infinity(&summed_pubnonces[1]));
 }
@@ -372,7 +372,7 @@ static void musig_api_tests(void) {
     {
         /* Check that the aggnonce encodes two points at infinity */
         secp256k1_ge aggnonce_pt[2];
-        secp256k1_musig_aggnonce_load(CTX, aggnonce_pt, &aggnonce);
+        CHECK(secp256k1_musig_aggnonce_load(CTX, aggnonce_pt, &aggnonce));
         for (i = 0; i < 2; i++) {
             CHECK(secp256k1_ge_is_infinity(&aggnonce_pt[i]) == 1);
         }

--- a/src/modules/recovery/main_impl.h
+++ b/src/modules/recovery/main_impl.h
@@ -84,7 +84,7 @@ int secp256k1_ecdsa_recoverable_signature_convert(const secp256k1_context* ctx, 
     return 1;
 }
 
-static int secp256k1_ecdsa_sig_recover(const secp256k1_scalar *sigr, const secp256k1_scalar* sigs, secp256k1_ge *pubkey, const secp256k1_scalar *message, int recid) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sig_recover(const secp256k1_scalar *sigr, const secp256k1_scalar* sigs, secp256k1_ge *pubkey, const secp256k1_scalar *message, int recid) {
     unsigned char brx[32];
     secp256k1_fe fx;
     secp256k1_ge x;

--- a/src/modules/schnorrsig/main_impl.h
+++ b/src/modules/schnorrsig/main_impl.h
@@ -37,7 +37,7 @@ static const unsigned char bip340_algo[] = {'B', 'I', 'P', '0', '3', '4', '0', '
 
 static const unsigned char schnorrsig_extraparams_magic[4] = SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC;
 
-static int nonce_function_bip340_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char *nonce32, const unsigned char *msg, size_t msglen, const unsigned char *key32, const unsigned char *xonly_pk32, const unsigned char *algo, size_t algolen, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int nonce_function_bip340_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char *nonce32, const unsigned char *msg, size_t msglen, const unsigned char *key32, const unsigned char *xonly_pk32, const unsigned char *algo, size_t algolen, void *data) {
     secp256k1_sha256 sha;
     unsigned char masked_key[32];
     int i;
@@ -87,7 +87,7 @@ static int nonce_function_bip340_impl(const secp256k1_hash_ctx *hash_ctx, unsign
     return 1;
 }
 
-static int nonce_function_bip340(unsigned char *nonce32, const unsigned char *msg, size_t msglen, const unsigned char *key32, const unsigned char *xonly_pk32, const unsigned char *algo, size_t algolen, void *data) {
+static SECP256K1_WARN_UNUSED_RESULT int nonce_function_bip340(unsigned char *nonce32, const unsigned char *msg, size_t msglen, const unsigned char *key32, const unsigned char *xonly_pk32, const unsigned char *algo, size_t algolen, void *data) {
     return nonce_function_bip340_impl(secp256k1_get_hash_context(secp256k1_context_static), nonce32, msg, msglen, key32, xonly_pk32, algo, algolen, data);
 }
 
@@ -119,7 +119,7 @@ static void secp256k1_schnorrsig_challenge(const secp256k1_hash_ctx *hash_ctx, s
     secp256k1_scalar_set_b32(e, buf, NULL);
 }
 
-static int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg, size_t msglen, const secp256k1_keypair *keypair, secp256k1_nonce_function_hardened noncefp, void *ndata) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg, size_t msglen, const secp256k1_keypair *keypair, secp256k1_nonce_function_hardened noncefp, void *ndata) {
     secp256k1_scalar sk;
     secp256k1_scalar e;
     secp256k1_scalar k;

--- a/src/scalar.h
+++ b/src/scalar.h
@@ -37,7 +37,7 @@ static void secp256k1_scalar_set_b32(secp256k1_scalar *r, const unsigned char *b
 
 /** Set a scalar from a big endian byte array and returns 1 if it is a valid
  *  seckey and 0 otherwise. */
-static int secp256k1_scalar_set_b32_seckey(secp256k1_scalar *r, const unsigned char *bin);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_set_b32_seckey(secp256k1_scalar *r, const unsigned char *bin);
 
 /** Set a scalar to an unsigned integer. */
 static void secp256k1_scalar_set_int(secp256k1_scalar *r, unsigned int v);
@@ -67,23 +67,23 @@ static void secp256k1_scalar_negate(secp256k1_scalar *r, const secp256k1_scalar 
 static void secp256k1_scalar_half(secp256k1_scalar *r, const secp256k1_scalar *a);
 
 /** Check whether a scalar equals zero. */
-static int secp256k1_scalar_is_zero(const secp256k1_scalar *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_zero(const secp256k1_scalar *a);
 
 /** Check whether a scalar equals one. */
-static int secp256k1_scalar_is_one(const secp256k1_scalar *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_one(const secp256k1_scalar *a);
 
 /** Check whether a scalar, considered as an nonnegative integer, is even. */
-static int secp256k1_scalar_is_even(const secp256k1_scalar *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_even(const secp256k1_scalar *a);
 
 /** Check whether a scalar is higher than the group order divided by 2. */
-static int secp256k1_scalar_is_high(const secp256k1_scalar *a);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_high(const secp256k1_scalar *a);
 
 /** Conditionally negate a number, in constant time. Flag must be 0 or 1.
  * Returns -1 if the number was negated, 1 otherwise */
 static int secp256k1_scalar_cond_negate(secp256k1_scalar *a, int flag);
 
 /** Compare two scalars. */
-static int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b);
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b);
 
 /** Find r1 and r2 such that r1+r2*2^128 = k. */
 static void secp256k1_scalar_split_128(secp256k1_scalar *r1, secp256k1_scalar *r2, const secp256k1_scalar *k);

--- a/src/scalar_4x64_impl.h
+++ b/src/scalar_4x64_impl.h
@@ -59,7 +59,7 @@ SECP256K1_INLINE static uint32_t secp256k1_scalar_get_bits_var(const secp256k1_s
     }
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_check_overflow(const secp256k1_scalar *a) {
     int yes = 0;
     int no = 0;
     no |= (a->d[3] < SECP256K1_N_3); /* No need for a > check. */
@@ -71,7 +71,7 @@ SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scal
     return yes;
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_reduce(secp256k1_scalar *r, unsigned int overflow) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_reduce(secp256k1_scalar *r, unsigned int overflow) {
     secp256k1_uint128 t;
     VERIFY_CHECK(overflow <= 1);
 
@@ -165,7 +165,7 @@ static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar*
     secp256k1_write_be64(&bin[24], a->d[0]);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return (a->d[0] | a->d[1] | a->d[2] | a->d[3]) == 0;
@@ -233,13 +233,13 @@ static void secp256k1_scalar_half(secp256k1_scalar *r, const secp256k1_scalar *a
 #endif
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return ((a->d[0] ^ 1) | a->d[1] | a->d[2] | a->d[3]) == 0;
 }
 
-static int secp256k1_scalar_is_high(const secp256k1_scalar *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_high(const secp256k1_scalar *a) {
     int yes = 0;
     int no = 0;
     SECP256K1_SCALAR_VERIFY(a);
@@ -881,7 +881,7 @@ static void secp256k1_scalar_split_128(secp256k1_scalar *r1, secp256k1_scalar *r
     SECP256K1_SCALAR_VERIFY(r2);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b) {
     SECP256K1_SCALAR_VERIFY(a);
     SECP256K1_SCALAR_VERIFY(b);
 
@@ -994,7 +994,7 @@ static void secp256k1_scalar_inverse_var(secp256k1_scalar *r, const secp256k1_sc
     VERIFY_CHECK(secp256k1_scalar_is_zero(r) == zero_in);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_even(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_even(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return !(a->d[0] & 1);

--- a/src/scalar_4x64_impl.h
+++ b/src/scalar_4x64_impl.h
@@ -111,7 +111,7 @@ static int secp256k1_scalar_add(secp256k1_scalar *r, const secp256k1_scalar *a, 
     r->d[3] = secp256k1_u128_to_u64(&t); secp256k1_u128_rshift(&t, 64);
     overflow = secp256k1_u128_to_u64(&t) + secp256k1_scalar_check_overflow(r);
     VERIFY_CHECK(overflow == 0 || overflow == 1);
-    secp256k1_scalar_reduce(r, overflow);
+    { int _r_ = secp256k1_scalar_reduce(r, overflow); (void)_r_; }
 
     SECP256K1_SCALAR_VERIFY(r);
     return overflow;
@@ -674,7 +674,7 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint64_t *l) 
 #endif
 
     /* Final reduction of r. */
-    secp256k1_scalar_reduce(r, c + secp256k1_scalar_check_overflow(r));
+    { int _r_ = secp256k1_scalar_reduce(r, c + secp256k1_scalar_check_overflow(r)); (void)_r_; }
 }
 
 static void secp256k1_scalar_mul_512(uint64_t *l8, const secp256k1_scalar *a, const secp256k1_scalar *b) {

--- a/src/scalar_8x32_impl.h
+++ b/src/scalar_8x32_impl.h
@@ -138,7 +138,7 @@ static int secp256k1_scalar_add(secp256k1_scalar *r, const secp256k1_scalar *a, 
     r->d[7] = t & 0xFFFFFFFFULL; t >>= 32;
     overflow = t + secp256k1_scalar_check_overflow(r);
     VERIFY_CHECK(overflow == 0 || overflow == 1);
-    secp256k1_scalar_reduce(r, overflow);
+    { int _r_ = secp256k1_scalar_reduce(r, overflow); (void)_r_; }
 
     SECP256K1_SCALAR_VERIFY(r);
     return overflow;
@@ -542,7 +542,7 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint32_t *l) 
     r->d[7] = c & 0xFFFFFFFFUL; c >>= 32;
 
     /* Final reduction of r. */
-    secp256k1_scalar_reduce(r, c + secp256k1_scalar_check_overflow(r));
+    { int _r_ = secp256k1_scalar_reduce(r, c + secp256k1_scalar_check_overflow(r)); (void)_r_; }
 }
 
 static void secp256k1_scalar_mul_512(uint32_t *l, const secp256k1_scalar *a, const secp256k1_scalar *b) {

--- a/src/scalar_8x32_impl.h
+++ b/src/scalar_8x32_impl.h
@@ -72,7 +72,7 @@ SECP256K1_INLINE static uint32_t secp256k1_scalar_get_bits_var(const secp256k1_s
     }
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_check_overflow(const secp256k1_scalar *a) {
     int yes = 0;
     int no = 0;
     no |= (a->d[7] < SECP256K1_N_7); /* No need for a > check. */
@@ -90,7 +90,7 @@ SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scal
     return yes;
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_reduce(secp256k1_scalar *r, uint32_t overflow) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_reduce(secp256k1_scalar *r, uint32_t overflow) {
     uint64_t t;
     VERIFY_CHECK(overflow <= 1);
 
@@ -204,7 +204,7 @@ static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar*
     secp256k1_write_be32(&bin[28], a->d[0]);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return (a->d[0] | a->d[1] | a->d[2] | a->d[3] | a->d[4] | a->d[5] | a->d[6] | a->d[7]) == 0;
@@ -282,13 +282,13 @@ static void secp256k1_scalar_half(secp256k1_scalar *r, const secp256k1_scalar *a
     SECP256K1_SCALAR_VERIFY(r);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return ((a->d[0] ^ 1) | a->d[1] | a->d[2] | a->d[3] | a->d[4] | a->d[5] | a->d[6] | a->d[7]) == 0;
 }
 
-static int secp256k1_scalar_is_high(const secp256k1_scalar *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_high(const secp256k1_scalar *a) {
     int yes = 0;
     int no = 0;
     SECP256K1_SCALAR_VERIFY(a);
@@ -675,7 +675,7 @@ static void secp256k1_scalar_split_128(secp256k1_scalar *r1, secp256k1_scalar *r
     SECP256K1_SCALAR_VERIFY(r2);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b) {
     SECP256K1_SCALAR_VERIFY(a);
     SECP256K1_SCALAR_VERIFY(b);
 
@@ -810,7 +810,7 @@ static void secp256k1_scalar_inverse_var(secp256k1_scalar *r, const secp256k1_sc
     VERIFY_CHECK(secp256k1_scalar_is_zero(r) == zero_in);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_even(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_even(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return !(a->d[0] & 1);

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -31,7 +31,7 @@ SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar *r) {
     secp256k1_memclear_explicit(r, sizeof(secp256k1_scalar));
 }
 
-static int secp256k1_scalar_set_b32_seckey(secp256k1_scalar *r, const unsigned char *bin) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_set_b32_seckey(secp256k1_scalar *r, const unsigned char *bin) {
     int overflow;
     secp256k1_scalar_set_b32(r, bin, &overflow);
 

--- a/src/scalar_low_impl.h
+++ b/src/scalar_low_impl.h
@@ -13,7 +13,7 @@
 
 #include <string.h>
 
-SECP256K1_INLINE static int secp256k1_scalar_is_even(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_even(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return !(*a & 1);
@@ -42,7 +42,7 @@ SECP256K1_INLINE static uint32_t secp256k1_scalar_get_bits_var(const secp256k1_s
     return secp256k1_scalar_get_bits_limb32(a, offset, count);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scalar *a) { return *a >= EXHAUSTIVE_TEST_ORDER; }
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_check_overflow(const secp256k1_scalar *a) { return *a >= EXHAUSTIVE_TEST_ORDER; }
 
 static int secp256k1_scalar_add(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b) {
     SECP256K1_SCALAR_VERIFY(a);
@@ -90,7 +90,7 @@ static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar*
     bin[28] = *a >> 24; bin[29] = *a >> 16; bin[30] = *a >> 8; bin[31] = *a;
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return *a == 0;
@@ -108,13 +108,13 @@ static void secp256k1_scalar_negate(secp256k1_scalar *r, const secp256k1_scalar 
     SECP256K1_SCALAR_VERIFY(r);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return *a == 1;
 }
 
-static int secp256k1_scalar_is_high(const secp256k1_scalar *a) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_is_high(const secp256k1_scalar *a) {
     SECP256K1_SCALAR_VERIFY(a);
 
     return *a > EXHAUSTIVE_TEST_ORDER / 2;
@@ -149,7 +149,7 @@ static void secp256k1_scalar_split_128(secp256k1_scalar *r1, secp256k1_scalar *r
     SECP256K1_SCALAR_VERIFY(r2);
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b) {
+SECP256K1_INLINE static SECP256K1_WARN_UNUSED_RESULT int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b) {
     SECP256K1_SCALAR_VERIFY(a);
     SECP256K1_SCALAR_VERIFY(b);
 

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -81,7 +81,7 @@ const secp256k1_context * const secp256k1_context_no_precomp = &secp256k1_contex
  * This is intended for "context" functions such as secp256k1_context_clone. Functions that need specific
  * features of a context should still check for these features directly. For example, a function that needs
  * ecmult_gen should directly check for the existence of the ecmult_gen context. */
-static int secp256k1_context_is_proper(const secp256k1_context* ctx) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_is_proper(const secp256k1_context* ctx) {
     return secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx);
 }
 
@@ -256,7 +256,7 @@ static SECP256K1_INLINE void secp256k1_declassify(const secp256k1_context* ctx, 
     if (EXPECT(ctx->declassify, 0)) SECP256K1_CHECKMEM_DEFINE(p, len);
 }
 
-static int secp256k1_pubkey_load(const secp256k1_context* ctx, secp256k1_ge* ge, const secp256k1_pubkey* pubkey) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_pubkey_load(const secp256k1_context* ctx, secp256k1_ge* ge, const secp256k1_pubkey* pubkey) {
     secp256k1_ge_from_bytes(ge, pubkey->data);
     ARG_CHECK(!secp256k1_fe_is_zero(&ge->x));
     return 1;
@@ -336,7 +336,7 @@ int secp256k1_ec_pubkey_cmp(const secp256k1_context* ctx, const secp256k1_pubkey
     return secp256k1_memcmp_var(out[0], out[1], sizeof(out[0]));
 }
 
-static int secp256k1_ec_pubkey_sort_cmp(const void* pk1, const void* pk2, void *ctx) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_sort_cmp(const void* pk1, const void* pk2, void *ctx) {
     return secp256k1_ec_pubkey_cmp((secp256k1_context *)ctx,
                                      *(secp256k1_pubkey **)pk1,
                                      *(secp256k1_pubkey **)pk2);
@@ -495,7 +495,7 @@ static SECP256K1_INLINE void buffer_append(unsigned char *buf, unsigned int *off
     *offset += len;
 }
 
-static int nonce_function_rfc6979_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char *nonce32, const unsigned char *msg32, const unsigned char *key32, const unsigned char *algo16, void *data, unsigned int counter) {
+static SECP256K1_WARN_UNUSED_RESULT int nonce_function_rfc6979_impl(const secp256k1_hash_ctx *hash_ctx, unsigned char *nonce32, const unsigned char *msg32, const unsigned char *key32, const unsigned char *algo16, void *data, unsigned int counter) {
    unsigned char keydata[112];
    unsigned int offset = 0;
    secp256k1_rfc6979_hmac_sha256 rng;
@@ -531,14 +531,14 @@ static int nonce_function_rfc6979_impl(const secp256k1_hash_ctx *hash_ctx, unsig
    return 1;
 }
 
-static int nonce_function_rfc6979(unsigned char *nonce32, const unsigned char *msg32, const unsigned char *key32, const unsigned char *algo16, void *data, unsigned int counter) {
+static SECP256K1_WARN_UNUSED_RESULT int nonce_function_rfc6979(unsigned char *nonce32, const unsigned char *msg32, const unsigned char *key32, const unsigned char *algo16, void *data, unsigned int counter) {
     return nonce_function_rfc6979_impl(secp256k1_get_hash_context(secp256k1_context_static), nonce32, msg32, key32, algo16, data, counter);
 }
 
 const secp256k1_nonce_function secp256k1_nonce_function_rfc6979 = nonce_function_rfc6979;
 const secp256k1_nonce_function secp256k1_nonce_function_default = nonce_function_rfc6979;
 
-static int secp256k1_ecdsa_sign_inner(const secp256k1_context* ctx, secp256k1_scalar* r, secp256k1_scalar* s, int* recid, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_sign_inner(const secp256k1_context* ctx, secp256k1_scalar* r, secp256k1_scalar* s, int* recid, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
     secp256k1_scalar sec, non, msg;
     int ret = 0;
     int is_sec_valid;
@@ -623,7 +623,7 @@ int secp256k1_ec_seckey_verify(const secp256k1_context* ctx, const unsigned char
     return ret;
 }
 
-static int secp256k1_ec_pubkey_create_helper(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_scalar *seckey_scalar, secp256k1_ge *p, const unsigned char *seckey) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create_helper(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_scalar *seckey_scalar, secp256k1_ge *p, const unsigned char *seckey) {
     int ret;
 
     ret = secp256k1_scalar_set_b32_seckey(seckey_scalar, seckey);
@@ -682,7 +682,7 @@ int secp256k1_ec_pubkey_negate(const secp256k1_context* ctx, secp256k1_pubkey *p
 }
 
 
-static int secp256k1_ec_seckey_tweak_add_helper(secp256k1_scalar *sec, const unsigned char *tweak32) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_tweak_add_helper(secp256k1_scalar *sec, const unsigned char *tweak32) {
     secp256k1_scalar term;
     int overflow = 0;
     int ret = 0;
@@ -709,7 +709,7 @@ int secp256k1_ec_seckey_tweak_add(const secp256k1_context* ctx, unsigned char *s
     return ret;
 }
 
-static int secp256k1_ec_pubkey_tweak_add_helper(secp256k1_ge *p, const unsigned char *tweak32) {
+static SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add_helper(secp256k1_ge *p, const unsigned char *tweak32) {
     secp256k1_scalar term;
     int overflow = 0;
     secp256k1_scalar_set_b32(&term, tweak32, &overflow);
@@ -801,7 +801,9 @@ int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *
 
     for (i = 0; i < n; i++) {
         ARG_CHECK(pubnonces[i] != NULL);
-        secp256k1_pubkey_load(ctx, &Q, pubnonces[i]);
+        if (!secp256k1_pubkey_load(ctx, &Q, pubnonces[i])) {
+            return 0;
+        }
         secp256k1_gej_add_ge(&Qj, &Qj, &Q);
     }
     if (secp256k1_gej_is_infinity(&Qj)) {


### PR DESCRIPTION
Annotate all static int functions in the library (non-test code) with `SECP256K1_WARN_UNUSED_RESULT` so that compilers can warn when return values are accidentally discarded. This covers ~140 functions across all modules.

Changes:
- Add `SECP256K1_WARN_UNUSED_RESULT` to field, scalar, group, eckey, ecmult, ecdsa, int128 utility functions and all module header/impl files
- Fix call sites where return values were being discarded:
  - `secp256k1_ec_pubkey_combine`: check `pubkey_load` return
  - `secp256k1_ecdh`: check `pubkey_load` return
  - `secp256k1_ellswift_swiftec_var`, `ellswift_xdh`: use assignment pattern
  - `bench_internal.c`, `bench_ecmult.c`, test files: wrap in `CHECK()`
- Exclude `scalar_add` and `scalar_cond_negate` whose returns are intentionally informational/redundant at all existing call sites

See #1610 for prior discussion.