### PR TITLE
field: correct `fe_equal` magnitude bound for `b`

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -166,7 +166,7 @@ static int secp256k1_fe_is_odd(const secp256k1_fe *a);
 /** Determine whether two field elements are equal.
  *
  * On input, a and b must be valid field elements with magnitudes not exceeding
- * 1 and 31, respectively.
+ * 1 and 30, respectively.
  * Returns a = b (mod p).
  */
 static int secp256k1_fe_equal(const secp256k1_fe *a, const secp256k1_fe *b);

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -27,7 +27,7 @@ SECP256K1_INLINE static int secp256k1_fe_equal(const secp256k1_fe *a, const secp
     SECP256K1_FE_VERIFY(a);
     SECP256K1_FE_VERIFY(b);
     SECP256K1_FE_VERIFY_MAGNITUDE(a, 1);
-    SECP256K1_FE_VERIFY_MAGNITUDE(b, 31);
+    SECP256K1_FE_VERIFY_MAGNITUDE(b, 30);
 
     secp256k1_fe_negate(&na, a, 1);
     secp256k1_fe_add(&na, b);

--- a/src/tests.c
+++ b/src/tests.c
@@ -3064,6 +3064,18 @@ static int fe_equal(const secp256k1_fe *a, const secp256k1_fe *b) {
     return secp256k1_fe_equal(&an, &bn);
 }
 
+static void run_fe_equal_magnitude_boundaries(void) {
+    int i;
+    secp256k1_fe a, b;
+    for (i = 0; i < 100 * COUNT; ++i) {
+        testutil_random_fe(&a);
+        b = a;
+        testutil_random_fe_magnitude(&a, 1);
+        testutil_random_fe_magnitude(&b, 30);
+        CHECK(secp256k1_fe_equal(&a, &b));
+    }
+}
+
 static void run_field_convert(void) {
     static const unsigned char b32[32] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -7970,6 +7982,7 @@ static const struct tf_test_entry tests_scalar[] = {
 static const struct tf_test_entry tests_field[] = {
     CASE(field_half),
     CASE(field_misc),
+    CASE(fe_equal_magnitude_boundaries),
     CASE(field_convert),
     CASE(field_be32_overflow),
     CASE(fe_mul),


### PR DESCRIPTION
**Problem:** While reviewing this area with Fable, I noticed that `secp256k1_fe_equal(a, b)` documented `b` up to magnitude 31.
Review pointed out that the implementation negates `a` before adding `b`, so the actual internal bound is 30.

**Fix:** Lower the documented and checked bound to 30.
This keeps `fe_equal` unchanged at runtime and matches current callers, which use much smaller magnitudes.

**Test:** Add a focused test with random field elements whose magnitudes are randomized within the accepted `a <= 1` and `b <= 30` bounds.