### PR TITLE
field: correct `_fe_half` docs (output is not normalized, input requires magnitude <= 31)

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -323,8 +323,8 @@ static void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_fe *a, int flag);
 
 /** Halve the value of a field element modulo the field prime in constant-time.
  *
- * On input, r must be a valid field element.
- * On output, r will be normalized and have magnitude floor(m/2) + 1 where m is
+ * On input, r must be a valid field element with magnitude not exceeding 31.
+ * On output, r will not be normalized, and have magnitude floor(m/2) + 1 where m is
  * the magnitude of r on input.
  */
 static void secp256k1_fe_half(secp256k1_fe *r);


### PR DESCRIPTION
After reviewing #1877, I took a look at the other field module function docs w.r.t. their normalized/magnitude promises and found this mismatch: the `secp256k1_fe_half` docs state the output is normalized, but the impl sets r->normalized = 0 (it only halves the limbs, without a reduction):

https://github.com/bitcoin-core/secp256k1/blob/bd0287d650c24dc41e0362675a9f6a49ee952def/src/field_impl.h#L448-L450

This is a minimum-diff fix to match the implementation, with a similar "On output" structure as used for `_fe_add`:
https://github.com/bitcoin-core/secp256k1/blob/bd0287d650c24dc41e0362675a9f6a49ee952def/src/field.h#L246