### PR TITLE
ci: add 'brew trust' invocation to macOS CI

### DIFF
--- a/.github/actions/install-homebrew-valgrind/action.yml
+++ b/.github/actions/install-homebrew-valgrind/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - run: |
         brew tap LouisBrunner/valgrind
+        brew trust --formula LouisBrunner/valgrind/valgrind
         brew fetch --HEAD LouisBrunner/valgrind/valgrind
         echo "CI_HOMEBREW_CELLAR_VALGRIND=$(brew --cellar valgrind)" >> "$GITHUB_ENV"
       shell: bash


### PR DESCRIPTION
This is probably needed to fix the issues in the macOS Valgrind jobs. i.e in #1877: https://github.com/bitcoin-core/secp256k1/actions/runs/28111568199/job/83240127830?pr=1877#step:4:199

```bash
Cache restored from key: x86_64-macos-native-valgrind-6ebc928a1e40da9db2f283a1c4ac74cfcff9f06687481fd0396a7b4c26ecfb09
Run brew link valgrind
Error: Refusing to load formula louisbrunner/valgrind/valgrind from untrusted tap louisbrunner/valgrind.
Run `brew trust --formula louisbrunner/valgrind/valgrind` or `brew trust louisbrunner/valgrind` to trust it.
Error: Process completed with exit code 1.
```