### PR TITLE
ecmult_gen: add variable-time generator point multiplication (no API behaviour changes yet)

### DIFF
--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -108,6 +108,15 @@ static void bench_ecmult_gen(void* arg, int iters) {
     }
 }
 
+static void bench_ecmult_gen_var(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    int i;
+
+    for (i = 0; i < iters; ++i) {
+        secp256k1_ecmult_gen_var_gej(&data->output[i], &data->scalars[(data->offset1+i) % POINTS]);
+    }
+}
+
 static void bench_ecmult_gen_teardown(void* arg, int iters) {
     bench_data* data = (bench_data*)arg;
     bench_ecmult_teardown_helper(data, NULL, NULL, &data->offset1, iters);
@@ -199,6 +208,8 @@ static void run_ecmult_bench(bench_data* data, int iters) {
     char str[32];
     sprintf(str, "ecmult_gen");
     run_benchmark(str, bench_ecmult_gen, bench_ecmult_setup, bench_ecmult_gen_teardown, data, 10, iters);
+    sprintf(str, "ecmult_gen_var");
+    run_benchmark(str, bench_ecmult_gen_var, bench_ecmult_setup, bench_ecmult_gen_teardown, data, 10, iters);
     sprintf(str, "ecmult_const");
     run_benchmark(str, bench_ecmult_const, bench_ecmult_setup, bench_ecmult_const_teardown, data, 10, iters);
     sprintf(str, "ecmult_const_xonly");

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -140,6 +140,10 @@ static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context* ctx
 static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context* ctx, secp256k1_gej *r, const secp256k1_scalar *a);
 static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context* ctx, secp256k1_ge *r, const secp256k1_scalar *a);
 
+/** Multiply with the generator: R = a*G, without constant-time guarantee. */
+static void secp256k1_ecmult_gen_var_gej(secp256k1_gej *r, const secp256k1_scalar *a);
+static void secp256k1_ecmult_gen_var_ge(secp256k1_ge *r, const secp256k1_scalar *a);
+
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32);
 
 #endif /* SECP256K1_ECMULT_GEN_H */

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -140,6 +140,10 @@ static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ecm
 static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_gej *r, const secp256k1_scalar *a);
 static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_ge *r, const secp256k1_scalar *a);
 
+/** Multiply with the generator: R = a*G, without constant-time guarantee. */
+static void secp256k1_ecmult_gen_var_gej(secp256k1_gej *r, const secp256k1_scalar *a);
+static void secp256k1_ecmult_gen_var_ge(secp256k1_ge *r, const secp256k1_scalar *a);
+
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32);
 
 #endif /* SECP256K1_ECMULT_GEN_H */

--- a/src/ecmult_gen_compute_table.h
+++ b/src/ecmult_gen_compute_table.h
@@ -10,5 +10,6 @@
 #include "ecmult_gen.h"
 
 static void secp256k1_ecmult_gen_compute_table(secp256k1_ge_storage* table, const secp256k1_ge* gen, int blocks, int teeth, int spacing);
+static void secp256k1_ecmult_gen_compute_scalar_diff(secp256k1_scalar* diff, int blocks, int teeth, int spacing);
 
 #endif /* SECP256K1_ECMULT_GEN_COMPUTE_TABLE_H */

--- a/src/ecmult_gen_compute_table_impl.h
+++ b/src/ecmult_gen_compute_table_impl.h
@@ -105,4 +105,26 @@ static void secp256k1_ecmult_gen_compute_table(secp256k1_ge_storage* table, cons
     free(prec);
 }
 
+/* Compute the scalar (2^COMB_BITS - 1) / 2, the difference between the gn argument to
+ * secp256k1_ecmult_gen, and the scalar whose encoding the table lookup bits are drawn
+ * from (before applying blinding). */
+static void secp256k1_ecmult_gen_compute_scalar_diff(secp256k1_scalar* diff, int blocks, int teeth, int spacing) {
+    int i;
+    int comb_bits = blocks * teeth * spacing;
+
+    /* Compute scalar -1/2. */
+    secp256k1_scalar neghalf;
+    secp256k1_scalar_half(&neghalf, &secp256k1_scalar_one);
+    secp256k1_scalar_negate(&neghalf, &neghalf);
+
+    /* Compute offset = 2^(COMB_BITS - 1). */
+    *diff = secp256k1_scalar_one;
+    for (i = 0; i < comb_bits - 1; ++i) {
+        secp256k1_scalar_add(diff, diff, diff);
+    }
+
+    /* The result is the sum 2^(COMB_BITS - 1) + (-1/2). */
+    secp256k1_scalar_add(diff, diff, &neghalf);
+}
+
 #endif /* SECP256K1_ECMULT_GEN_COMPUTE_TABLE_IMPL_H */

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -30,27 +30,6 @@ static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ctx
     secp256k1_fe_clear(&ctx->proj_blind);
 }
 
-/* Compute the scalar (2^COMB_BITS - 1) / 2, the difference between the gn argument to
- * secp256k1_ecmult_gen, and the scalar whose encoding the table lookup bits are drawn
- * from (before applying blinding). */
-static void secp256k1_ecmult_gen_scalar_diff(secp256k1_scalar* diff) {
-    int i;
-
-    /* Compute scalar -1/2. */
-    secp256k1_scalar neghalf;
-    secp256k1_scalar_half(&neghalf, &secp256k1_scalar_one);
-    secp256k1_scalar_negate(&neghalf, &neghalf);
-
-    /* Compute offset = 2^(COMB_BITS - 1). */
-    *diff = secp256k1_scalar_one;
-    for (i = 0; i < COMB_BITS - 1; ++i) {
-        secp256k1_scalar_add(diff, diff, diff);
-    }
-
-    /* The result is the sum 2^(COMB_BITS - 1) + (-1/2). */
-    secp256k1_scalar_add(diff, diff, &neghalf);
-}
-
 static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, secp256k1_gej *r, const secp256k1_scalar *gn) {
     uint32_t comb_off;
     secp256k1_ge add;
@@ -293,14 +272,11 @@ SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_
 /* Setup blinding values for secp256k1_ecmult_gen. */
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
     secp256k1_scalar b;
-    secp256k1_scalar diff;
+    const secp256k1_scalar diff = secp256k1_ecmult_gen_scalar_diff;
     secp256k1_fe f;
     unsigned char nonce32[32];
     secp256k1_rfc6979_hmac_sha256 rng;
     unsigned char keydata[64];
-
-    /* Compute the (2^COMB_BITS - 1)/2 term once. */
-    secp256k1_ecmult_gen_scalar_diff(&diff);
 
     if (seed32 == NULL) {
         /* When seed is NULL, reset the final point and blinding value. */

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -269,6 +269,74 @@ SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_
     secp256k1_gej_clear(&rj);
 }
 
+/* Variable-time variant for generator point multiplication.
+ *
+ * This is essentially a copy of `secp256k1_ecmult_gen_gej`, but with all side-channel
+ * mitigations (i.e., constant-time code, random scalar blinding, and memory clearing)
+ * removed. The EC point operation calls (addition, doubling) are replaced with their
+ * faster variable-time equivalents. This function is stateless and does not require
+ * a context parameter, enabling its use in internal functions.
+ *
+ * Note that the branch for the first table lookup assignment is also removed: since
+ * the result is initialized to the point at infinity, adding to it with `_gej_add_ge_var`
+ * is equivalent to a simple copy. */
+static void secp256k1_ecmult_gen_var_gej(secp256k1_gej *r, const secp256k1_scalar *gn) {
+    uint32_t comb_off;
+    secp256k1_ge add;
+    secp256k1_scalar d;
+    uint32_t recoded[(COMB_BITS + 31) >> 5] = {0};
+    int i;
+
+    /* Adjust input scalar for difference and convert to recoded array. */
+    secp256k1_scalar_add(&d, &secp256k1_ecmult_gen_scalar_diff, gn);
+    for (i = 0; i < 8 && i < ((COMB_BITS + 31) >> 5); ++i) {
+        recoded[i] = secp256k1_scalar_get_bits_limb32(&d, 32 * i, 32);
+    }
+
+    /* Outer loop: iterate over comb_off from COMB_SPACING - 1 down to 0. */
+    secp256k1_gej_set_infinity(r);
+    comb_off = COMB_SPACING - 1;
+    while (1) {
+        uint32_t block;
+        uint32_t bit_pos = comb_off;
+        /* Inner loop: for each block, add table entries to the result. */
+        for (block = 0; block < COMB_BLOCKS; ++block) {
+            /* Gather the mask(block)-selected bits of d into bits. They're packed:
+             * bits[tooth] = d[(block*COMB_TEETH + tooth)*COMB_SPACING + comb_off]. */
+            uint32_t bits = 0, sign, abs, tooth;
+            for (tooth = 0; tooth < COMB_TEETH; ++tooth) {
+                uint32_t bit = (recoded[bit_pos >> 5] >> (bit_pos & 0x1f)) & 1;
+                bits |= bit << tooth;
+                bit_pos += COMB_SPACING;
+            }
+
+            /* If the top bit of bits is 1, flip them all (corresponding to looking up
+             * the negated table value), and remember to negate the result in sign. */
+            sign = (bits >> (COMB_TEETH - 1)) & 1;
+            abs = (bits ^ -sign) & (COMB_POINTS - 1);
+            VERIFY_CHECK(sign == 0 || sign == 1);
+            VERIFY_CHECK(abs < COMB_POINTS);
+
+            /* Perform lookup, negate if necessary and add to r. */
+            secp256k1_ge_from_storage(&add, &secp256k1_ecmult_gen_prec_table[block][abs]);
+            if (sign) {
+                secp256k1_fe_negate(&add.y, &add.y, 1);
+            }
+            secp256k1_gej_add_ge_var(r, r, &add, NULL);
+        }
+
+        /* Double the result, except in the last iteration. */
+        if (comb_off-- == 0) break;
+        secp256k1_gej_double_var(r, r, NULL);
+    }
+}
+
+SECP256K1_INLINE static void secp256k1_ecmult_gen_var_ge(secp256k1_ge *r, const secp256k1_scalar *a) {
+    secp256k1_gej rj;
+    secp256k1_ecmult_gen_var_gej(&rj, a);
+    secp256k1_ge_set_gej_var(r, &rj);
+}
+
 /* Setup blinding values for secp256k1_ecmult_gen. */
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
     secp256k1_scalar b;

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -269,6 +269,74 @@ SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_
     secp256k1_gej_clear(&rj);
 }
 
+/* Variable-time variant for generator point multiplication.
+ *
+ * This is essentially a copy of `secp256k1_ecmult_gen_gej`, but with all side-channel
+ * mitigations (i.e., constant-time code, random scalar blinding, and memory clearing)
+ * removed. The EC point operation calls (addition, doubling) are replaced with their
+ * faster variable-time equivalents. This function is stateless and does not require
+ * a context parameter, enabling its use in internal functions.
+ *
+ * Note that the branch for the first table lookup assignment is also removed: since
+ * the result is initialized to the point at infinity, adding to it with `_gej_add_ge_var`
+ * is equivalent to a simple copy. */
+static void secp256k1_ecmult_gen_var_gej(secp256k1_gej *r, const secp256k1_scalar *gn) {
+    uint32_t comb_off;
+    secp256k1_ge add;
+    secp256k1_scalar d;
+    uint32_t recoded[(COMB_BITS + 31) >> 5] = {0};
+    int i;
+
+    /* Adjust input scalar for difference and convert to recoded array. */
+    secp256k1_scalar_add(&d, &secp256k1_ecmult_gen_scalar_diff, gn);
+    for (i = 0; i < 8 && i < ((COMB_BITS + 31) >> 5); ++i) {
+        recoded[i] = secp256k1_scalar_get_bits_limb32(&d, 32 * i, 32);
+    }
+
+    /* Outer loop: iterate over comb_off from COMB_SPACING - 1 down to 0. */
+    secp256k1_gej_set_infinity(r);
+    comb_off = COMB_SPACING - 1;
+    while (1) {
+        uint32_t block;
+        uint32_t bit_pos = comb_off;
+        /* Inner loop: for each block, add table entries to the result. */
+        for (block = 0; block < COMB_BLOCKS; ++block) {
+            /* Gather the mask(block)-selected bits of d into bits. They're packed:
+             * bits[tooth] = d[(block*COMB_TEETH + tooth)*COMB_SPACING + comb_off]. */
+            uint32_t bits = 0, sign, abs, tooth;
+            for (tooth = 0; tooth < COMB_TEETH; ++tooth) {
+                uint32_t bit = (recoded[bit_pos >> 5] >> (bit_pos & 0x1f)) & 1;
+                bits |= bit << tooth;
+                bit_pos += COMB_SPACING;
+            }
+
+            /* If the top bit of bits is 1, flip them all (corresponding to looking up
+             * the negated table value), and remember to negate the result in sign. */
+            sign = (bits >> (COMB_TEETH - 1)) & 1;
+            abs = (bits ^ -sign) & (COMB_POINTS - 1);
+            VERIFY_CHECK(sign == 0 || sign == 1);
+            VERIFY_CHECK(abs < COMB_POINTS);
+
+            /* Perform lookup, negate if necessary and add to r. */
+            secp256k1_ge_from_storage(&add, &secp256k1_ecmult_gen_prec_table[block][abs]);
+            if (sign) {
+                secp256k1_fe_negate(&add.y, &add.y, 1);
+            }
+            secp256k1_gej_add_ge_var(r, r, &add, NULL);
+        }
+
+        /* Double the result, except in the last iteration. */
+        if (comb_off-- == 0) break;
+        secp256k1_gej_double_var(r, r, NULL);
+    }
+}
+
+SECP256K1_INLINE static void secp256k1_ecmult_gen_var_ge(secp256k1_ge *r, const secp256k1_scalar *a) {
+    secp256k1_gej rj;
+    secp256k1_ecmult_gen_var_gej(&rj, a);
+    secp256k1_ge_set_gej_var(r, &rj);
+}
+
 /* Setup blinding values for secp256k1_ecmult_gen. */
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
     secp256k1_scalar b;

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -30,27 +30,6 @@ static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ecm
     secp256k1_fe_clear(&ecmult_gen_ctx->proj_blind);
 }
 
-/* Compute the scalar (2^COMB_BITS - 1) / 2, the difference between the gn argument to
- * secp256k1_ecmult_gen, and the scalar whose encoding the table lookup bits are drawn
- * from (before applying blinding). */
-static void secp256k1_ecmult_gen_scalar_diff(secp256k1_scalar* diff) {
-    int i;
-
-    /* Compute scalar -1/2. */
-    secp256k1_scalar neghalf;
-    secp256k1_scalar_half(&neghalf, &secp256k1_scalar_one);
-    secp256k1_scalar_negate(&neghalf, &neghalf);
-
-    /* Compute offset = 2^(COMB_BITS - 1). */
-    *diff = secp256k1_scalar_one;
-    for (i = 0; i < COMB_BITS - 1; ++i) {
-        secp256k1_scalar_add(diff, diff, diff);
-    }
-
-    /* The result is the sum 2^(COMB_BITS - 1) + (-1/2). */
-    secp256k1_scalar_add(diff, diff, &neghalf);
-}
-
 static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_gej *r, const secp256k1_scalar *gn) {
     uint32_t comb_off;
     secp256k1_ge add;
@@ -293,14 +272,11 @@ SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_
 /* Setup blinding values for secp256k1_ecmult_gen. */
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
     secp256k1_scalar b;
-    secp256k1_scalar diff;
+    const secp256k1_scalar diff = secp256k1_ecmult_gen_scalar_diff;
     secp256k1_fe f;
     unsigned char nonce32[32];
     secp256k1_rfc6979_hmac_sha256 rng;
     unsigned char keydata[64];
-
-    /* Compute the (2^COMB_BITS - 1)/2 term once. */
-    secp256k1_ecmult_gen_scalar_diff(&diff);
 
     if (seed32 == NULL) {
         /* When seed is NULL, reset the final point and blinding value. */

--- a/src/precompute_ecmult_gen.c
+++ b/src/precompute_ecmult_gen.c
@@ -53,6 +53,21 @@ static void print_table(FILE* fp, int blocks, int teeth) {
     free(table);
 }
 
+static void print_scalar_diff(FILE* fp, int blocks, int teeth) {
+    int spacing = CEIL_DIV(256, blocks * teeth);
+    secp256k1_scalar diff;
+    int limb;
+
+    secp256k1_ecmult_gen_compute_scalar_diff(&diff, blocks, teeth, spacing);
+    fprintf(fp, "#elif (COMB_BLOCKS == %d) && (COMB_TEETH == %d) && (COMB_SPACING == %d)\n", blocks, teeth, spacing);
+    fprintf(fp, "    SECP256K1_SCALAR_CONST(");
+    for (limb = 7; limb >= 0; limb--) {
+        fprintf(fp, "0x%08x", secp256k1_scalar_get_bits_var(&diff, limb*32, 32));
+        if (limb != 0) fprintf(fp, ",");
+    }
+    fprintf(fp, ")\n");
+}
+
 int main(int argc, char **argv) {
     const char outfile[] = "src/precomputed_ecmult_gen.c";
     FILE* fp;
@@ -92,9 +107,21 @@ int main(int argc, char **argv) {
     fprintf(fp, "#else\n");
     fprintf(fp, "#    error Configuration mismatch, invalid COMB_* parameters. Try deleting precomputed_ecmult_gen.c before the build.\n");
     fprintf(fp, "#endif\n");
-
     fprintf(fp, "};\n");
-    fprintf(fp, "#undef S\n");
+    fprintf(fp, "#undef S\n\n");
+
+    fprintf(fp, "const secp256k1_scalar secp256k1_ecmult_gen_scalar_diff =\n");
+    fprintf(fp, "#if 0\n");
+    for (config = 0; config < ARRAY_SIZE(CONFIGS); ++config) {
+        print_scalar_diff(fp, CONFIGS[config][0], CONFIGS[config][1]);
+    }
+    if (!did_current_config) {
+        print_scalar_diff(fp, COMB_BLOCKS, COMB_TEETH);
+    }
+    fprintf(fp, "#else\n");
+    fprintf(fp, "#    error Configuration mismatch, invalid COMB_* parameters. Try deleting precomputed_ecmult_gen.c before the build.\n");
+    fprintf(fp, "#endif\n");
+    fprintf(fp, ";\n");
     fclose(fp);
 
     return EXIT_SUCCESS;

--- a/src/precomputed_ecmult_gen.c
+++ b/src/precomputed_ecmult_gen.c
@@ -1777,3 +1777,16 @@ S(ff3d6136,ffac5b0c,bfc6c5c0,c30dc01a,7ea3d56c,20bd3103,b178e3d3,ae180068,eccdc6
 #endif
 };
 #undef S
+
+const secp256k1_scalar secp256k1_ecmult_gen_scalar_diff =
+#if 0
+#elif (COMB_BLOCKS == 2) && (COMB_TEETH == 5) && (COMB_SPACING == 26)
+    SECP256K1_SCALAR_CONST(0x80000000,0x00000000,0x00000000,0x00000009,0x87e0873d,0xdd5f4e3f,0xe1563adf,0xe6691698)
+#elif (COMB_BLOCKS == 11) && (COMB_TEETH == 6) && (COMB_SPACING == 4)
+    SECP256K1_SCALAR_CONST(0x80000000,0x00000000,0x00000000,0x000000a2,0x05e8fb1b,0xb354323d,0xf6b9e8de,0x4cfa8020)
+#elif (COMB_BLOCKS == 43) && (COMB_TEETH == 6) && (COMB_SPACING == 1)
+    SECP256K1_SCALAR_CONST(0x80000000,0x00000000,0x00000000,0x00000001,0xe7f9b4a5,0xf9130fa6,0x6044722c,0xc7ae9e1e)
+#else
+#    error Configuration mismatch, invalid COMB_* parameters. Try deleting precomputed_ecmult_gen.c before the build.
+#endif
+;

--- a/src/precomputed_ecmult_gen.h
+++ b/src/precomputed_ecmult_gen.h
@@ -17,8 +17,10 @@ extern "C" {
 
 #ifdef EXHAUSTIVE_TEST_ORDER
 static secp256k1_ge_storage secp256k1_ecmult_gen_prec_table[COMB_BLOCKS][COMB_POINTS];
+static secp256k1_scalar secp256k1_ecmult_gen_scalar_diff;
 #else
 SECP256K1_LOCAL_VAR const secp256k1_ge_storage secp256k1_ecmult_gen_prec_table[COMB_BLOCKS][COMB_POINTS];
+SECP256K1_LOCAL_VAR const secp256k1_scalar secp256k1_ecmult_gen_scalar_diff;
 #endif /* defined(EXHAUSTIVE_TEST_ORDER) */
 
 #ifdef __cplusplus

--- a/src/tests.c
+++ b/src/tests.c
@@ -4617,10 +4617,14 @@ static void test_ecmult_target(const secp256k1_scalar* target, int mode) {
         secp256k1_ecmult(&p1j, &pj, &n1, &secp256k1_scalar_zero);
         secp256k1_ecmult(&p2j, &pj, &n2, &secp256k1_scalar_zero);
         secp256k1_ecmult(&ptj, &pj, target, &secp256k1_scalar_zero);
-    } else {
+    } else if (mode == 2) {
         secp256k1_ecmult_const(&p1j, &p, &n1);
         secp256k1_ecmult_const(&p2j, &p, &n2);
         secp256k1_ecmult_const(&ptj, &p, target);
+    } else {
+        secp256k1_ecmult_gen_var_gej(&p1j, &n1);
+        secp256k1_ecmult_gen_var_gej(&p2j, &n2);
+        secp256k1_ecmult_gen_var_gej(&ptj, target);
     }
 
     /* Add them all up: n1*P + n2*P + target*P = (n1+n2+target)*P = (n1+n1-n1-n2)*P = 0. */
@@ -4637,6 +4641,7 @@ static void run_ecmult_near_split_bound(void) {
             test_ecmult_target(&scalars_near_split_bounds[j], 0);
             test_ecmult_target(&scalars_near_split_bounds[j], 1);
             test_ecmult_target(&scalars_near_split_bounds[j], 2);
+            test_ecmult_target(&scalars_near_split_bounds[j], 3);
         }
     }
 }
@@ -5654,7 +5659,7 @@ static void test_ecmult_accumulate(secp256k1_sha256* acc, const secp256k1_scalar
     /* Compute x*G in many different ways, serialize it uncompressed, and feed it into acc. */
     secp256k1_gej gj, infj;
     secp256k1_ge r;
-    secp256k1_gej rj[7];
+    secp256k1_gej rj[8];
     unsigned char bytes[65];
     size_t i;
     secp256k1_gej_set_ge(&gj, &secp256k1_ge_const_g);
@@ -5666,6 +5671,7 @@ static void test_ecmult_accumulate(secp256k1_sha256* acc, const secp256k1_scalar
     CHECK(secp256k1_ecmult_multi_var(&CTX->error_callback, scratch, &rj[4], x, NULL, NULL, 0));
     CHECK(secp256k1_ecmult_multi_var(&CTX->error_callback, scratch, &rj[5], &secp256k1_scalar_zero, test_ecmult_accumulate_cb, (void*)x, 1));
     secp256k1_ecmult_const(&rj[6], &secp256k1_ge_const_g, x);
+    secp256k1_ecmult_gen_var_gej(&rj[7], x);
     secp256k1_ge_set_gej_var(&r, &rj[0]);
     for (i = 0; i < ARRAY_SIZE(rj); i++) {
         CHECK(secp256k1_gej_eq_ge_var(&rj[i], &r));

--- a/src/tests.c
+++ b/src/tests.c
@@ -4694,10 +4694,14 @@ static void test_ecmult_target(const secp256k1_scalar* target, int mode) {
         secp256k1_ecmult(&p1j, &pj, &n1, &secp256k1_scalar_zero);
         secp256k1_ecmult(&p2j, &pj, &n2, &secp256k1_scalar_zero);
         secp256k1_ecmult(&ptj, &pj, target, &secp256k1_scalar_zero);
-    } else {
+    } else if (mode == 2) {
         secp256k1_ecmult_const(&p1j, &p, &n1);
         secp256k1_ecmult_const(&p2j, &p, &n2);
         secp256k1_ecmult_const(&ptj, &p, target);
+    } else {
+        secp256k1_ecmult_gen_var_gej(&p1j, &n1);
+        secp256k1_ecmult_gen_var_gej(&p2j, &n2);
+        secp256k1_ecmult_gen_var_gej(&ptj, target);
     }
 
     /* Add them all up: n1*P + n2*P + target*P = (n1+n2+target)*P = (n1+n1-n1-n2)*P = 0. */
@@ -4714,6 +4718,7 @@ static void run_ecmult_near_split_bound(void) {
             test_ecmult_target(&scalars_near_split_bounds[j], 0);
             test_ecmult_target(&scalars_near_split_bounds[j], 1);
             test_ecmult_target(&scalars_near_split_bounds[j], 2);
+            test_ecmult_target(&scalars_near_split_bounds[j], 3);
         }
     }
 }
@@ -5731,7 +5736,7 @@ static void test_ecmult_accumulate(secp256k1_sha256* acc, const secp256k1_scalar
     /* Compute x*G in many different ways, serialize it uncompressed, and feed it into acc. */
     secp256k1_gej gj, infj;
     secp256k1_ge r;
-    secp256k1_gej rj[7];
+    secp256k1_gej rj[8];
     unsigned char bytes[65];
     size_t i;
     secp256k1_gej_set_ge(&gj, &secp256k1_ge_const_g);
@@ -5743,6 +5748,7 @@ static void test_ecmult_accumulate(secp256k1_sha256* acc, const secp256k1_scalar
     CHECK(secp256k1_ecmult_multi_var(&CTX->error_callback, scratch, &rj[4], x, NULL, NULL, 0));
     CHECK(secp256k1_ecmult_multi_var(&CTX->error_callback, scratch, &rj[5], &secp256k1_scalar_zero, test_ecmult_accumulate_cb, (void*)x, 1));
     secp256k1_ecmult_const(&rj[6], &secp256k1_ge_const_g, x);
+    secp256k1_ecmult_gen_var_gej(&rj[7], x);
     secp256k1_ge_set_gej_var(&r, &rj[0]);
     for (i = 0; i < ARRAY_SIZE(rj); i++) {
         CHECK(secp256k1_gej_eq_ge_var(&rj[i], &r));

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -399,6 +399,8 @@ int main(int argc, char** argv) {
         printf("running tests for core %lu (out of [0..%lu])\n", (unsigned long)this_core, (unsigned long)num_cores - 1);
     }
 
+    /* Recreate the scalar_diff value using the proper COMB parameters (as selected via EXHAUSTIVE_TEST_ORDER) */
+    secp256k1_ecmult_gen_compute_scalar_diff(&secp256k1_ecmult_gen_scalar_diff, COMB_BLOCKS, COMB_TEETH, COMB_SPACING);
     /* Recreate the ecmult{,_gen} tables using the right generator (as selected via EXHAUSTIVE_TEST_ORDER) */
     secp256k1_ecmult_gen_compute_table(&secp256k1_ecmult_gen_prec_table[0][0], &secp256k1_ge_const_g, COMB_BLOCKS, COMB_TEETH, COMB_SPACING);
     secp256k1_ecmult_compute_two_tables(secp256k1_pre_g, secp256k1_pre_g_128, WINDOW_G, &secp256k1_ge_const_g);

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -425,13 +425,15 @@ int main(int argc, char** argv) {
                 secp256k1_gej_rescale(&groupj[i], &z);
             }
 
-            /* Verify against ecmult_gen */
+            /* Verify against ecmult_gen(_var) */
             {
                 secp256k1_scalar scalar_i;
-                secp256k1_ge generated;
+                secp256k1_ge generated, generated_var;
 
                 secp256k1_scalar_set_int(&scalar_i, i);
                 secp256k1_ecmult_gen_ge(&ctx->ecmult_gen_ctx, &generated, &scalar_i);
+                secp256k1_ecmult_gen_var_ge(&generated_var, &scalar_i);
+                CHECK(secp256k1_ge_eq_var(&generated, &generated_var));
 
                 CHECK(!secp256k1_ge_is_infinity(&group[i]));
                 CHECK(secp256k1_ge_eq_var(&group[i], &generated));


### PR DESCRIPTION
The PR is a rebased subset of #1843: it adds a variable-time variant for generator point multiplication, with the idea of enabling potential performance gains for use cases where the scalar isn't treated as secret. The implementation is essentially a copy of the existing `secp256k1_ecmult_gen_gej` function, but with all side-channel mitigations (i.e., constant-time code, random scalar blinding, and memory clearing) removed. The EC point operation calls (addition, doubling) are replaced with their faster variable-time equivalents.

The first commit moves the calculation of the `ecmult_gen_scalar_diff` constant (scalar `(2^COMB_BITS - 1) / 2`) from run-time to compile-time, in order to avoid needing a context object and thus enable computing the result statelessly.

On my arm64 machine, the variable-time variant is ~86% faster than the constant-time variant (with the default build table size, i.e. ECMULT_GEN_KB=86):

```
$ ./build/bin/bench_ecmult
Benchmark                     ,    Min(us)    ,    Avg(us)    ,    Max(us)

ecmult_gen                    ,     9.32      ,     9.35      ,     9.60
ecmult_gen_var                ,     5.02      ,     5.02      ,     5.02
.....
```
Note that in contrast to #1843, this PR doesn't take use of the new functions in any user-facing code (API functions) yet, to keep discussions about potential behavior changes w.r.t. constant-timing guarantees separated. The only visible change for users after merging this PR would be that the library is a tiny bit larger, as the generated tables now also contain the `ecmult_gen_scalar_diff` constant. On my arm64 machine, this leads to an increase of 56 bytes for the .so file (1392672 bytes master vs. 1392728 bytes PR on a default release build), which I think we can treat as negligible.

One relatively obvious scenario where using the variable-time variant would make sense is for verifying P2TR script-paths spends in Bitcoin Core via `secp256k1_xonly_pubkey_tweak_add_check` (see https://github.com/bitcoin-core/secp256k1/pull/1843#issuecomment-4299716270). However, whether to change the behavior of the existing API function or adding a new one (e.g. with `_var` suffix) still has to be decided and might be a topic for a different PR (see https://github.com/bitcoin-core/secp256k1/pull/1843#issuecomment-4325379402). Another scenario could be scanning of Silent Payments, though in this case it has to be carefully evaluated whether it's safe to treat the tweak [t_k](https://github.com/bitcoin/bips/blob/f078d4f5ff70fe2921fd005d799a3d4a8ff7d55c/bip-0352.mediawiki?plain=1#L347-L349) as non-secret.