### PR TITLE
Clear scalar variables computed from scalar in `secp256k1_ecmult_const`

### DIFF
--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -263,6 +263,11 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
 
     /* Map the result back to the secp256k1 curve from the isomorphic curve. */
     secp256k1_fe_mul(&r->z, &r->z, &global_z);
+
+    /* Clear local variables computed from scalar q */
+    secp256k1_scalar_clear(&s);
+    secp256k1_scalar_clear(&v1);
+    secp256k1_scalar_clear(&v2);
 }
 
 static int secp256k1_ecmult_const_xonly(secp256k1_fe* r, const secp256k1_fe *n, const secp256k1_fe *d, const secp256k1_scalar *q, int known_on_curve) {

--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -96,8 +96,10 @@ static void secp256k1_ecmult_const_odd_multiples_table_globalz(secp256k1_ge *pre
         secp256k1_fe_cmov(&(r)->x, &(pre)[m].x, m == index); \
         secp256k1_fe_cmov(&(r)->y, &(pre)[m].y, m == index); \
     } \
+    secp256k1_memclear_explicit(&index, sizeof(index)); \
     secp256k1_fe_negate(&neg_y, &(r)->y, 1); \
     secp256k1_fe_cmov(&(r)->y, &neg_y, negative); \
+    secp256k1_fe_clear(&neg_y); \
 } while(0)
 
 /* For K as defined in the comment of secp256k1_ecmult_const, we have several precomputed
@@ -247,6 +249,7 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
         int j;
 
         ECMULT_CONST_TABLE_GET_GE(&t, pre_a, bits1);
+        secp256k1_memclear_explicit(&bits1, sizeof(bits1));
         if (group == ECMULT_CONST_GROUPS - 1) {
             /* Directly set r in the first iteration. */
             secp256k1_gej_set_ge(r, &t);
@@ -258,7 +261,9 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
             secp256k1_gej_add_ge(r, r, &t);
         }
         ECMULT_CONST_TABLE_GET_GE(&t, pre_a_lam, bits2);
+        secp256k1_memclear_explicit(&bits2, sizeof(bits2));
         secp256k1_gej_add_ge(r, r, &t);
+        secp256k1_ge_clear(&t);
     }
 
     /* Map the result back to the secp256k1 curve from the isomorphic curve. */


### PR DESCRIPTION
Hello,
Function `secp256k1_ecdh` performs an ECDH computation and clears some intermediate values from the stack before returning: https://github.com/bitcoin-core/secp256k1/blob/68b45fd4e266c5a6b80097319155114475de697e/src/modules/ecdh/main_impl.h#L70-L74

This function calls `secp256k1_ecmult_const`, which does not clear anything.

Clear the scalar variables computed from the scalar operand in `secp256k1_ecmult_const`.

N.B. After this PR, some stack variables still hold values related to scalar `q`. For example: macro `ECMULT_CONST_TABLE_GET_GE` uses a temporary variable `secp256k1_fe neg_y` which value comes from some bits of the scalar ; a `for` loop uses a temporary point `secp256k1_ge t` which is never cleared ; variables `unsigned int bits1` and `unsigned int bits2` are not cleared, even though the compiler may choose to put them in registers instead of the stack. Nonetheless these remaining variables do not seem to enable reconstructing the value of input scalar `q` (contrary to `s`, `v1`, `v2`, whose values could be used to reconstruct `q`). I therefore believe it is all right to limit the clearing to what this Pull Request adds.