### PR TITLE
Remove deprecated `secp256k1_context_no_precomp` pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - CMake: Shared libraries built with CMake on OpenBSD and NetBSD now create the full versioned filename (e.g. `libsecp256k1.so.6.2` instead of `libsecp256k1.so.6`) and symlink chain, matching the behavior of GNU Autotools builds.
 
 #### Removed
+- Removed previously deprecated pointer `secp256k1_context_no_precomp`. Use `secp256k1_context_static` instead.
 - Removed previously deprecated function alias `secp256k1_schnorrsig_sign`. Use `secp256k1_schnorrsig_sign32` instead.
 
 ## [0.7.1] - 2026-01-26

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -236,10 +236,6 @@ typedef int (*secp256k1_nonce_function)(
  */
 SECP256K1_API const secp256k1_context * const secp256k1_context_static;
 
-/** Deprecated alias for secp256k1_context_static. */
-SECP256K1_API const secp256k1_context * const secp256k1_context_no_precomp
-SECP256K1_DEPRECATED("Use secp256k1_context_static instead");
-
 /** Perform basic self tests (to be used in conjunction with secp256k1_context_static)
  *
  *  This function performs self tests that detect some serious usage errors and

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -74,7 +74,6 @@ static const secp256k1_context secp256k1_context_static_ = {
     0
 };
 const secp256k1_context * const secp256k1_context_static = &secp256k1_context_static_;
-const secp256k1_context * const secp256k1_context_no_precomp = &secp256k1_context_static_;
 
 /* Helper function that determines if a context is proper, i.e., is not the static context or a copy thereof.
  *

--- a/src/tests.c
+++ b/src/tests.c
@@ -194,9 +194,6 @@ static void run_ec_illegal_argument_tests(void) {
 }
 
 static void run_static_context_tests(int use_prealloc) {
-    /* Check that deprecated secp256k1_context_no_precomp is an alias to secp256k1_context_static. */
-    CHECK(secp256k1_context_no_precomp == secp256k1_context_static);
-
     {
         unsigned char seed[32] = {0x17};
 


### PR DESCRIPTION
This context pointer has been deprecated since the rename to `_context_static` more than three and a half years ago (see PR #1126, commit 53796d2b24e813750feae73e85c0a6eee40dc391), for the first official release 0.2.0. Removing it should be fine by now.

Same as for #1776, there is no urgency for this change, so it can wait until there are more reasons for a breaking release.