### PR TITLE
Make theStack a maintainer and a security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,5 +10,6 @@ The following keys may be used to communicate sensitive information to developer
 |------|-------------|
 | Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
 | Tim Ruffing | 09E0 3F87 1092 E40E 106E  902B 33BC 86AB 80FF 5516 |
+| Sebastian Falbesoner | 6A8F 9C26 6528 E25A EB1D  7731 C237 1D91 CB71 6EA7 |
 
 You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,10 @@ To report security issues send an email to secp256k1-security@bitcoincore.org (n
 
 The following keys may be used to communicate sensitive information to developers:
 
-| Name | Fingerprint |
-|------|-------------|
-| Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
-| Tim Ruffing | 09E0 3F87 1092 E40E 106E  902B 33BC 86AB 80FF 5516 |
+| Name                 | Fingerprint                                        |
+|----------------------|----------------------------------------------------|
+| Pieter Wuille        | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
+| Tim Ruffing          | 09E0 3F87 1092 E40E 106E  902B 33BC 86AB 80FF 5516 |
 | Sebastian Falbesoner | 6A8F 9C26 6528 E25A EB1D  7731 C237 1D91 CB71 6EA7 |
 
 You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.


### PR DESCRIPTION
@sipa, @jonasnick and I [proposed in a recent Bitcoin Core dev meeting](https://achow101.com/ircmeetings/2026/bitcoin-core-dev.2026-06-25_16_00.log.html#f6c02cf2aae64685af41255b948d8eb5) to add @theStack as a maintainer of libsecp256k1. The purpose of this PR is to seek (N)ACKs for the maintainer change and for adding his public key fingerprint to SECURITY.md.
