### PR TITLE
nonce: terminate RFC6979 loop at UINT_MAX

### DIFF
--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -521,8 +521,9 @@ static int nonce_function_rfc6979_impl(const secp256k1_hash_ctx *hash_ctx, unsig
        buffer_append(keydata, &offset, algo16, 16);
    }
    secp256k1_rfc6979_hmac_sha256_initialize(hash_ctx, &rng, keydata, offset);
-   for (i = 0; i <= counter; i++) {
+   for (i = 0; ; i++) {
        secp256k1_rfc6979_hmac_sha256_generate(hash_ctx, &rng, nonce32, 32);
+       if (i == counter) break;
    }
    secp256k1_rfc6979_hmac_sha256_finalize(&rng);
 


### PR DESCRIPTION
**Problem:** The [public nonce callback](https://github.com/bitcoin-core/secp256k1/blob/8c3e6e6d992456d3b9228305ae84a6703273cf70/include/secp256k1.h#L88-L102) accepts `UINT_MAX`, but `nonce_function_rfc6979_impl` never returns for that attempt.
Its `i <= counter` loop wraps after the final candidate and starts again.

**Fix:** Generate the candidate before checking whether it is the requested attempt.
This preserves the result for every `unsigned int` attempt, including `UINT_MAX`, and exits before the index can wrap.