### PR TITLE
test: cover schnorrsig_sign_custom in constant-time tests

### DIFF
--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -45,6 +45,30 @@
 # pragma GCC diagnostic warning "-Wunused-function"
 #endif
 
+#ifdef ENABLE_MODULE_SCHNORRSIG
+static int nonce_function_custom(
+    unsigned char *nonce32,
+    const unsigned char *msg,
+    size_t msglen,
+    const unsigned char *key32,
+    const unsigned char *xonly_pk32,
+    const unsigned char *algo,
+    size_t algolen,
+    void *data
+) {
+    return secp256k1_nonce_function_bip340(
+        nonce32,
+        msg,
+        msglen,
+        key32,
+        xonly_pk32,
+        algo,
+        algolen,
+        data
+    );
+}
+#endif
+
 static void run_tests(secp256k1_context *ctx, unsigned char *key);
 
 int main(void) {
@@ -94,6 +118,10 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
 #endif
 #ifdef ENABLE_MODULE_EXTRAKEYS
     secp256k1_keypair keypair;
+#endif
+#ifdef ENABLE_MODULE_SCHNORRSIG
+    secp256k1_schnorrsig_extraparams extraparams = SECP256K1_SCHNORRSIG_EXTRAPARAMS_INIT;
+    unsigned char aux_rand[32] = { 0 };
 #endif
 #ifdef ENABLE_MODULE_ELLSWIFT
     unsigned char ellswift[64];
@@ -190,7 +218,6 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 
-    /* Also cover the public sign_custom entry point (default nonce path). */
     SECP256K1_CHECKMEM_UNDEFINE(key, 32);
     ret = secp256k1_keypair_create(ctx, &keypair, key);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
@@ -198,6 +225,32 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
     SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
     SECP256K1_CHECKMEM_UNDEFINE(msg, 32);
     ret = secp256k1_schnorrsig_sign_custom(ctx, sig, msg, 32, &keypair, NULL);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+
+    extraparams.noncefp = NULL;
+    extraparams.ndata = aux_rand;
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    ret = secp256k1_keypair_create(ctx, &keypair, key);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+    SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
+    SECP256K1_CHECKMEM_UNDEFINE(msg, 32);
+    SECP256K1_CHECKMEM_UNDEFINE(aux_rand, sizeof(aux_rand));
+    ret = secp256k1_schnorrsig_sign_custom(ctx, sig, msg, 32, &keypair, &extraparams);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+
+    extraparams.noncefp = nonce_function_custom;
+    extraparams.ndata = aux_rand;
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    ret = secp256k1_keypair_create(ctx, &keypair, key);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+    SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
+    SECP256K1_CHECKMEM_UNDEFINE(msg, sizeof(msg) - 1);
+    SECP256K1_CHECKMEM_UNDEFINE(aux_rand, sizeof(aux_rand));
+    ret = secp256k1_schnorrsig_sign_custom(ctx, sig, msg, sizeof(msg) - 1, &keypair, &extraparams);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 #endif

--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -189,6 +189,17 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
     ret = secp256k1_schnorrsig_sign32(ctx, sig, msg, &keypair, NULL);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
+
+    /* Also cover the public sign_custom entry point (default nonce path). */
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    ret = secp256k1_keypair_create(ctx, &keypair, key);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+    SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
+    SECP256K1_CHECKMEM_UNDEFINE(msg, 32);
+    ret = secp256k1_schnorrsig_sign_custom(ctx, sig, msg, 32, &keypair, NULL);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
 #endif
 
 #ifdef ENABLE_MODULE_MUSIG

--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -189,6 +189,15 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
     ret = secp256k1_schnorrsig_sign32(ctx, sig, msg, &keypair, NULL);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
+
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    ret = secp256k1_keypair_create(ctx, &keypair, key);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+    SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
+    ret = secp256k1_schnorrsig_sign_custom(ctx, sig, msg, 32, &keypair, NULL);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
 #endif
 
 #ifdef ENABLE_MODULE_MUSIG

--- a/src/ctime_tests.c
+++ b/src/ctime_tests.c
@@ -45,6 +45,12 @@
 # pragma GCC diagnostic warning "-Wunused-function"
 #endif
 
+#ifdef ENABLE_MODULE_SCHNORRSIG
+static int nonce_function_custom(unsigned char *nonce32, const unsigned char *msg, size_t msglen, const unsigned char *key32, const unsigned char *xonly_pk32, const unsigned char *algo, size_t algolen, void *data) {
+    return secp256k1_nonce_function_bip340(nonce32, msg, msglen, key32, xonly_pk32, algo, algolen, data);
+}
+#endif
+
 static void run_tests(secp256k1_context *ctx, unsigned char *key);
 
 int main(void) {
@@ -94,6 +100,10 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
 #endif
 #ifdef ENABLE_MODULE_EXTRAKEYS
     secp256k1_keypair keypair;
+#endif
+#ifdef ENABLE_MODULE_SCHNORRSIG
+    secp256k1_schnorrsig_extraparams extraparams = SECP256K1_SCHNORRSIG_EXTRAPARAMS_INIT;
+    unsigned char aux_rand[32] = { 0 };
 #endif
 #ifdef ENABLE_MODULE_ELLSWIFT
     unsigned char ellswift[64];
@@ -196,6 +206,28 @@ static void run_tests(secp256k1_context *ctx, unsigned char *key) {
     CHECK(ret == 1);
     SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
     ret = secp256k1_schnorrsig_sign_custom(ctx, sig, msg, 32, &keypair, NULL);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+
+    extraparams.noncefp = NULL;
+    extraparams.ndata = aux_rand;
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    ret = secp256k1_keypair_create(ctx, &keypair, key);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+    SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
+    ret = secp256k1_schnorrsig_sign_custom(ctx, sig, msg, 32, &keypair, &extraparams);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+
+    extraparams.noncefp = nonce_function_custom;
+    extraparams.ndata = aux_rand;
+    SECP256K1_CHECKMEM_UNDEFINE(key, 32);
+    ret = secp256k1_keypair_create(ctx, &keypair, key);
+    SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
+    CHECK(ret == 1);
+    SECP256K1_CHECKMEM_UNDEFINE(&keypair, sizeof(keypair));
+    ret = secp256k1_schnorrsig_sign_custom(ctx, sig, msg, sizeof(msg), &keypair, &extraparams);
     SECP256K1_CHECKMEM_DEFINE(&ret, sizeof(ret));
     CHECK(ret == 1);
 #endif


### PR DESCRIPTION
### Description

`src/ctime_tests.c` covers `secp256k1_schnorrsig_sign32` and `secp256k1_schnorrsig_sign_custom` entry points under Valgrind/CHECKMEM.

`secp256k1_schnorrsig_sign_custom` accepts optional `extraparams`, including a custom nonce function, before calling the shared internal signer. Functional tests cover this API, but previously it was not exercised under the constant-time CHECKMEM harness.

This PR adds coverage for:

- `secp256k1_schnorrsig_sign_custom(..., NULL)` using the default nonce path with NULL extraparams.
- The default BIP340 nonce function with non-NULL `extraparams.ndata`.
- The custom nonce callback dispatch path via a distinct `nonce_function_custom` callback that delegates to `secp256k1_nonce_function_bip340`.
- Secret key material and keypair state under CHECKMEM for these signing paths.

Message and auxiliary data are not treated as secret inputs in these tests.

### Coverage gap

The existing constant-time test suite exercised `secp256k1_schnorrsig_sign32`, but did not exercise the public `secp256k1_schnorrsig_sign_custom` entry point and its custom nonce callback dispatch path under CHECKMEM.

Local synthetic mutations were used during development to verify that the added coverage reaches these paths. These mutations are not included in this branch.

This is a test-coverage improvement. No production cryptographic code is modified, and this PR does not claim a production vulnerability in unmodified libsecp256k1.

### Change

- `src/ctime_tests.c` only
- No production code changes
- No new dependencies

### Build / test

```sh
cmake -B build \
  -DSECP256K1_VALGRIND=ON \
  -DSECP256K1_BUILD_CTIME_TESTS=ON \
  -DSECP256K1_ENABLE_MODULE_SCHNORRSIG=ON \
  -DSECP256K1_ENABLE_MODULE_EXTRAKEYS=ON

cmake --build build --parallel
ctest --test-dir build --output-on-failure
valgrind --error-exitcode=42 ./build/bin/ctime_tests
```

Local validation after addressing review feedback:

- 207/207 CTest tests passed.
- `ctime_tests` passed under Valgrind.
- Valgrind reported `ERROR SUMMARY: 0 errors`.
- Valgrind process exited with code 0.
