### PR TITLE
extrakeys: check invariant that x-only pubkeys have even Y

### DIFF
--- a/src/modules/extrakeys/main_impl.h
+++ b/src/modules/extrakeys/main_impl.h
@@ -16,6 +16,13 @@ static SECP256K1_INLINE int secp256k1_xonly_pubkey_load(const secp256k1_context*
 }
 
 static SECP256K1_INLINE void secp256k1_xonly_pubkey_save(secp256k1_xonly_pubkey *pubkey, secp256k1_ge *ge) {
+#ifdef VERIFY
+    /* ensure that the group element's Y coordinate is even, as per definition of x-only public keys */
+    secp256k1_fe y = ge->y;
+    secp256k1_fe_normalize_var(&y);
+    VERIFY_CHECK(!secp256k1_fe_is_odd(&y));
+#endif
+
     secp256k1_pubkey_save((secp256k1_pubkey *) pubkey, ge);
 }
 


### PR DESCRIPTION
A violation of this invariant has been found by reviewers of the silentpayments module (kudos to w0xlt and andrewtoth, see https://github.com/bitcoin-core/secp256k1/pull/1765#discussion_r3229620362, https://github.com/bitcoin-core/secp256k1/pull/1765#discussion_r3238616034). Closes #1892.