### PR TITLE
silentpayments: address #1765 follow-ups, add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Added
+ - New module `silentpayments` implements sending and receiving of Silent Payments according to [BIP 352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki). See:
+   - Header file `include/secp256k1_silentpayments.h` which defines the new API.
+   - Usage example `examples/silentpayments.c`.
+ - The `silentpayments` API currently requires full access to the transaction data (light client scanning is not implemented).
+
 ## [0.7.1] - 2026-01-26
 
 #### Changed

--- a/examples/silentpayments.c
+++ b/examples/silentpayments.c
@@ -295,7 +295,7 @@ int main(void) {
             NULL, 0
         );
         if (!ret) {
-            printf("Something went wrong, a recipient provided an invalid address.\n");
+            printf("Something went wrong, group limit exceeded or input secret keys sum to zero.\n");
             return EXIT_FAILURE;
         }
         printf("Alice created the following outputs for Bob and Carol:\n");

--- a/include/secp256k1_silentpayments.h
+++ b/include/secp256k1_silentpayments.h
@@ -75,15 +75,14 @@ typedef struct secp256k1_silentpayments_recipient {
  *  unfindable by the recipient.
  *
  *  Returns: 1 if creation of outputs was successful.
- *           0 on failure. This is expected only with an adversarially chosen
- *           recipient spend key. Specifically, failure occurs when:
- *             - Input secret keys sum to 0
- *               (negligible probability if at least one of the input secret
- *               keys is uniformly random and independent of all other keys)
- *             - A hash output is not a valid scalar (negligible probability
- *               per hash evaluation)
- *             - Any group (i.e. recipients sharing the same scan public key) exceeds
- *               the protocol limit SECP256K1_SILENTPAYMENTS_RECIPIENT_GROUP_LIMIT
+ *           0 on failure, i.e., when one of the following occurs:
+ *             - The size of any group (i.e. recipients sharing the same scan public key)
+ *               exceeds the protocol limit SECP256K1_SILENTPAYMENTS_RECIPIENT_GROUP_LIMIT.
+ *             - The sum of all input secret keys is 0.
+ *               (This occurs only with negligible probability if at least one of the
+ *               input secret keys is uniformly random and independent of all other keys.)
+ *             - An invalid output public key is created. (This can only happen for an
+ *               adversarially chosen recipient spend public key.)
  *
  *  Args:                ctx: pointer to a context object
  *                            (not secp256k1_context_static).
@@ -97,16 +96,14 @@ typedef struct secp256k1_silentpayments_recipient {
  *  In:           recipients: pointer to an array of pointers to Silent Payments
  *                            recipients, where each recipient is a scan public
  *                            key, a spend public key, and an index indicating
- *                            its position in the original ordering. The
- *                            recipient array will be grouped by scan public key
- *                            in place (as specified in BIP0352), but generated
- *                            outputs are saved in the `generated_outputs` array
- *                            to match the original ordering (using the index
- *                            field). This ensures the caller is able to match
- *                            the generated outputs to the correct Silent
- *                            Payments addresses. The same recipient can be
- *                            passed multiple times to create multiple outputs
- *                            for the same recipient.
+ *                            its position in the original ordering. This function
+ *                            may reorder the pointers to the recipient objects
+ *                            within the array, i.e., after the call (including on
+ *                            failure), the index fields of the recipient objects
+ *                            may no longer correspond to the positions in the
+ *                            array. Multiple recipient objects with the same scan
+ *                            public key and/or same spend public key can be passed
+ *                            if they carry different indices.
  *              n_recipients: the size of the recipients array.
  *       outpoint_smallest36: serialized (36-byte) smallest outpoint
  *                            (lexicographically) from the transaction inputs

--- a/src/modules/silentpayments/main_impl.h
+++ b/src/modules/silentpayments/main_impl.h
@@ -588,8 +588,11 @@ static int secp256k1_silentpayments_check_label_batch(
     *label_tweak = NULL;
     secp256k1_ge_set_all_gej_var(label_candidates_ge, label_candidates_gej, 2 * n_batch);
     for (i = 0; i < 2 * n_batch; i++) {
-        /* Serialize only non-infinity points because candidates are collected only when
-         * tx_output != unlabeled_output_xonly. */
+        /* Note: serialize will only fail if a label candidate is the point at infinity, but we know
+         * this cannot happen since we only collect candidates if tx_output != unlabeled_output. Thus,
+         * we know that label_candidate = tx_output - unlabeled_output cannot be the point at infinity.
+         */
+        VERIFY_CHECK(!secp256k1_ge_is_infinity(&label_candidates_ge[i]));
         secp256k1_eckey_pubkey_serialize33(&label_candidates_ge[i], label33);
         *label_tweak = label_lookup(label33, label_context);
         if (*label_tweak != NULL) {
@@ -648,6 +651,8 @@ int secp256k1_silentpayments_recipient_scan_outputs(
     }
     secp256k1_ge_from_bytes(&prevouts_pubkey_sum_ge, &prevouts_summary->data[5]);
     combined = (int)prevouts_summary->data[4];
+    /* Note that the "combined" flag can currently only be 0, as we only have support for full nodes, i.e.,
+     * the following branch is always taken. "combined" can also be 1 once we add light client support. */
     if (!combined) {
         secp256k1_scalar input_hash_scalar;
         secp256k1_scalar_set_b32(&input_hash_scalar, &prevouts_summary->data[5 + 64], NULL);


### PR DESCRIPTION
This PR addresses follow-up reviewer comments and Claude nits from #1765, see
 * https://github.com/bitcoin-core/secp256k1/pull/1765#discussion_r3629070333
 * https://github.com/bitcoin-core/secp256k1/pull/1765#discussion_r3628888249
 * https://github.com/bitcoin-core/secp256k1/pull/1765#discussion_r3629066762
 * https://github.com/bitcoin-core/secp256k1/pull/1765#pullrequestreview-4754517850 (points 3., 4. and 5. are tackled)

and adds an entry to the changelog.