### PR TITLE
changelog: add missing entries for #1777 and #1860

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 #### Added
+ - New function `secp256k1_context_set_sha256_compression` for overriding the internal SHA256 compression function used by the library at runtime (e.g., to route SHA256 through a hardware-accelerated implementation).
  - New module `silentpayments` implements sending and receiving of Silent Payments according to [BIP 352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki). See:
    - Header file `include/secp256k1_silentpayments.h` which defines the new API.
    - Usage example `examples/silentpayments.c`.
  - The `silentpayments` API currently requires full access to the transaction data (light client scanning is not implemented).
+
+#### Changed
+ - CMake: Shared libraries built with CMake on OpenBSD and NetBSD now create the full versioned filename (e.g. `libsecp256k1.so.6.2` instead of `libsecp256k1.so.6`) and symlink chain, matching the behavior of GNU Autotools builds.
 
 ## [0.7.1] - 2026-01-26
 
@@ -36,7 +40,8 @@ The ABI is backward compatible with version 0.7.0.
  - Removed `SECP256K1_WARN_UNUSED_RESULT` attribute (defined as `__attribute__ ((__warn_unused_result__))`) from several API functions that always return 1. Compilers will no longer warn if the return value is unused.
  - CMake: Building with CMake is no longer considered experimental.
  - CMake: The minimum required CMake version was increased to 3.22.
- - CMake: Shared libraries built with CMake on FreeBSD now create the full versioned filename and symlink chain, matching the behavior of autotools builds.
+ - CMake: Shared libraries built with CMake on FreeBSD now create the full versioned filename (e.g. `libsecp256k1.so.5.0.1` instead of `libsecp256k1.so.5`) and symlink chain, matching the behavior of GNU Autotools builds.
+
 
 #### Removed
 - Removed previously deprecated function aliases `secp256k1_ec_privkey_negate`, `secp256k1_ec_privkey_tweak_add` and


### PR DESCRIPTION
Adds changelog entries for merged PRs that still have the "needs-changelog" label, preparing for the upcoming release (scheduled for next week, August 3rd):
- #1777: "Make SHA256 compression runtime pluggable"
- #1860: "cmake: Emulate Libtool's behavior on NetBSD and OpenBSD"

The release note for #1860 is based on an earlier note on FreeBSD:
https://github.com/bitcoin-core/secp256k1/blob/0f6baf319fcae0d7f11a44fc9b4d4899b3f8082a/CHANGELOG.md?plain=1#L39