### PR TITLE
Use SHA256 override for pointers to known aux functions

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -417,7 +417,7 @@ typedef void (*secp256k1_sha256_compression_function)(
 /**
  * Set a callback function to override the internal SHA256 compression function.
  *
- * This installs a function to replace the built-in block-compression
+ * This installs a callback to replace the built-in block-compression
  * step used by the library's internal SHA256 implementation.
  * The provided callback must exactly implement the effect of n_blocks
  * repeated applications of the SHA256 compression function.
@@ -426,6 +426,14 @@ typedef void (*secp256k1_sha256_compression_function)(
  * SHA256 compression step through a hardware-accelerated or otherwise
  * specialized implementation. It is NOT meant for replacing SHA256
  * with a different hash function.
+ *
+ * Since auxiliary functions exposed by the library via a function
+ * pointer such as secp256k1_nonce_function_default do not take a
+ * context object, they will not use the callback when called directly
+ * from user code. (But they will use the callback when called from
+ * other library functions that do take a context object, e.g., when
+ * noncefp==NULL or noncefp==secp256k1_nonce_function_default is passed
+ * as an argument to secp256k1_ecdsa_sign.)
  *
  * Args:    ctx:             pointer to a context object.
  * In:      fn_compression:  pointer to a function implementing the compression function;

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -60,7 +60,7 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const se
     secp256k1_fe_get_b32(x, &pt.x);
     secp256k1_fe_get_b32(y, &pt.y);
 
-    if (hashfp == NULL) {
+    if (hashfp == NULL || hashfp == secp256k1_ecdh_hash_function_sha256) {
         /* Use ctx-aware function by default */
         ret = ecdh_hash_function_sha256_impl(secp256k1_get_hash_context(ctx), output, x, y, data);
     } else {

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -559,7 +559,7 @@ static int secp256k1_ecdsa_sign_inner(const secp256k1_context* ctx, secp256k1_sc
     while (1) {
         int is_nonce_valid;
 
-        if (noncefp == NULL) {
+        if (noncefp == NULL || noncefp == secp256k1_nonce_function_rfc6979) {
             /* Use ctx-aware function by default */
             ret = nonce_function_rfc6979_impl(secp256k1_get_hash_context(ctx), nonce32, msg32, seckey, NULL, (void*)noncedata, count);
         } else {


### PR DESCRIPTION
Resolves one item in #1835.