### PR TITLE
changelog: add entry for #1821

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Usage example `examples/silentpayments.c`.
  - The `silentpayments` API currently requires full access to the transaction data (light client scanning is not implemented).
 
+#### Fixed
+ - Module `ellswift`: `secp256k1_ellswift_xdh` now treats secret keys greater than or equal to the curve order as invalid and returns 0 as documented. Previously, keys greater than the curve order were silently reduced modulo the order and accepted. The probability that a securely generated key is greater than the curve order is negligible, and thus the old behavior does not constitute a security issue.
+
 #### Changed
  - The field multiplication and squaring routines of the 5x52 (64-bit) implementation are now force-inlined. This speeds up many library functions with GCC and MSVC (Clang is largely unaffected), e.g. `secp256k1_ecdsa_verify` and `secp256k1_schnorrsig_verify` by up to ~11%, at the cost of a somewhat larger compiled library. Force-inlining is disabled in unoptimized builds and when optimizing for size.
  - CMake: Shared libraries built with CMake on OpenBSD and NetBSD now create the full versioned filename (e.g. `libsecp256k1.so.6.2` instead of `libsecp256k1.so.6`) and symlink chain, matching the behavior of GNU Autotools builds.


### PR DESCRIPTION
Even though #1821 has the "needs-changelog" label, it doesn't show up in the search: https://github.com/bitcoin-core/secp256k1/pulls?q=is%3Apr+label%3Aneeds-changelog+is%3Aclosed (probably a bug?). Thanks to @real-or-random for finding this candidate by looking at the commit list manually (which is now also suggested in the release process since #1709).