### PR TITLE
refactor: rename `ctx` param to `ecmult_gen_ctx` where applicable

### DIFF
--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -16,6 +16,6 @@
 static int secp256k1_ecdsa_sig_parse(secp256k1_scalar *r, secp256k1_scalar *s, const unsigned char *sig, size_t size);
 static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar *r, const secp256k1_scalar *s);
 static int secp256k1_ecdsa_sig_verify(const secp256k1_scalar* r, const secp256k1_scalar* s, const secp256k1_ge *pubkey, const secp256k1_scalar *message);
-static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar* r, secp256k1_scalar* s, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid);
+static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_scalar *r, secp256k1_scalar *s, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid);
 
 #endif /* SECP256K1_ECDSA_H */

--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -271,14 +271,14 @@ static int secp256k1_ecdsa_sig_verify(const secp256k1_scalar *sigr, const secp25
 #endif
 }
 
-static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid) {
+static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid) {
     unsigned char b[32];
     secp256k1_ge r;
     secp256k1_scalar n;
     int overflow = 0;
     int high;
 
-    secp256k1_ecmult_gen_ge(ctx, &r, nonce);
+    secp256k1_ecmult_gen_ge(ecmult_gen_ctx, &r, nonce);
     secp256k1_fe_normalize(&r.x);
     secp256k1_fe_normalize(&r.y);
     secp256k1_fe_get_b32(b, &r.x);

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -133,13 +133,13 @@ typedef struct {
     secp256k1_fe proj_blind;
 } secp256k1_ecmult_gen_context;
 
-static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context* ctx, const secp256k1_hash_ctx *hash_ctx);
-static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context* ctx);
+static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx);
+static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ecmult_gen_ctx);
 
 /** Multiply with the generator: R = a*G */
-static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context* ctx, secp256k1_gej *r, const secp256k1_scalar *a);
-static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context* ctx, secp256k1_ge *r, const secp256k1_scalar *a);
+static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_gej *r, const secp256k1_scalar *a);
+static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_ge *r, const secp256k1_scalar *a);
 
-static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32);
+static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32);
 
 #endif /* SECP256K1_ECMULT_GEN_H */

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -14,20 +14,20 @@
 #include "hash_impl.h"
 #include "precomputed_ecmult_gen.h"
 
-static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context *ctx, const secp256k1_hash_ctx *hash_ctx) {
-    secp256k1_ecmult_gen_blind(ctx, hash_ctx, NULL);
-    ctx->built = 1;
+static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx) {
+    secp256k1_ecmult_gen_blind(ecmult_gen_ctx, hash_ctx, NULL);
+    ecmult_gen_ctx->built = 1;
 }
 
-static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context* ctx) {
-    return ctx->built;
+static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context *ecmult_gen_ctx) {
+    return ecmult_gen_ctx->built;
 }
 
-static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ctx) {
-    ctx->built = 0;
-    secp256k1_scalar_clear(&ctx->scalar_offset);
-    secp256k1_ge_clear(&ctx->ge_offset);
-    secp256k1_fe_clear(&ctx->proj_blind);
+static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ecmult_gen_ctx) {
+    ecmult_gen_ctx->built = 0;
+    secp256k1_scalar_clear(&ecmult_gen_ctx->scalar_offset);
+    secp256k1_ge_clear(&ecmult_gen_ctx->ge_offset);
+    secp256k1_fe_clear(&ecmult_gen_ctx->proj_blind);
 }
 
 /* Compute the scalar (2^COMB_BITS - 1) / 2, the difference between the gn argument to
@@ -51,7 +51,7 @@ static void secp256k1_ecmult_gen_scalar_diff(secp256k1_scalar* diff) {
     secp256k1_scalar_add(diff, diff, &neghalf);
 }
 
-static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, secp256k1_gej *r, const secp256k1_scalar *gn) {
+static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_gej *r, const secp256k1_scalar *gn) {
     uint32_t comb_off;
     secp256k1_ge add;
     secp256k1_fe neg;
@@ -97,17 +97,17 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
      *
      * Adding precomputation, our final equations become:
      *
-     *     ctx->scalar_offset = (2^COMB_BITS - 1)/2 - b (mod order)
-     *     ctx->ge_offset = b*G
-     *     d = gn + ctx->scalar_offset (mod order)
-     *     R = comb(d, G/2) + ctx->ge_offset
+     *     ecmult_gen_ctx->scalar_offset = (2^COMB_BITS - 1)/2 - b (mod order)
+     *     ecmult_gen_ctx->ge_offset = b*G
+     *     d = gn + ecmult_gen_ctx->scalar_offset (mod order)
+     *     R = comb(d, G/2) + ecmult_gen_ctx->ge_offset
      *
      * comb(d, G/2) function is then computed by summing + or - 2^(i-1)*G, for i=0..COMB_BITS-1,
      * depending on the value of the bits d[i] of the binary representation of scalar d.
      */
 
-    /* Compute the scalar d = (gn + ctx->scalar_offset). */
-    secp256k1_scalar_add(&d, &ctx->scalar_offset, gn);
+    /* Compute the scalar d = (gn + ecmult_gen_ctx->scalar_offset). */
+    secp256k1_scalar_add(&d, &ecmult_gen_ctx->scalar_offset, gn);
     /* Convert to recoded array. */
     for (i = 0; i < 8 && i < ((COMB_BITS + 31) >> 5); ++i) {
         recoded[i] = secp256k1_scalar_get_bits_limb32(&d, 32 * i, 32);
@@ -168,10 +168,10 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
      *       c = 2*c
      *   return c
      *
-     * This computes c = comb(d, G/2), and thus finally R = c + ctx->ge_offset. Note that it would
-     * be possible to apply an initial offset instead of a final offset (moving ge_offset to take
-     * the place of infinity above), but the chosen approach allows using (in a future improvement)
-     * an incomplete addition formula for most of the multiplication.
+     * This computes c = comb(d, G/2), and thus finally R = c + ecmult_gen_ctx->ge_offset. Note that
+     * it would be possible to apply an initial offset instead of a final offset (moving ge_offset
+     * to take the place of infinity above), but the chosen approach allows using (in a future
+     * improvement) an incomplete addition formula for most of the multiplication.
      *
      * The last question is how to implement the table(b, m) function. For any value of b,
      * m=(d & mask(b)) can only take on at most 2^COMB_TEETH possible values (the last one may have
@@ -258,7 +258,7 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
                 /* If this is the first table lookup, we can skip addition. */
                 secp256k1_gej_set_ge(r, &add);
                 /* Give the entry a random Z coordinate to blind intermediary results. */
-                secp256k1_gej_rescale(r, &ctx->proj_blind);
+                secp256k1_gej_rescale(r, &ecmult_gen_ctx->proj_blind);
                 first = 0;
             } else {
                 secp256k1_gej_add_ge(r, r, &add);
@@ -272,7 +272,7 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
 
     /* Correct for the scalar_offset added at the start (ge_offset = b*G, while b was
      * subtracted from the input scalar gn). */
-    secp256k1_gej_add_ge(r, r, &ctx->ge_offset);
+    secp256k1_gej_add_ge(r, r, &ecmult_gen_ctx->ge_offset);
 
     /* Cleanup. */
     secp256k1_fe_clear(&neg);
@@ -281,9 +281,9 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
     secp256k1_memclear_explicit(&recoded, sizeof(recoded));
 }
 
-SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context *ctx, secp256k1_ge *r, const secp256k1_scalar *a) {
+SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_ge *r, const secp256k1_scalar *a) {
     secp256k1_gej rj;
-    secp256k1_ecmult_gen_gej(ctx, &rj, a);
+    secp256k1_ecmult_gen_gej(ecmult_gen_ctx, &rj, a);
     secp256k1_ge_set_gej(r, &rj);
     /* Jacobian coordinates resulting from our multiplication algorithm could potentially leak
      * information about the secret input scalar, so clear the memory out to be on the safe side. */
@@ -291,7 +291,7 @@ SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_
 }
 
 /* Setup blinding values for secp256k1_ecmult_gen. */
-static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
+static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
     secp256k1_scalar b;
     secp256k1_scalar diff;
     secp256k1_fe f;
@@ -304,13 +304,13 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
 
     if (seed32 == NULL) {
         /* When seed is NULL, reset the final point and blinding value. */
-        secp256k1_ge_neg(&ctx->ge_offset, &secp256k1_ge_const_g);
-        secp256k1_scalar_add(&ctx->scalar_offset, &secp256k1_scalar_one, &diff);
-        ctx->proj_blind = secp256k1_fe_one;
+        secp256k1_ge_neg(&ecmult_gen_ctx->ge_offset, &secp256k1_ge_const_g);
+        secp256k1_scalar_add(&ecmult_gen_ctx->scalar_offset, &secp256k1_scalar_one, &diff);
+        ecmult_gen_ctx->proj_blind = secp256k1_fe_one;
         return;
     }
     /* The prior blinding value (if not reset) is chained forward by including it in the hash. */
-    secp256k1_scalar_get_b32(keydata, &ctx->scalar_offset);
+    secp256k1_scalar_get_b32(keydata, &ecmult_gen_ctx->scalar_offset);
     /** Using a CSPRNG allows a failure free interface, avoids needing large amounts of random data,
      *   and guards against weak or adversarial seeds.  This is a simpler and safer interface than
      *   asking the caller for blinding values directly and expecting them to retry on failure.
@@ -324,7 +324,7 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
     secp256k1_rfc6979_hmac_sha256_generate(hash_ctx, &rng, nonce32, 32);
     secp256k1_fe_set_b32_mod(&f, nonce32);
     secp256k1_fe_cmov(&f, &secp256k1_fe_one, secp256k1_fe_normalizes_to_zero(&f));
-    ctx->proj_blind = f;
+    ecmult_gen_ctx->proj_blind = f;
 
     /* For a random blinding value b, set scalar_offset=diff-b, ge_offset=bG */
     secp256k1_rfc6979_hmac_sha256_generate(hash_ctx, &rng, nonce32, 32);
@@ -333,9 +333,9 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
      * which secp256k1_gej_add_ge cannot handle. */
     secp256k1_scalar_cmov(&b, &secp256k1_scalar_one, secp256k1_scalar_is_zero(&b));
     secp256k1_rfc6979_hmac_sha256_finalize(&rng);
-    secp256k1_ecmult_gen_ge(ctx, &ctx->ge_offset, &b);
+    secp256k1_ecmult_gen_ge(ecmult_gen_ctx, &ecmult_gen_ctx->ge_offset, &b);
     secp256k1_scalar_negate(&b, &b);
-    secp256k1_scalar_add(&ctx->scalar_offset, &b, &diff);
+    secp256k1_scalar_add(&ecmult_gen_ctx->scalar_offset, &b, &diff);
 
     /* Clean up. */
     secp256k1_memclear_explicit(nonce32, sizeof(nonce32));

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -14,20 +14,20 @@
 #include "hash_impl.h"
 #include "precomputed_ecmult_gen.h"
 
-static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context *ctx, const secp256k1_hash_ctx *hash_ctx) {
-    secp256k1_ecmult_gen_blind(ctx, hash_ctx, NULL);
-    ctx->built = 1;
+static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx) {
+    secp256k1_ecmult_gen_blind(ecmult_gen_ctx, hash_ctx, NULL);
+    ecmult_gen_ctx->built = 1;
 }
 
-static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context* ctx) {
-    return ctx->built;
+static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context *ecmult_gen_ctx) {
+    return ecmult_gen_ctx->built;
 }
 
-static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ctx) {
-    ctx->built = 0;
-    secp256k1_scalar_clear(&ctx->scalar_offset);
-    secp256k1_ge_clear(&ctx->ge_offset);
-    secp256k1_fe_clear(&ctx->proj_blind);
+static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ecmult_gen_ctx) {
+    ecmult_gen_ctx->built = 0;
+    secp256k1_scalar_clear(&ecmult_gen_ctx->scalar_offset);
+    secp256k1_ge_clear(&ecmult_gen_ctx->ge_offset);
+    secp256k1_fe_clear(&ecmult_gen_ctx->proj_blind);
 }
 
 /* Compute the scalar (2^COMB_BITS - 1) / 2, the difference between the gn argument to
@@ -51,7 +51,7 @@ static void secp256k1_ecmult_gen_scalar_diff(secp256k1_scalar* diff) {
     secp256k1_scalar_add(diff, diff, &neghalf);
 }
 
-static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, secp256k1_gej *r, const secp256k1_scalar *gn) {
+static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_gej *r, const secp256k1_scalar *gn) {
     uint32_t comb_off;
     secp256k1_ge add;
     secp256k1_fe neg;
@@ -107,7 +107,7 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
      */
 
     /* Compute the scalar d = (gn + ctx->scalar_offset). */
-    secp256k1_scalar_add(&d, &ctx->scalar_offset, gn);
+    secp256k1_scalar_add(&d, &ecmult_gen_ctx->scalar_offset, gn);
     /* Convert to recoded array. */
     for (i = 0; i < 8 && i < ((COMB_BITS + 31) >> 5); ++i) {
         recoded[i] = secp256k1_scalar_get_bits_limb32(&d, 32 * i, 32);
@@ -258,7 +258,7 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
                 /* If this is the first table lookup, we can skip addition. */
                 secp256k1_gej_set_ge(r, &add);
                 /* Give the entry a random Z coordinate to blind intermediary results. */
-                secp256k1_gej_rescale(r, &ctx->proj_blind);
+                secp256k1_gej_rescale(r, &ecmult_gen_ctx->proj_blind);
                 first = 0;
             } else {
                 secp256k1_gej_add_ge(r, r, &add);
@@ -272,7 +272,7 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
 
     /* Correct for the scalar_offset added at the start (ge_offset = b*G, while b was
      * subtracted from the input scalar gn). */
-    secp256k1_gej_add_ge(r, r, &ctx->ge_offset);
+    secp256k1_gej_add_ge(r, r, &ecmult_gen_ctx->ge_offset);
 
     /* Cleanup. */
     secp256k1_fe_clear(&neg);
@@ -281,9 +281,9 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ctx, se
     secp256k1_memclear_explicit(&recoded, sizeof(recoded));
 }
 
-SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context *ctx, secp256k1_ge *r, const secp256k1_scalar *a) {
+SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_ge *r, const secp256k1_scalar *a) {
     secp256k1_gej rj;
-    secp256k1_ecmult_gen_gej(ctx, &rj, a);
+    secp256k1_ecmult_gen_gej(ecmult_gen_ctx, &rj, a);
     secp256k1_ge_set_gej(r, &rj);
     /* Jacobian coordinates resulting from our multiplication algorithm could potentially leak
      * information about the secret input scalar, so clear the memory out to be on the safe side. */
@@ -291,7 +291,7 @@ SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_
 }
 
 /* Setup blinding values for secp256k1_ecmult_gen. */
-static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
+static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
     secp256k1_scalar b;
     secp256k1_scalar diff;
     secp256k1_fe f;
@@ -304,13 +304,13 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
 
     if (seed32 == NULL) {
         /* When seed is NULL, reset the final point and blinding value. */
-        secp256k1_ge_neg(&ctx->ge_offset, &secp256k1_ge_const_g);
-        secp256k1_scalar_add(&ctx->scalar_offset, &secp256k1_scalar_one, &diff);
-        ctx->proj_blind = secp256k1_fe_one;
+        secp256k1_ge_neg(&ecmult_gen_ctx->ge_offset, &secp256k1_ge_const_g);
+        secp256k1_scalar_add(&ecmult_gen_ctx->scalar_offset, &secp256k1_scalar_one, &diff);
+        ecmult_gen_ctx->proj_blind = secp256k1_fe_one;
         return;
     }
     /* The prior blinding value (if not reset) is chained forward by including it in the hash. */
-    secp256k1_scalar_get_b32(keydata, &ctx->scalar_offset);
+    secp256k1_scalar_get_b32(keydata, &ecmult_gen_ctx->scalar_offset);
     /** Using a CSPRNG allows a failure free interface, avoids needing large amounts of random data,
      *   and guards against weak or adversarial seeds.  This is a simpler and safer interface than
      *   asking the caller for blinding values directly and expecting them to retry on failure.
@@ -324,7 +324,7 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
     secp256k1_rfc6979_hmac_sha256_generate(hash_ctx, &rng, nonce32, 32);
     secp256k1_fe_set_b32_mod(&f, nonce32);
     secp256k1_fe_cmov(&f, &secp256k1_fe_one, secp256k1_fe_normalizes_to_zero(&f));
-    ctx->proj_blind = f;
+    ecmult_gen_ctx->proj_blind = f;
 
     /* For a random blinding value b, set scalar_offset=diff-b, ge_offset=bG */
     secp256k1_rfc6979_hmac_sha256_generate(hash_ctx, &rng, nonce32, 32);
@@ -333,9 +333,9 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
      * which secp256k1_gej_add_ge cannot handle. */
     secp256k1_scalar_cmov(&b, &secp256k1_scalar_one, secp256k1_scalar_is_zero(&b));
     secp256k1_rfc6979_hmac_sha256_finalize(&rng);
-    secp256k1_ecmult_gen_ge(ctx, &ctx->ge_offset, &b);
+    secp256k1_ecmult_gen_ge(ecmult_gen_ctx, &ecmult_gen_ctx->ge_offset, &b);
     secp256k1_scalar_negate(&b, &b);
-    secp256k1_scalar_add(&ctx->scalar_offset, &b, &diff);
+    secp256k1_scalar_add(&ecmult_gen_ctx->scalar_offset, &b, &diff);
 
     /* Clean up. */
     secp256k1_memclear_explicit(nonce32, sizeof(nonce32));


### PR DESCRIPTION
To be more consistent and avoid confusion with regular `secp256k1_context` instances, rename the `ctx` parameter to `ecmult_gen_ctx` in all functions that take `secp256k1_ecmult_gen_context` pointers (see discussion https://github.com/bitcoin-core/secp256k1/issues/1835#issuecomment-4057203336 ff.).

While at it, move the * in pointer declarations of the touched functions to the right side for consistency across the code base, see PR #1252.