### PR TITLE
context: prevent clones from copying allocator residue

### DIFF
--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -128,6 +128,8 @@ secp256k1_context* secp256k1_context_preallocated_create(void* prealloc, unsigne
     }
     VERIFY_CHECK(prealloc != NULL);
     ret = (secp256k1_context*)prealloc;
+    /* Initialize padding before member writes leave it untouched. */
+    memset(ret, 0, sizeof(*ret));
     ret->illegal_callback = default_illegal_callback;
     ret->error_callback = default_error_callback;
     secp256k1_hash_ctx_init(&ret->hash_ctx);
@@ -158,6 +160,8 @@ secp256k1_context* secp256k1_context_preallocated_clone(const secp256k1_context*
     ARG_CHECK(secp256k1_context_is_proper(ctx));
 
     ret = (secp256k1_context*)prealloc;
+    /* Initialize padding if structure assignment leaves it untouched. */
+    memset(ret, 0, sizeof(*ret));
     *ret = *ctx;
     return ret;
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -258,6 +258,7 @@ static void run_proper_context_tests(int use_prealloc) {
     } else {
         my_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     }
+    SECP256K1_CHECKMEM_DEFINE(my_ctx, sizeof(*my_ctx)); /* TODO: Require defined padding. */
 
     /* Randomize and reset randomization */
     CHECK(context_eq(my_ctx, my_ctx_fresh));
@@ -310,6 +311,7 @@ static void run_proper_context_tests(int use_prealloc) {
             free(prealloc_tmp);
         }
     }
+    SECP256K1_CHECKMEM_DEFINE(my_ctx, sizeof(*my_ctx)); /* TODO: Require defined padding. */
 
     /* Verify that the error callback makes it across the clone. */
     CHECK(my_ctx->error_callback.fn != secp256k1_default_error_callback_fn);

--- a/src/tests.c
+++ b/src/tests.c
@@ -258,7 +258,7 @@ static void run_proper_context_tests(int use_prealloc) {
     } else {
         my_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     }
-    SECP256K1_CHECKMEM_DEFINE(my_ctx, sizeof(*my_ctx)); /* TODO: Require defined padding. */
+    SECP256K1_CHECKMEM_CHECK(my_ctx, sizeof(*my_ctx));
 
     /* Randomize and reset randomization */
     CHECK(context_eq(my_ctx, my_ctx_fresh));
@@ -311,7 +311,7 @@ static void run_proper_context_tests(int use_prealloc) {
             free(prealloc_tmp);
         }
     }
-    SECP256K1_CHECKMEM_DEFINE(my_ctx, sizeof(*my_ctx)); /* TODO: Require defined padding. */
+    SECP256K1_CHECKMEM_CHECK(my_ctx, sizeof(*my_ctx));
 
     /* Verify that the error callback makes it across the clone. */
     CHECK(my_ctx->error_callback.fn != secp256k1_default_error_callback_fn);


### PR DESCRIPTION
**Problem:** Context creation initializes every member but leaves padding bytes untouched.
Cloning a dynamically allocated context into caller-provided storage may copy undefined allocator bytes with the other members.
[The caller remains responsible for that storage after destroying the context](https://github.com/bitcoin-core/secp256k1/blob/687155df6b76f1da1639a6f0923b69e6beaa3a09/include/secp256k1_preallocated.h#L105-L119), so memory checkers report the undefined bytes when the block is compared or written out.
This is a local initialization defect, no remote or Bitcoin Core path is known.

**Fix:** Zero the complete context representation before member initialization and clone assignment.
Extend the existing context test to require every byte to be defined after both creation modes and both clone modes.