### PR TITLE
silentpayments: tweak spend pubkey using ecmult_gen_var (~25% scanning speedup for small N)

### DIFF
--- a/src/bench_ecmult.c
+++ b/src/bench_ecmult.c
@@ -108,6 +108,15 @@ static void bench_ecmult_gen(void* arg, int iters) {
     }
 }
 
+static void bench_ecmult_gen_var(void* arg, int iters) {
+    bench_data* data = (bench_data*)arg;
+    int i;
+
+    for (i = 0; i < iters; ++i) {
+        secp256k1_ecmult_gen_var_gej(&data->output[i], &data->scalars[(data->offset1+i) % POINTS]);
+    }
+}
+
 static void bench_ecmult_gen_teardown(void* arg, int iters) {
     bench_data* data = (bench_data*)arg;
     bench_ecmult_teardown_helper(data, NULL, NULL, &data->offset1, iters);
@@ -199,6 +208,8 @@ static void run_ecmult_bench(bench_data* data, int iters) {
     char str[32];
     sprintf(str, "ecmult_gen");
     run_benchmark(str, bench_ecmult_gen, bench_ecmult_setup, bench_ecmult_gen_teardown, data, 10, iters);
+    sprintf(str, "ecmult_gen_var");
+    run_benchmark(str, bench_ecmult_gen_var, bench_ecmult_setup, bench_ecmult_gen_teardown, data, 10, iters);
     sprintf(str, "ecmult_const");
     run_benchmark(str, bench_ecmult_const, bench_ecmult_setup, bench_ecmult_const_teardown, data, 10, iters);
     sprintf(str, "ecmult_const_xonly");

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -140,6 +140,10 @@ static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ecm
 static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_gej *r, const secp256k1_scalar *a);
 static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_ge *r, const secp256k1_scalar *a);
 
+/** Multiply with the generator: R = a*G, without constant-time guarantee. */
+static void secp256k1_ecmult_gen_var_gej(secp256k1_gej *r, const secp256k1_scalar *a);
+static void secp256k1_ecmult_gen_var_ge(secp256k1_ge *r, const secp256k1_scalar *a);
+
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32);
 
 #endif /* SECP256K1_ECMULT_GEN_H */

--- a/src/ecmult_gen_compute_table.h
+++ b/src/ecmult_gen_compute_table.h
@@ -10,5 +10,6 @@
 #include "ecmult_gen.h"
 
 static void secp256k1_ecmult_gen_compute_table(secp256k1_ge_storage* table, const secp256k1_ge* gen, int blocks, int teeth, int spacing);
+static void secp256k1_ecmult_gen_compute_scalar_diff(secp256k1_scalar* diff, int blocks, int teeth, int spacing);
 
 #endif /* SECP256K1_ECMULT_GEN_COMPUTE_TABLE_H */

--- a/src/ecmult_gen_compute_table_impl.h
+++ b/src/ecmult_gen_compute_table_impl.h
@@ -105,4 +105,26 @@ static void secp256k1_ecmult_gen_compute_table(secp256k1_ge_storage* table, cons
     free(prec);
 }
 
+/* Compute the scalar (2^COMB_BITS - 1) / 2, the difference between the gn argument to
+ * secp256k1_ecmult_gen, and the scalar whose encoding the table lookup bits are drawn
+ * from (before applying blinding). */
+static void secp256k1_ecmult_gen_compute_scalar_diff(secp256k1_scalar* diff, int blocks, int teeth, int spacing) {
+    int i;
+    int comb_bits = blocks * teeth * spacing;
+
+    /* Compute scalar -1/2. */
+    secp256k1_scalar neghalf;
+    secp256k1_scalar_half(&neghalf, &secp256k1_scalar_one);
+    secp256k1_scalar_negate(&neghalf, &neghalf);
+
+    /* Compute offset = 2^(COMB_BITS - 1). */
+    *diff = secp256k1_scalar_one;
+    for (i = 0; i < comb_bits - 1; ++i) {
+        secp256k1_scalar_add(diff, diff, diff);
+    }
+
+    /* The result is the sum 2^(COMB_BITS - 1) + (-1/2). */
+    secp256k1_scalar_add(diff, diff, &neghalf);
+}
+
 #endif /* SECP256K1_ECMULT_GEN_COMPUTE_TABLE_IMPL_H */

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -269,6 +269,74 @@ SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_
     secp256k1_gej_clear(&rj);
 }
 
+/* Variable-time variant for generator point multiplication.
+ *
+ * This is essentially a copy of `secp256k1_ecmult_gen_gej`, but with all side-channel
+ * mitigations (i.e., constant-time code, random scalar blinding, and memory clearing)
+ * removed. The EC point operation calls (addition, doubling) are replaced with their
+ * faster variable-time equivalents. This function is stateless and does not require
+ * a context parameter, enabling its use in internal functions.
+ *
+ * Note that the branch for the first table lookup assignment is also removed: since
+ * the result is initialized to the point at infinity, adding to it with `_gej_add_ge_var`
+ * is equivalent to a simple copy. */
+static void secp256k1_ecmult_gen_var_gej(secp256k1_gej *r, const secp256k1_scalar *gn) {
+    uint32_t comb_off;
+    secp256k1_ge add;
+    secp256k1_scalar d;
+    uint32_t recoded[(COMB_BITS + 31) >> 5] = {0};
+    int i;
+
+    /* Adjust input scalar for difference and convert to recoded array. */
+    secp256k1_scalar_add(&d, &secp256k1_ecmult_gen_scalar_diff, gn);
+    for (i = 0; i < 8 && i < ((COMB_BITS + 31) >> 5); ++i) {
+        recoded[i] = secp256k1_scalar_get_bits_limb32(&d, 32 * i, 32);
+    }
+
+    /* Outer loop: iterate over comb_off from COMB_SPACING - 1 down to 0. */
+    secp256k1_gej_set_infinity(r);
+    comb_off = COMB_SPACING - 1;
+    while (1) {
+        uint32_t block;
+        uint32_t bit_pos = comb_off;
+        /* Inner loop: for each block, add table entries to the result. */
+        for (block = 0; block < COMB_BLOCKS; ++block) {
+            /* Gather the mask(block)-selected bits of d into bits. They're packed:
+             * bits[tooth] = d[(block*COMB_TEETH + tooth)*COMB_SPACING + comb_off]. */
+            uint32_t bits = 0, sign, abs, tooth;
+            for (tooth = 0; tooth < COMB_TEETH; ++tooth) {
+                uint32_t bit = (recoded[bit_pos >> 5] >> (bit_pos & 0x1f)) & 1;
+                bits |= bit << tooth;
+                bit_pos += COMB_SPACING;
+            }
+
+            /* If the top bit of bits is 1, flip them all (corresponding to looking up
+             * the negated table value), and remember to negate the result in sign. */
+            sign = (bits >> (COMB_TEETH - 1)) & 1;
+            abs = (bits ^ -sign) & (COMB_POINTS - 1);
+            VERIFY_CHECK(sign == 0 || sign == 1);
+            VERIFY_CHECK(abs < COMB_POINTS);
+
+            /* Perform lookup, negate if necessary and add to r. */
+            secp256k1_ge_from_storage(&add, &secp256k1_ecmult_gen_prec_table[block][abs]);
+            if (sign) {
+                secp256k1_fe_negate(&add.y, &add.y, 1);
+            }
+            secp256k1_gej_add_ge_var(r, r, &add, NULL);
+        }
+
+        /* Double the result, except in the last iteration. */
+        if (comb_off-- == 0) break;
+        secp256k1_gej_double_var(r, r, NULL);
+    }
+}
+
+SECP256K1_INLINE static void secp256k1_ecmult_gen_var_ge(secp256k1_ge *r, const secp256k1_scalar *a) {
+    secp256k1_gej rj;
+    secp256k1_ecmult_gen_var_gej(&rj, a);
+    secp256k1_ge_set_gej_var(r, &rj);
+}
+
 /* Setup blinding values for secp256k1_ecmult_gen. */
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
     secp256k1_scalar b;

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -30,27 +30,6 @@ static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context *ecm
     secp256k1_fe_clear(&ecmult_gen_ctx->proj_blind);
 }
 
-/* Compute the scalar (2^COMB_BITS - 1) / 2, the difference between the gn argument to
- * secp256k1_ecmult_gen, and the scalar whose encoding the table lookup bits are drawn
- * from (before applying blinding). */
-static void secp256k1_ecmult_gen_scalar_diff(secp256k1_scalar* diff) {
-    int i;
-
-    /* Compute scalar -1/2. */
-    secp256k1_scalar neghalf;
-    secp256k1_scalar_half(&neghalf, &secp256k1_scalar_one);
-    secp256k1_scalar_negate(&neghalf, &neghalf);
-
-    /* Compute offset = 2^(COMB_BITS - 1). */
-    *diff = secp256k1_scalar_one;
-    for (i = 0; i < COMB_BITS - 1; ++i) {
-        secp256k1_scalar_add(diff, diff, diff);
-    }
-
-    /* The result is the sum 2^(COMB_BITS - 1) + (-1/2). */
-    secp256k1_scalar_add(diff, diff, &neghalf);
-}
-
 static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ecmult_gen_ctx, secp256k1_gej *r, const secp256k1_scalar *gn) {
     uint32_t comb_off;
     secp256k1_ge add;
@@ -293,14 +272,11 @@ SECP256K1_INLINE static void secp256k1_ecmult_gen_ge(const secp256k1_ecmult_gen_
 /* Setup blinding values for secp256k1_ecmult_gen. */
 static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ecmult_gen_ctx, const secp256k1_hash_ctx *hash_ctx, const unsigned char *seed32) {
     secp256k1_scalar b;
-    secp256k1_scalar diff;
+    const secp256k1_scalar diff = secp256k1_ecmult_gen_scalar_diff;
     secp256k1_fe f;
     unsigned char nonce32[32];
     secp256k1_rfc6979_hmac_sha256 rng;
     unsigned char keydata[64];
-
-    /* Compute the (2^COMB_BITS - 1)/2 term once. */
-    secp256k1_ecmult_gen_scalar_diff(&diff);
 
     if (seed32 == NULL) {
         /* When seed is NULL, reset the final point and blinding value. */

--- a/src/modules/silentpayments/main_impl.h
+++ b/src/modules/silentpayments/main_impl.h
@@ -11,7 +11,6 @@
 #include "../../../include/secp256k1_silentpayments.h"
 
 #include "../../eckey.h"
-#include "../../ecmult.h"
 #include "../../ecmult_const.h"
 #include "../../ecmult_gen.h"
 #include "../../group.h"
@@ -148,6 +147,20 @@ static int secp256k1_silentpayments_create_output_tweak(const secp256k1_context 
     return (!secp256k1_scalar_is_zero(t_k_scalar)) & (!overflow);
 }
 
+/* faster variant of _eckey_pubkey_tweak_add, taking advantage of variable-time generator point multiplication */
+static int secp256k1_silentpayments_pubkey_tweak_add(secp256k1_ge *pubkey, const secp256k1_scalar *tweak) {
+    secp256k1_gej tweak_g_gej, tweaked_pubkey_gej;
+
+    secp256k1_ecmult_gen_var_gej(&tweak_g_gej, tweak);
+    secp256k1_gej_add_ge_var(&tweaked_pubkey_gej, &tweak_g_gej, pubkey, NULL);
+    if (secp256k1_gej_is_infinity(&tweaked_pubkey_gej)) {
+        return 0;
+    }
+    secp256k1_ge_set_gej_var(pubkey, &tweaked_pubkey_gej);
+
+    return 1;
+}
+
 static int secp256k1_silentpayments_create_output_pubkey(const secp256k1_context *ctx, secp256k1_xonly_pubkey *output_xonly, const unsigned char *shared_secret33, const secp256k1_pubkey *spend_pubkey, uint32_t k) {
     secp256k1_ge output_ge;
     secp256k1_scalar t_k_scalar;
@@ -171,7 +184,7 @@ static int secp256k1_silentpayments_create_output_pubkey(const secp256k1_context
      * to protect against this function being called with malicious inputs, i.e.,
      *     spend_pubkey = -(_create_output_tweak(shared_secret33, k))*G
      */
-    if (!secp256k1_eckey_pubkey_tweak_add(&output_ge, &t_k_scalar)) {
+    if (!secp256k1_silentpayments_pubkey_tweak_add(&output_ge, &t_k_scalar)) {
         secp256k1_scalar_clear(&t_k_scalar);
         return 0;
     }
@@ -701,7 +714,7 @@ int secp256k1_silentpayments_recipient_scan_outputs(
         /* Calculate unlabeled_output = unlabeled_spend_pubkey + t_k * G.
          * This can fail if t_k * G is the negation of unlabeled_spend_pubkey, but this happens only with negligible
          * probability for honestly created unlabeled_spend_pubkey as t_k is the output of a hash function. */
-        if (!secp256k1_eckey_pubkey_tweak_add(&unlabeled_output_ge, &t_k_scalar)) {
+        if (!secp256k1_silentpayments_pubkey_tweak_add(&unlabeled_output_ge, &t_k_scalar)) {
             /* Leaking these values would break indistinguishability of the transaction, so clear them. */
             secp256k1_scalar_clear(&t_k_scalar);
             secp256k1_memclear_explicit(&shared_secret, sizeof(shared_secret));

--- a/src/precompute_ecmult_gen.c
+++ b/src/precompute_ecmult_gen.c
@@ -53,6 +53,21 @@ static void print_table(FILE* fp, int blocks, int teeth) {
     free(table);
 }
 
+static void print_scalar_diff(FILE* fp, int blocks, int teeth) {
+    int spacing = CEIL_DIV(256, blocks * teeth);
+    secp256k1_scalar diff;
+    int limb;
+
+    secp256k1_ecmult_gen_compute_scalar_diff(&diff, blocks, teeth, spacing);
+    fprintf(fp, "#elif (COMB_BLOCKS == %d) && (COMB_TEETH == %d) && (COMB_SPACING == %d)\n", blocks, teeth, spacing);
+    fprintf(fp, "    SECP256K1_SCALAR_CONST(");
+    for (limb = 7; limb >= 0; limb--) {
+        fprintf(fp, "0x%08x", secp256k1_scalar_get_bits_var(&diff, limb*32, 32));
+        if (limb != 0) fprintf(fp, ",");
+    }
+    fprintf(fp, ")\n");
+}
+
 int main(int argc, char **argv) {
     const char outfile[] = "src/precomputed_ecmult_gen.c";
     FILE* fp;
@@ -92,9 +107,21 @@ int main(int argc, char **argv) {
     fprintf(fp, "#else\n");
     fprintf(fp, "#    error Configuration mismatch, invalid COMB_* parameters. Try deleting precomputed_ecmult_gen.c before the build.\n");
     fprintf(fp, "#endif\n");
-
     fprintf(fp, "};\n");
-    fprintf(fp, "#undef S\n");
+    fprintf(fp, "#undef S\n\n");
+
+    fprintf(fp, "const secp256k1_scalar secp256k1_ecmult_gen_scalar_diff =\n");
+    fprintf(fp, "#if 0\n");
+    for (config = 0; config < ARRAY_SIZE(CONFIGS); ++config) {
+        print_scalar_diff(fp, CONFIGS[config][0], CONFIGS[config][1]);
+    }
+    if (!did_current_config) {
+        print_scalar_diff(fp, COMB_BLOCKS, COMB_TEETH);
+    }
+    fprintf(fp, "#else\n");
+    fprintf(fp, "#    error Configuration mismatch, invalid COMB_* parameters. Try deleting precomputed_ecmult_gen.c before the build.\n");
+    fprintf(fp, "#endif\n");
+    fprintf(fp, ";\n");
     fclose(fp);
 
     return EXIT_SUCCESS;

--- a/src/precomputed_ecmult_gen.c
+++ b/src/precomputed_ecmult_gen.c
@@ -1777,3 +1777,16 @@ S(ff3d6136,ffac5b0c,bfc6c5c0,c30dc01a,7ea3d56c,20bd3103,b178e3d3,ae180068,eccdc6
 #endif
 };
 #undef S
+
+const secp256k1_scalar secp256k1_ecmult_gen_scalar_diff =
+#if 0
+#elif (COMB_BLOCKS == 2) && (COMB_TEETH == 5) && (COMB_SPACING == 26)
+    SECP256K1_SCALAR_CONST(0x80000000,0x00000000,0x00000000,0x00000009,0x87e0873d,0xdd5f4e3f,0xe1563adf,0xe6691698)
+#elif (COMB_BLOCKS == 11) && (COMB_TEETH == 6) && (COMB_SPACING == 4)
+    SECP256K1_SCALAR_CONST(0x80000000,0x00000000,0x00000000,0x000000a2,0x05e8fb1b,0xb354323d,0xf6b9e8de,0x4cfa8020)
+#elif (COMB_BLOCKS == 43) && (COMB_TEETH == 6) && (COMB_SPACING == 1)
+    SECP256K1_SCALAR_CONST(0x80000000,0x00000000,0x00000000,0x00000001,0xe7f9b4a5,0xf9130fa6,0x6044722c,0xc7ae9e1e)
+#else
+#    error Configuration mismatch, invalid COMB_* parameters. Try deleting precomputed_ecmult_gen.c before the build.
+#endif
+;

--- a/src/precomputed_ecmult_gen.h
+++ b/src/precomputed_ecmult_gen.h
@@ -17,8 +17,10 @@ extern "C" {
 
 #ifdef EXHAUSTIVE_TEST_ORDER
 static secp256k1_ge_storage secp256k1_ecmult_gen_prec_table[COMB_BLOCKS][COMB_POINTS];
+static secp256k1_scalar secp256k1_ecmult_gen_scalar_diff;
 #else
 SECP256K1_LOCAL_VAR const secp256k1_ge_storage secp256k1_ecmult_gen_prec_table[COMB_BLOCKS][COMB_POINTS];
+SECP256K1_LOCAL_VAR const secp256k1_scalar secp256k1_ecmult_gen_scalar_diff;
 #endif /* defined(EXHAUSTIVE_TEST_ORDER) */
 
 #ifdef __cplusplus

--- a/src/tests.c
+++ b/src/tests.c
@@ -4694,10 +4694,14 @@ static void test_ecmult_target(const secp256k1_scalar* target, int mode) {
         secp256k1_ecmult(&p1j, &pj, &n1, &secp256k1_scalar_zero);
         secp256k1_ecmult(&p2j, &pj, &n2, &secp256k1_scalar_zero);
         secp256k1_ecmult(&ptj, &pj, target, &secp256k1_scalar_zero);
-    } else {
+    } else if (mode == 2) {
         secp256k1_ecmult_const(&p1j, &p, &n1);
         secp256k1_ecmult_const(&p2j, &p, &n2);
         secp256k1_ecmult_const(&ptj, &p, target);
+    } else {
+        secp256k1_ecmult_gen_var_gej(&p1j, &n1);
+        secp256k1_ecmult_gen_var_gej(&p2j, &n2);
+        secp256k1_ecmult_gen_var_gej(&ptj, target);
     }
 
     /* Add them all up: n1*P + n2*P + target*P = (n1+n2+target)*P = (n1+n1-n1-n2)*P = 0. */
@@ -4714,6 +4718,7 @@ static void run_ecmult_near_split_bound(void) {
             test_ecmult_target(&scalars_near_split_bounds[j], 0);
             test_ecmult_target(&scalars_near_split_bounds[j], 1);
             test_ecmult_target(&scalars_near_split_bounds[j], 2);
+            test_ecmult_target(&scalars_near_split_bounds[j], 3);
         }
     }
 }
@@ -5731,7 +5736,7 @@ static void test_ecmult_accumulate(secp256k1_sha256* acc, const secp256k1_scalar
     /* Compute x*G in many different ways, serialize it uncompressed, and feed it into acc. */
     secp256k1_gej gj, infj;
     secp256k1_ge r;
-    secp256k1_gej rj[7];
+    secp256k1_gej rj[8];
     unsigned char bytes[65];
     size_t i;
     secp256k1_gej_set_ge(&gj, &secp256k1_ge_const_g);
@@ -5743,6 +5748,7 @@ static void test_ecmult_accumulate(secp256k1_sha256* acc, const secp256k1_scalar
     CHECK(secp256k1_ecmult_multi_var(&CTX->error_callback, scratch, &rj[4], x, NULL, NULL, 0));
     CHECK(secp256k1_ecmult_multi_var(&CTX->error_callback, scratch, &rj[5], &secp256k1_scalar_zero, test_ecmult_accumulate_cb, (void*)x, 1));
     secp256k1_ecmult_const(&rj[6], &secp256k1_ge_const_g, x);
+    secp256k1_ecmult_gen_var_gej(&rj[7], x);
     secp256k1_ge_set_gej_var(&r, &rj[0]);
     for (i = 0; i < ARRAY_SIZE(rj); i++) {
         CHECK(secp256k1_gej_eq_ge_var(&rj[i], &r));

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -399,6 +399,8 @@ int main(int argc, char** argv) {
         printf("running tests for core %lu (out of [0..%lu])\n", (unsigned long)this_core, (unsigned long)num_cores - 1);
     }
 
+    /* Recreate the scalar_diff value using the proper COMB parameters (as selected via EXHAUSTIVE_TEST_ORDER) */
+    secp256k1_ecmult_gen_compute_scalar_diff(&secp256k1_ecmult_gen_scalar_diff, COMB_BLOCKS, COMB_TEETH, COMB_SPACING);
     /* Recreate the ecmult{,_gen} tables using the right generator (as selected via EXHAUSTIVE_TEST_ORDER) */
     secp256k1_ecmult_gen_compute_table(&secp256k1_ecmult_gen_prec_table[0][0], &secp256k1_ge_const_g, COMB_BLOCKS, COMB_TEETH, COMB_SPACING);
     secp256k1_ecmult_compute_two_tables(secp256k1_pre_g, secp256k1_pre_g_128, WINDOW_G, &secp256k1_ge_const_g);

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -425,13 +425,15 @@ int main(int argc, char** argv) {
                 secp256k1_gej_rescale(&groupj[i], &z);
             }
 
-            /* Verify against ecmult_gen */
+            /* Verify against ecmult_gen(_var) */
             {
                 secp256k1_scalar scalar_i;
-                secp256k1_ge generated;
+                secp256k1_ge generated, generated_var;
 
                 secp256k1_scalar_set_int(&scalar_i, i);
                 secp256k1_ecmult_gen_ge(&ctx->ecmult_gen_ctx, &generated, &scalar_i);
+                secp256k1_ecmult_gen_var_ge(&generated_var, &scalar_i);
+                CHECK(secp256k1_ge_eq_var(&generated, &generated_var));
 
                 CHECK(!secp256k1_ge_is_infinity(&group[i]));
                 CHECK(secp256k1_ge_eq_var(&group[i], &generated));


### PR DESCRIPTION
Based on the #1883 branch, this PR takes advantage of the variable-time generator point multiplication function `ecmult_gen_var` for  spend public key tweaking in the output public key calculation $P_k = B_{spend} + t_k \cdot G$ (used both for [sending](https://github.com/bitcoin/bips/blob/60f5b33b0a7be3cf09b933d97b78071d684db7d1/bip-0352.mediawiki?plain=1#L313) and [scanning](https://github.com/bitcoin/bips/blob/60f5b33b0a7be3cf09b933d97b78071d684db7d1/bip-0352.mediawiki?plain=1#L349)). Note that $t_k$ is not considered a long-term secret (in contrast to e.g. the scan secret key), so using variable-time functions should be fine. This leads to a ~25% scanning speedup if the number of transaction outputs is small (N <= 10).

Results on my arm64 machine (as per `$ ./build/bin/bench silentpayments_scan_nomatch`, see also the commit body):

| N    | master    | PR branch | speedup |
|------|-----------|-----------|---------|
| 2    | 39.3 us   | 30.3 us   | 28.85%  |
| 5    | 40.4 us   | 31.7 us   | 27.44%  |
| 10   | 43.3 us   | 34.6 us   | 25.14%  |
| 100  | 89.6 us   | 81.2 us   | 10.34%  |
| 1000 | 1259.0 us | 1244.0 us | 1.99%   |

This PR is similar to the previous ones #1843, #1844, but it only changes the behavior of the silentpayments module and leaves other API functions unchanged.