### PR TITLE
refactor: Move (de)ser helpers from musig and eckey to group

### DIFF
--- a/src/eckey.h
+++ b/src/eckey.h
@@ -14,12 +14,6 @@
 #include "ecmult.h"
 #include "ecmult_gen.h"
 
-static int secp256k1_eckey_pubkey_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size);
-/** Serialize a group element (that is not allowed to be infinity) to a compressed public key (33 bytes). */
-static void secp256k1_eckey_pubkey_serialize33(secp256k1_ge *elem, unsigned char *pub33);
-/** Serialize a group element (that is not allowed to be infinity) to an uncompressed public key (65 bytes). */
-static void secp256k1_eckey_pubkey_serialize65(secp256k1_ge *elem, unsigned char *pub65);
-
 static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak);
 static int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_scalar *tweak);
 static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak);

--- a/src/eckey.h
+++ b/src/eckey.h
@@ -14,9 +14,9 @@
 #include "ecmult.h"
 #include "ecmult_gen.h"
 
-static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak);
+static int secp256k1_eckey_seckey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak);
 static int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_scalar *tweak);
-static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak);
+static int secp256k1_eckey_seckey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak);
 static int secp256k1_eckey_pubkey_tweak_mul(secp256k1_ge *key, const secp256k1_scalar *tweak);
 
 #endif /* SECP256K1_ECKEY_H */

--- a/src/eckey_impl.h
+++ b/src/eckey_impl.h
@@ -15,7 +15,7 @@
 #include "group.h"
 #include "ecmult_gen.h"
 
-static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
+static int secp256k1_eckey_seckey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
     secp256k1_scalar_add(key, key, tweak);
     return !secp256k1_scalar_is_zero(key);
 }
@@ -32,7 +32,7 @@ static int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge *key, const secp256k1_s
     return 1;
 }
 
-static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
+static int secp256k1_eckey_seckey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
     int ret;
     ret = !secp256k1_scalar_is_zero(tweak);
 

--- a/src/eckey_impl.h
+++ b/src/eckey_impl.h
@@ -15,45 +15,6 @@
 #include "group.h"
 #include "ecmult_gen.h"
 
-static int secp256k1_eckey_pubkey_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size) {
-    if (size == 33 && (pub[0] == SECP256K1_TAG_PUBKEY_EVEN || pub[0] == SECP256K1_TAG_PUBKEY_ODD)) {
-        secp256k1_fe x;
-        return secp256k1_fe_set_b32_limit(&x, pub+1) && secp256k1_ge_set_xo_var(elem, &x, pub[0] == SECP256K1_TAG_PUBKEY_ODD);
-    } else if (size == 65 && (pub[0] == SECP256K1_TAG_PUBKEY_UNCOMPRESSED || pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_EVEN || pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_ODD)) {
-        secp256k1_fe x, y;
-        if (!secp256k1_fe_set_b32_limit(&x, pub+1) || !secp256k1_fe_set_b32_limit(&y, pub+33)) {
-            return 0;
-        }
-        secp256k1_ge_set_xy(elem, &x, &y);
-        if ((pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_EVEN || pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_ODD) &&
-            secp256k1_fe_is_odd(&y) != (pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_ODD)) {
-            return 0;
-        }
-        return secp256k1_ge_is_valid_var(elem);
-    } else {
-        return 0;
-    }
-}
-
-static void secp256k1_eckey_pubkey_serialize33(secp256k1_ge *elem, unsigned char *pub33) {
-    VERIFY_CHECK(!secp256k1_ge_is_infinity(elem));
-
-    secp256k1_fe_normalize_var(&elem->x);
-    secp256k1_fe_normalize_var(&elem->y);
-    pub33[0] = secp256k1_fe_is_odd(&elem->y) ? SECP256K1_TAG_PUBKEY_ODD : SECP256K1_TAG_PUBKEY_EVEN;
-    secp256k1_fe_get_b32(&pub33[1], &elem->x);
-}
-
-static void secp256k1_eckey_pubkey_serialize65(secp256k1_ge *elem, unsigned char *pub65) {
-    VERIFY_CHECK(!secp256k1_ge_is_infinity(elem));
-
-    secp256k1_fe_normalize_var(&elem->x);
-    secp256k1_fe_normalize_var(&elem->y);
-    pub65[0] = SECP256K1_TAG_PUBKEY_UNCOMPRESSED;
-    secp256k1_fe_get_b32(&pub65[1], &elem->x);
-    secp256k1_fe_get_b32(&pub65[33], &elem->y);
-}
-
 static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
     secp256k1_scalar_add(key, key, tweak);
     return !secp256k1_scalar_is_zero(key);

--- a/src/group.h
+++ b/src/group.h
@@ -196,6 +196,15 @@ static void secp256k1_ge_to_bytes_ext(unsigned char *data, const secp256k1_ge *g
  *  provided buffer is the output of secp256k1_ge_to_bytes_ext. */
 static void secp256k1_ge_from_bytes_ext(secp256k1_ge *ge, const unsigned char *data);
 
+/** Parse a group element from a 33-byte compressed or 65-byte uncompressed public key. */
+static int secp256k1_ge_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size);
+
+/** Serialize a group element (that is not allowed to be infinity) to a compressed public key (33 bytes). */
+static void secp256k1_ge_serialize33(secp256k1_ge *elem, unsigned char *pub33);
+
+/** Serialize a group element (that is not allowed to be infinity) to an uncompressed public key (65 bytes). */
+static void secp256k1_ge_serialize65(secp256k1_ge *elem, unsigned char *pub65);
+
 /** Determine if a point (which is assumed to be on the curve) is in the correct (sub)group of the curve.
  *
  * In normal mode, the used group is secp256k1, which has cofactor=1 meaning that every point on the curve is in the

--- a/src/group.h
+++ b/src/group.h
@@ -205,6 +205,14 @@ static void secp256k1_ge_serialize33(secp256k1_ge *elem, unsigned char *pub33);
 /** Serialize a group element (that is not allowed to be infinity) to an uncompressed public key (65 bytes). */
 static void secp256k1_ge_serialize65(secp256k1_ge *elem, unsigned char *pub65);
 
+/** Outputs 33 zero bytes if the given group element is the point at infinity and
+ *  otherwise outputs the compressed serialization */
+static void secp256k1_ge_serialize_ext33(unsigned char *out33, secp256k1_ge *ge);
+
+/** Outputs the point at infinity if the given byte array is all zero, otherwise
+ *  attempts to parse compressed point serialization. */
+static int secp256k1_ge_parse_ext33(secp256k1_ge *ge, const unsigned char *in33);
+
 /** Determine if a point (which is assumed to be on the curve) is in the correct (sub)group of the curve.
  *
  * In normal mode, the used group is secp256k1, which has cofactor=1 meaning that every point on the curve is in the

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -1011,4 +1011,43 @@ static void secp256k1_ge_from_bytes_ext(secp256k1_ge *ge, const unsigned char *d
     }
 }
 
+static int secp256k1_ge_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size) {
+    if (size == 33 && (pub[0] == SECP256K1_TAG_PUBKEY_EVEN || pub[0] == SECP256K1_TAG_PUBKEY_ODD)) {
+        secp256k1_fe x;
+        return secp256k1_fe_set_b32_limit(&x, pub+1) && secp256k1_ge_set_xo_var(elem, &x, pub[0] == SECP256K1_TAG_PUBKEY_ODD);
+    } else if (size == 65 && (pub[0] == SECP256K1_TAG_PUBKEY_UNCOMPRESSED || pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_EVEN || pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_ODD)) {
+        secp256k1_fe x, y;
+        if (!secp256k1_fe_set_b32_limit(&x, pub+1) || !secp256k1_fe_set_b32_limit(&y, pub+33)) {
+            return 0;
+        }
+        secp256k1_ge_set_xy(elem, &x, &y);
+        if ((pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_EVEN || pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_ODD) &&
+            secp256k1_fe_is_odd(&y) != (pub[0] == SECP256K1_TAG_PUBKEY_HYBRID_ODD)) {
+            return 0;
+        }
+        return secp256k1_ge_is_valid_var(elem);
+    } else {
+        return 0;
+    }
+}
+
+static void secp256k1_ge_serialize33(secp256k1_ge *elem, unsigned char *pub33) {
+    VERIFY_CHECK(!secp256k1_ge_is_infinity(elem));
+
+    secp256k1_fe_normalize_var(&elem->x);
+    secp256k1_fe_normalize_var(&elem->y);
+    pub33[0] = secp256k1_fe_is_odd(&elem->y) ? SECP256K1_TAG_PUBKEY_ODD : SECP256K1_TAG_PUBKEY_EVEN;
+    secp256k1_fe_get_b32(&pub33[1], &elem->x);
+}
+
+static void secp256k1_ge_serialize65(secp256k1_ge *elem, unsigned char *pub65) {
+    VERIFY_CHECK(!secp256k1_ge_is_infinity(elem));
+
+    secp256k1_fe_normalize_var(&elem->x);
+    secp256k1_fe_normalize_var(&elem->y);
+    pub65[0] = SECP256K1_TAG_PUBKEY_UNCOMPRESSED;
+    secp256k1_fe_get_b32(&pub65[1], &elem->x);
+    secp256k1_fe_get_b32(&pub65[33], &elem->y);
+}
+
 #endif /* SECP256K1_GROUP_IMPL_H */

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -1050,4 +1050,26 @@ static void secp256k1_ge_serialize65(secp256k1_ge *elem, unsigned char *pub65) {
     secp256k1_fe_get_b32(&pub65[33], &elem->y);
 }
 
+static void secp256k1_ge_serialize_ext33(unsigned char *out33, secp256k1_ge *ge) {
+    if (secp256k1_ge_is_infinity(ge)) {
+        memset(out33, 0, 33);
+    } else {
+        /* Serialize must succeed because the point is not at infinity */
+        secp256k1_ge_serialize33(ge, out33);
+    }
+}
+
+static int secp256k1_ge_parse_ext33(secp256k1_ge *ge, const unsigned char *in33) {
+    unsigned char zeros[33] = { 0 };
+
+    if (secp256k1_memcmp_var(in33, zeros, sizeof(zeros)) == 0) {
+        secp256k1_ge_set_infinity(ge);
+        return 1;
+    }
+    if (!secp256k1_ge_parse(ge, in33, 33)) {
+        return 0;
+    }
+    return secp256k1_ge_is_in_correct_subgroup(ge);
+}
+
 #endif /* SECP256K1_GROUP_IMPL_H */

--- a/src/modules/ellswift/main_impl.h
+++ b/src/modules/ellswift/main_impl.h
@@ -405,7 +405,7 @@ int secp256k1_ellswift_encode(const secp256k1_context *ctx, unsigned char *ell64
         /* Set up hasher state; the used RNG is H(pubkey || "\x00"*31 || rnd32 || cnt++), using
          * BIP340 tagged hash with tag "secp256k1_ellswift_encode". */
         secp256k1_ellswift_sha256_init_encode(&hash);
-        secp256k1_eckey_pubkey_serialize33(&p, p64);
+        secp256k1_ge_serialize33(&p, p64);
         secp256k1_sha256_write(secp256k1_get_hash_context(ctx), &hash, p64, sizeof(p64));
         secp256k1_sha256_write(secp256k1_get_hash_context(ctx), &hash, rnd32, 32);
 

--- a/src/modules/musig/keyagg_impl.h
+++ b/src/modules/musig/keyagg_impl.h
@@ -116,7 +116,7 @@ static void secp256k1_musig_keyaggcoef_internal(const secp256k1_hash_ctx *hash_c
         secp256k1_sha256_write(hash_ctx, &sha, pks_hash, 32);
         /* Serialization does not fail since the pk is not the point at infinity
          * (according to this function's precondition). */
-        secp256k1_eckey_pubkey_serialize33(pk, buf);
+        secp256k1_ge_serialize33(pk, buf);
         secp256k1_sha256_write(hash_ctx, &sha, buf, sizeof(buf));
         secp256k1_sha256_finalize(hash_ctx, &sha, buf);
         secp256k1_scalar_set_b32(r, buf, NULL);

--- a/src/modules/musig/session_impl.h
+++ b/src/modules/musig/session_impl.h
@@ -19,32 +19,6 @@
 #include "../../scalar.h"
 #include "../../util.h"
 
-/* Outputs 33 zero bytes if the given group element is the point at infinity and
- * otherwise outputs the compressed serialization */
-static void secp256k1_musig_ge_serialize_ext(unsigned char *out33, secp256k1_ge* ge) {
-    if (secp256k1_ge_is_infinity(ge)) {
-        memset(out33, 0, 33);
-    } else {
-        /* Serialize must succeed because the point is not at infinity */
-        secp256k1_ge_serialize33(ge, out33);
-    }
-}
-
-/* Outputs the point at infinity if the given byte array is all zero, otherwise
- * attempts to parse compressed point serialization. */
-static int secp256k1_musig_ge_parse_ext(secp256k1_ge* ge, const unsigned char *in33) {
-    unsigned char zeros[33] = { 0 };
-
-    if (secp256k1_memcmp_var(in33, zeros, sizeof(zeros)) == 0) {
-        secp256k1_ge_set_infinity(ge);
-        return 1;
-    }
-    if (!secp256k1_ge_parse(ge, in33, 33)) {
-        return 0;
-    }
-    return secp256k1_ge_is_in_correct_subgroup(ge);
-}
-
 static const unsigned char secp256k1_musig_secnonce_magic[4] = { 0x22, 0x0e, 0xdc, 0xf1 };
 
 static void secp256k1_musig_secnonce_save(secp256k1_musig_secnonce *secnonce, const secp256k1_scalar *k, const secp256k1_ge *pk) {
@@ -233,7 +207,7 @@ int secp256k1_musig_aggnonce_parse(const secp256k1_context* ctx, secp256k1_musig
     ARG_CHECK(in66 != NULL);
 
     for (i = 0; i < 2; i++) {
-        if (!secp256k1_musig_ge_parse_ext(&ges[i], &in66[33*i])) {
+        if (!secp256k1_ge_parse_ext33(&ges[i], &in66[33*i])) {
             return 0;
         }
     }
@@ -254,7 +228,7 @@ int secp256k1_musig_aggnonce_serialize(const secp256k1_context* ctx, unsigned ch
         return 0;
     }
     for (i = 0; i < 2; i++) {
-        secp256k1_musig_ge_serialize_ext(&out66[33*i], &ges[i]);
+        secp256k1_ge_serialize_ext33(&out66[33*i], &ges[i]);
     }
     return 1;
 }
@@ -546,7 +520,7 @@ static void secp256k1_musig_compute_noncehash(const secp256k1_hash_ctx *hash_ctx
 
     secp256k1_musig_compute_noncehash_sha256_tagged(&sha);
     for (i = 0; i < 2; i++) {
-        secp256k1_musig_ge_serialize_ext(buf, &aggnonce[i]);
+        secp256k1_ge_serialize_ext33(buf, &aggnonce[i]);
         secp256k1_sha256_write(hash_ctx, &sha, buf, sizeof(buf));
     }
     secp256k1_sha256_write(hash_ctx, &sha, agg_pk32, 32);

--- a/src/modules/musig/session_impl.h
+++ b/src/modules/musig/session_impl.h
@@ -26,7 +26,7 @@ static void secp256k1_musig_ge_serialize_ext(unsigned char *out33, secp256k1_ge*
         memset(out33, 0, 33);
     } else {
         /* Serialize must succeed because the point is not at infinity */
-        secp256k1_eckey_pubkey_serialize33(ge, out33);
+        secp256k1_ge_serialize33(ge, out33);
     }
 }
 
@@ -39,7 +39,7 @@ static int secp256k1_musig_ge_parse_ext(secp256k1_ge* ge, const unsigned char *i
         secp256k1_ge_set_infinity(ge);
         return 1;
     }
-    if (!secp256k1_eckey_pubkey_parse(ge, in33, 33)) {
+    if (!secp256k1_ge_parse(ge, in33, 33)) {
         return 0;
     }
     return secp256k1_ge_is_in_correct_subgroup(ge);
@@ -194,7 +194,7 @@ int secp256k1_musig_pubnonce_parse(const secp256k1_context* ctx, secp256k1_musig
     ARG_CHECK(in66 != NULL);
 
     for (i = 0; i < 2; i++) {
-        if (!secp256k1_eckey_pubkey_parse(&ges[i], &in66[33*i], 33)) {
+        if (!secp256k1_ge_parse(&ges[i], &in66[33*i], 33)) {
             return 0;
         }
         if (!secp256k1_ge_is_in_correct_subgroup(&ges[i])) {
@@ -219,7 +219,7 @@ int secp256k1_musig_pubnonce_serialize(const secp256k1_context* ctx, unsigned ch
     }
     for (i = 0; i < 2; i++) {
         /* serialize must succeed because the point was just loaded */
-        secp256k1_eckey_pubkey_serialize33(&ges[i], &out66[33*i]);
+        secp256k1_ge_serialize33(&ges[i], &out66[33*i]);
     }
     return 1;
 }
@@ -405,7 +405,7 @@ static int secp256k1_musig_nonce_gen_internal(const secp256k1_context* ctx, secp
         return 0;
     }
     /* A pubkey cannot be the point at infinity */
-    secp256k1_eckey_pubkey_serialize33(&pk, pk_ser);
+    secp256k1_ge_serialize33(&pk, pk_ser);
 
     secp256k1_nonce_function_musig(secp256k1_get_hash_context(ctx), k, input_nonce, msg32, seckey, pk_ser, aggpk_ser_ptr, extra_input32);
     VERIFY_CHECK(!secp256k1_scalar_is_zero(&k[0]));

--- a/src/modules/silentpayments/main_impl.h
+++ b/src/modules/silentpayments/main_impl.h
@@ -71,7 +71,7 @@ static int secp256k1_silentpayments_calculate_input_hash_scalar(const secp256k1_
 
     secp256k1_silentpayments_sha256_init_inputs(&hash);
     secp256k1_sha256_write(hash_ctx, &hash, outpoint_smallest36, 36);
-    secp256k1_eckey_pubkey_serialize33(pubkey_sum, pubkey_sum_ser);
+    secp256k1_ge_serialize33(pubkey_sum, pubkey_sum_ser);
     secp256k1_sha256_write(hash_ctx, &hash, pubkey_sum_ser, sizeof(pubkey_sum_ser));
     secp256k1_sha256_finalize(hash_ctx, &hash, input_hash);
     /* Convert input_hash to a scalar.
@@ -367,7 +367,7 @@ int secp256k1_silentpayments_recipient_label_parse(const secp256k1_context* ctx,
     memset(label, 0, sizeof(*label));
     ARG_CHECK(in33 != NULL);
 
-    if (!secp256k1_eckey_pubkey_parse(&ge, in33, 33)) {
+    if (!secp256k1_ge_parse(&ge, in33, 33)) {
         return 0;
     }
 
@@ -386,7 +386,7 @@ int secp256k1_silentpayments_recipient_label_serialize(const secp256k1_context* 
     if (!secp256k1_silentpayments_label_load(ctx, &ge, label)) {
         return 0;
     }
-    secp256k1_eckey_pubkey_serialize33(&ge, out33);
+    secp256k1_ge_serialize33(&ge, out33);
     return 1;
 }
 
@@ -593,7 +593,7 @@ static int secp256k1_silentpayments_check_label_batch(
          * we know that label_candidate = tx_output - unlabeled_output cannot be the point at infinity.
          */
         VERIFY_CHECK(!secp256k1_ge_is_infinity(&label_candidates_ge[i]));
-        secp256k1_eckey_pubkey_serialize33(&label_candidates_ge[i], label33);
+        secp256k1_ge_serialize33(&label_candidates_ge[i], label33);
         *label_tweak = label_lookup(label33, label_context);
         if (*label_tweak != NULL) {
             *label_ge = label_candidates_ge[i];

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -272,7 +272,7 @@ int secp256k1_ec_pubkey_parse(const secp256k1_context* ctx, secp256k1_pubkey* pu
     ARG_CHECK(pubkey != NULL);
     memset(pubkey, 0, sizeof(*pubkey));
     ARG_CHECK(input != NULL);
-    if (!secp256k1_eckey_pubkey_parse(&Q, input, inputlen)) {
+    if (!secp256k1_ge_parse(&Q, input, inputlen)) {
         return 0;
     }
     if (!secp256k1_ge_is_in_correct_subgroup(&Q)) {
@@ -298,10 +298,10 @@ int secp256k1_ec_pubkey_serialize(const secp256k1_context* ctx, unsigned char *o
     ARG_CHECK((flags & SECP256K1_FLAGS_TYPE_MASK) == SECP256K1_FLAGS_TYPE_COMPRESSION);
     if (secp256k1_pubkey_load(ctx, &Q, pubkey)) {
         if (flags & SECP256K1_FLAGS_BIT_COMPRESSION) {
-            secp256k1_eckey_pubkey_serialize33(&Q, output);
+            secp256k1_ge_serialize33(&Q, output);
             *outputlen = 33;
         } else {
-            secp256k1_eckey_pubkey_serialize65(&Q, output);
+            secp256k1_ge_serialize65(&Q, output);
             *outputlen = 65;
         }
         return 1;

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -688,7 +688,7 @@ static int secp256k1_ec_seckey_tweak_add_helper(secp256k1_scalar *sec, const uns
     int ret = 0;
 
     secp256k1_scalar_set_b32(&term, tweak32, &overflow);
-    ret = (!overflow) & secp256k1_eckey_privkey_tweak_add(sec, &term);
+    ret = (!overflow) & secp256k1_eckey_seckey_tweak_add(sec, &term);
     secp256k1_scalar_clear(&term);
     return ret;
 }
@@ -744,7 +744,7 @@ int secp256k1_ec_seckey_tweak_mul(const secp256k1_context* ctx, unsigned char *s
 
     secp256k1_scalar_set_b32(&factor, tweak32, &overflow);
     ret = secp256k1_scalar_set_b32_seckey(&sec, seckey);
-    ret &= (!overflow) & secp256k1_eckey_privkey_tweak_mul(&sec, &factor);
+    ret &= (!overflow) & secp256k1_eckey_seckey_tweak_mul(&sec, &factor);
     secp256k1_scalar_cmov(&sec, &secp256k1_scalar_zero, !ret);
     secp256k1_scalar_get_b32(seckey, &sec);
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -5747,7 +5747,7 @@ static void test_ecmult_accumulate(secp256k1_sha256* acc, const secp256k1_scalar
         secp256k1_sha256_write(secp256k1_get_hash_context(CTX), acc, zerobyte, 1);
     } else {
         /* Store other points using their uncompressed serialization. */
-        secp256k1_eckey_pubkey_serialize65(&r, bytes);
+        secp256k1_ge_serialize65(&r, bytes);
         secp256k1_sha256_write(secp256k1_get_hash_context(CTX), acc, bytes, sizeof(bytes));
     }
 }
@@ -6853,7 +6853,7 @@ static void test_random_pubkeys(void) {
     if (len > 33) {
         testrand256(&in[33]);
     }
-    if (secp256k1_eckey_pubkey_parse(&elem, in, len)) {
+    if (secp256k1_ge_parse(&elem, in, len)) {
         unsigned char out[65];
         unsigned char firstb;
         int res;
@@ -6861,9 +6861,9 @@ static void test_random_pubkeys(void) {
         firstb = in[0];
         /* If the pubkey can be parsed, it should round-trip... */
         if (len == 33) {
-            secp256k1_eckey_pubkey_serialize33(&elem, out);
+            secp256k1_ge_serialize33(&elem, out);
         } else {
-            secp256k1_eckey_pubkey_serialize65(&elem, out);
+            secp256k1_ge_serialize65(&elem, out);
         }
         CHECK(secp256k1_memcmp_var(&in[1], &out[1], len-1) == 0);
         /* ... except for the type of hybrid inputs. */
@@ -6871,12 +6871,12 @@ static void test_random_pubkeys(void) {
             CHECK(in[0] == out[0]);
         }
         size = 65;
-        secp256k1_eckey_pubkey_serialize65(&elem, in);
-        CHECK(secp256k1_eckey_pubkey_parse(&elem2, in, size));
+        secp256k1_ge_serialize65(&elem, in);
+        CHECK(secp256k1_ge_parse(&elem2, in, size));
         CHECK(secp256k1_ge_eq_var(&elem2, &elem));
         /* Check that the X9.62 hybrid type is checked. */
         in[0] = testrand_bits(1) ? 6 : 7;
-        res = secp256k1_eckey_pubkey_parse(&elem2, in, size);
+        res = secp256k1_ge_parse(&elem2, in, size);
         if (firstb == 2 || firstb == 3) {
             if (in[0] == firstb + 4) {
               CHECK(res);
@@ -6886,7 +6886,7 @@ static void test_random_pubkeys(void) {
         }
         if (res) {
             CHECK(secp256k1_ge_eq_var(&elem, &elem2));
-            secp256k1_eckey_pubkey_serialize65(&elem, out);
+            secp256k1_ge_serialize65(&elem, out);
             CHECK(secp256k1_memcmp_var(&in[1], &out[1], 64) == 0);
         }
     }
@@ -7416,7 +7416,7 @@ static void run_ecdsa_edge_cases(void) {
         secp256k1_scalar_set_int(&ss, 1);
         secp256k1_scalar_set_int(&msg, 0);
         secp256k1_scalar_set_int(&sr, 0);
-        CHECK(secp256k1_eckey_pubkey_parse(&key, pubkey_mods_zero, 33));
+        CHECK(secp256k1_ge_parse(&key, pubkey_mods_zero, 33));
         CHECK(secp256k1_ecdsa_sig_verify( &sr, &ss, &key, &msg) == 0);
     }
 
@@ -7435,7 +7435,7 @@ static void run_ecdsa_edge_cases(void) {
         secp256k1_scalar_set_int(&ss, 0);
         secp256k1_scalar_set_int(&msg, 0);
         secp256k1_scalar_set_int(&sr, 1);
-        CHECK(secp256k1_eckey_pubkey_parse(&key, pubkey, 33));
+        CHECK(secp256k1_ge_parse(&key, pubkey, 33));
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 0);
     }
 
@@ -7462,8 +7462,8 @@ static void run_ecdsa_edge_cases(void) {
         secp256k1_scalar_set_int(&ss, 2);
         secp256k1_scalar_set_int(&msg, 0);
         secp256k1_scalar_set_int(&sr, 2);
-        CHECK(secp256k1_eckey_pubkey_parse(&key, pubkey, 33));
-        CHECK(secp256k1_eckey_pubkey_parse(&key2, pubkey2, 33));
+        CHECK(secp256k1_ge_parse(&key, pubkey, 33));
+        CHECK(secp256k1_ge_parse(&key2, pubkey2, 33));
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg) == 1);
         secp256k1_scalar_negate(&ss, &ss);
@@ -7503,8 +7503,8 @@ static void run_ecdsa_edge_cases(void) {
         secp256k1_scalar_set_int(&ss, 1);
         secp256k1_scalar_set_int(&msg, 1);
         secp256k1_scalar_set_b32(&sr, csr, NULL);
-        CHECK(secp256k1_eckey_pubkey_parse(&key, pubkey, 33));
-        CHECK(secp256k1_eckey_pubkey_parse(&key2, pubkey2, 33));
+        CHECK(secp256k1_ge_parse(&key, pubkey, 33));
+        CHECK(secp256k1_ge_parse(&key2, pubkey2, 33));
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key2, &msg) == 1);
         secp256k1_scalar_negate(&ss, &ss);
@@ -7538,7 +7538,7 @@ static void run_ecdsa_edge_cases(void) {
         secp256k1_scalar_set_int(&msg, 1);
         secp256k1_scalar_negate(&msg, &msg);
         secp256k1_scalar_set_b32(&sr, csr, NULL);
-        CHECK(secp256k1_eckey_pubkey_parse(&key, pubkey, 33));
+        CHECK(secp256k1_ge_parse(&key, pubkey, 33));
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);
         secp256k1_scalar_negate(&ss, &ss);
         CHECK(secp256k1_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 1);


### PR DESCRIPTION
These two helpers, `secp256k1_musig_ge_serialize_ext` and `secp256k1_musig_ge_parse_ext`, aren't really musig-specific. They (de)serialize a group element that can also be the point at infinity. This moves them to `eckey` as `secp256k1_eckey_serialize_ext` and `secp256k1_eckey_parse_ext`. They can't move further down to group.h because they depend on other `eckey` functions internally. There should be no functional change here.

I stumbled upon this while working on #1754 where I would want to reuse these helpers in that module, so it is split out of that. But the change seems to make sense on its own as well, so I wouldn't consider this prep work alone.