### PR TITLE
ecdh/ellswift: simplify seckey loading with `_scalar_set_b32_seckey`

### DIFF
--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -33,7 +33,7 @@ const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_default = ecdh_h
 
 int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const secp256k1_pubkey *point, const unsigned char *scalar, secp256k1_ecdh_hash_function hashfp, void *data) {
     int ret = 0;
-    int overflow = 0;
+    int is_sec_valid;
     secp256k1_gej res;
     secp256k1_ge pt;
     secp256k1_scalar s;
@@ -46,10 +46,8 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const se
     ARG_CHECK(scalar != NULL);
 
     secp256k1_pubkey_load(ctx, &pt, point);
-    secp256k1_scalar_set_b32(&s, scalar, &overflow);
-
-    overflow |= secp256k1_scalar_is_zero(&s);
-    secp256k1_scalar_cmov(&s, &secp256k1_scalar_one, overflow);
+    is_sec_valid = secp256k1_scalar_set_b32_seckey(&s, scalar);
+    secp256k1_scalar_cmov(&s, &secp256k1_scalar_one, !is_sec_valid);
 
     secp256k1_ecmult_const(&res, &pt, &s);
     secp256k1_ge_set_gej(&pt, &res);
@@ -73,7 +71,7 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const se
     secp256k1_ge_clear(&pt);
     secp256k1_gej_clear(&res);
 
-    return !!ret & !overflow;
+    return (!!ret) & is_sec_valid;
 }
 
 #endif /* SECP256K1_MODULE_ECDH_MAIN_H */

--- a/src/modules/ellswift/main_impl.h
+++ b/src/modules/ellswift/main_impl.h
@@ -535,7 +535,7 @@ const secp256k1_ellswift_xdh_hash_function secp256k1_ellswift_xdh_hash_function_
 
 int secp256k1_ellswift_xdh(const secp256k1_context *ctx, unsigned char *output, const unsigned char *ell_a64, const unsigned char *ell_b64, const unsigned char *seckey32, int party, secp256k1_ellswift_xdh_hash_function hashfp, void *data) {
     int ret = 0;
-    int overflow;
+    int is_sec_valid;
     secp256k1_scalar s;
     secp256k1_fe xn, xd, px, u, t;
     unsigned char sx[32];
@@ -555,9 +555,8 @@ int secp256k1_ellswift_xdh(const secp256k1_context *ctx, unsigned char *output, 
     secp256k1_ellswift_xswiftec_frac_var(&xn, &xd, &u, &t);
 
     /* Load private key (using one if invalid). */
-    secp256k1_scalar_set_b32(&s, seckey32, &overflow);
-    overflow |= secp256k1_scalar_is_zero(&s);
-    secp256k1_scalar_cmov(&s, &secp256k1_scalar_one, overflow);
+    is_sec_valid = secp256k1_scalar_set_b32_seckey(&s, seckey32);
+    secp256k1_scalar_cmov(&s, &secp256k1_scalar_one, !is_sec_valid);
 
     /* Compute shared X coordinate. */
     secp256k1_ecmult_const_xonly(&px, &xn, &xd, &s, 1);
@@ -577,7 +576,7 @@ int secp256k1_ellswift_xdh(const secp256k1_context *ctx, unsigned char *output, 
     secp256k1_fe_clear(&px);
     secp256k1_scalar_clear(&s);
 
-    return !!ret & !overflow;
+    return (!!ret) & is_sec_valid;
 }
 
 #endif


### PR DESCRIPTION
Instead of checking for overflow and zero manually, use the existing `_scalar_set_b32_seckey` helper which does both and returns zero if either of these two conditions apply. This can be seen as a very late follow-up to PR #701, commit 3fec9826086aa45ebbac1ff6fc3bb7b25ca78b1d, where the helper has been introduced and applied to the functions `_ecdsa_sign`, `_pubkey_create` and `_seckey_verify`. The variable name `is_sec_valid` has been chosen as it is currently also used in [`secp256k1_ecdsa_sign_inner`](https://github.com/bitcoin-core/secp256k1/blob/439278a649d3099d62dde966a76dc04aaca7ccb3/src/secp256k1.c#L555).

Note that introducing parantheses around `!!ret` was necessary to avoid warnings in the following form:
```
/home/thestack/secp256k1_master/src/modules/ecdh/main_impl.h: In function ‘secp256k1_ecdh’:
/home/thestack/secp256k1_master/src/modules/ecdh/main_impl.h:74:12: warning: suggest parentheses around operand of ‘!’ or change ‘&’ to ‘&&’ or ‘
!’ to ‘~’ [-Wparentheses]                                               
   74 |     return !!ret & is_sec_valid;                                                                                                         
      |            ^~~~~                                                
```