### PR TITLE
Allow overriding malloc and free at compile time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ env:
   ASM: 'no'
   WIDEMUL: 'auto'
   WITH_VALGRIND: 'yes'
+  MALLOC_OVERRIDE: 'no'
+  NO_MALLOC: 'no'
   EXTRAFLAGS:
   ### secp256k1 modules
   EXPERIMENTAL: 'no'
@@ -111,6 +113,8 @@ jobs:
           - env_vars: { CFLAGS: '-O1',     RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', MUSIG: 'yes', ELLSWIFT: 'yes', SILENTPAYMENTS: 'yes' }
           - env_vars: { ECMULTGENKB: 2, ECMULTWINDOW: 2 }
           - env_vars: { ECMULTGENKB: 86, ECMULTWINDOW: 4 }
+          - env_vars: { MALLOC_OVERRIDE: 'yes', EXTRAFLAGS: '--disable-benchmark', BENCH: 'no', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', MUSIG: 'yes', ELLSWIFT: 'yes', SILENTPAYMENTS: 'yes' }
+          - env_vars: { NO_MALLOC: 'yes', EXTRAFLAGS: '--disable-tests --disable-exhaustive-tests --disable-benchmark', BENCH: 'no', CTIMETESTS: 'no', EXAMPLES: 'no', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', MUSIG: 'yes', ELLSWIFT: 'yes', SILENTPAYMENTS: 'yes' }
         cc:
           - 'gcc'
           - 'clang'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Added
+ - The preprocessor macros `SECP256K1_MALLOC` and `SECP256K1_FREE` can be defined when compiling the library to replace `malloc` and `free`. `SECP256K1_FREE` also receives the size of the allocation.
+
 ## [0.8.0] - 2026-08-03
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
  - The preprocessor macros `SECP256K1_MALLOC` and `SECP256K1_FREE` can be defined when compiling the library to replace `malloc` and `free`. `SECP256K1_FREE` also receives the size of the allocation.
+ - The preprocessor macros `SECP256K1_ILLEGAL_CALLBACK_FN` and `SECP256K1_ERROR_CALLBACK_FN` can be defined when compiling the library to replace the default callbacks.
+
+#### Deprecated
+ - The preprocessor macro `USE_EXTERNAL_DEFAULT_CALLBACKS` and the corresponding build options `--enable-external-default-callbacks` and `SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS`. Define `SECP256K1_ILLEGAL_CALLBACK_FN` and `SECP256K1_ERROR_CALLBACK_FN` instead.
 
 ## [0.8.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
  - The preprocessor macros `SECP256K1_MALLOC` and `SECP256K1_FREE` can be defined when compiling the library to replace `malloc` and `free`. `SECP256K1_FREE` also receives the size of the allocation.
  - The preprocessor macros `SECP256K1_ILLEGAL_CALLBACK_FN` and `SECP256K1_ERROR_CALLBACK_FN` can be defined when compiling the library to replace the default callbacks.
+ - The preprocessor macro `SECP256K1_NO_MALLOC` can be defined when compiling the library to remove all dynamic memory allocation. The functions `secp256k1_context_create`, `secp256k1_context_clone` and `secp256k1_context_destroy` are then not built.
 
 #### Deprecated
  - The preprocessor macro `USE_EXTERNAL_DEFAULT_CALLBACKS` and the corresponding build options `--enable-external-default-callbacks` and `SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS`. Define `SECP256K1_ILLEGAL_CALLBACK_FN` and `SECP256K1_ERROR_CALLBACK_FN` instead.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(SECP256K1_ENABLE_MODULE_MUSIG "Enable musig module." ON)
 option(SECP256K1_ENABLE_MODULE_ELLSWIFT "Enable ElligatorSwift module." ON)
 option(SECP256K1_ENABLE_MODULE_SILENTPAYMENTS "Enable Silent Payments module." ON)
 
-option(SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS "Enable external default callback functions." OFF)
+option(SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS "Enable external default callback functions (deprecated)." OFF)
 if(SECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS)
   add_compile_definitions(USE_EXTERNAL_DEFAULT_CALLBACKS=1)
 endif()

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -12,7 +12,7 @@ print_environment() {
     # There are many ways to print variable names and their content. This one
     # does not rely on bash.
     for var in WERROR_CFLAGS MAKEFLAGS BUILD \
-            ECMULTWINDOW ECMULTGENKB ASM WIDEMUL WITH_VALGRIND EXTRAFLAGS \
+            ECMULTWINDOW ECMULTGENKB ASM WIDEMUL WITH_VALGRIND MALLOC_OVERRIDE NO_MALLOC EXTRAFLAGS \
             EXPERIMENTAL ECDH RECOVERY EXTRAKEYS MUSIG SCHNORRSIG ELLSWIFT SILENTPAYMENTS \
             SECP256K1_TEST_ITERS BENCH SECP256K1_BENCH_ITERS CTIMETESTS SYMBOL_CHECK \
             EXAMPLES \
@@ -54,6 +54,18 @@ fi
 
 ./autogen.sh
 
+# Build with custom memory allocation functions.
+if [ "$MALLOC_OVERRIDE" = "yes" ]
+then
+    export CPPFLAGS="${CPPFLAGS:-} -DSECP256K1_MALLOC=secp256k1_ci_malloc -DSECP256K1_FREE=secp256k1_ci_free -include $(pwd)/ci/malloc_override.h"
+fi
+
+# Build without heap allocation.
+if [ "$NO_MALLOC" = "yes" ]
+then
+    export CPPFLAGS="${CPPFLAGS:-} -DSECP256K1_NO_MALLOC"
+fi
+
 ./configure \
     --enable-experimental="$EXPERIMENTAL" \
     --with-test-override-wide-multiply="$WIDEMUL" --with-asm="$ASM" \
@@ -91,6 +103,15 @@ fi
 file *tests* || true
 file bench* || true
 file .libs/* || true
+
+if [ "$NO_MALLOC" = "yes" ]
+then
+    # The library must not reference malloc and free.
+    if nm -u .libs/libsecp256k1.so | grep -w -e malloc -e free
+    then
+        exit 1
+    fi
+fi
 
 if [ "$SYMBOL_CHECK" = "yes" ]
 then

--- a/ci/malloc_override.h
+++ b/ci/malloc_override.h
@@ -1,0 +1,19 @@
+/* Used to test building the library with custom memory allocation
+ * functions. */
+
+#include <assert.h>
+#include <stdlib.h>
+
+__attribute__((unused)) static void *secp256k1_ci_malloc(size_t size) {
+    assert(size != 0);
+    return malloc(size);
+}
+
+__attribute__((unused)) static void secp256k1_ci_free(void *ptr, size_t size) {
+    assert(ptr != NULL);
+    assert(size != 0);
+    free(ptr);
+}
+
+#define malloc secp256k1_ci_do_not_call_malloc_directly
+#define free secp256k1_ci_do_not_call_free_directly

--- a/configure.ac
+++ b/configure.ac
@@ -198,7 +198,7 @@ AC_ARG_ENABLE(module_silentpayments,
     [SECP_SET_DEFAULT([enable_module_silentpayments], [yes], [yes])])
 
 AC_ARG_ENABLE(external_default_callbacks,
-    AS_HELP_STRING([--enable-external-default-callbacks],[enable external default callback functions [default=no]]), [],
+    AS_HELP_STRING([--enable-external-default-callbacks],[enable external default callback functions (deprecated) [default=no]]), [],
     [SECP_SET_DEFAULT([enable_external_default_callbacks], [no], [no])])
 
 # Test-only override of the (autodetected by the C code) "widemul" setting.

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -345,14 +345,16 @@ SECP256K1_API void secp256k1_context_destroy(
  *
  *  When this function has not been called (or called with fun==NULL), then the
  *  default callback will be used. The library provides a default callback which
- *  writes the message to stderr and calls abort. This default callback can be
- *  replaced at link time if the preprocessor macro
- *  USE_EXTERNAL_DEFAULT_CALLBACKS is defined, which is the case if the build
- *  has been configured with --enable-external-default-callbacks (GNU Autotools) or
- *  -DSECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS=ON (CMake). Then the
- *  following two symbols must be provided to link against:
- *   - void secp256k1_default_illegal_callback_fn(const char *message, void *data);
- *   - void secp256k1_default_error_callback_fn(const char *message, void *data);
+ *  writes the message to stderr and calls abort. The default callbacks can be
+ *  replaced by defining the macros SECP256K1_ILLEGAL_CALLBACK_FN and
+ *  SECP256K1_ERROR_CALLBACK_FN when compiling the library, in the same way as
+ *  SECP256K1_MALLOC and SECP256K1_FREE (see secp256k1_context_create). The
+ *  replacements must have the same signature as the fun argument below.
+ *  The deprecated macro USE_EXTERNAL_DEFAULT_CALLBACKS (set via
+ *  --enable-external-default-callbacks or
+ *  -DSECP256K1_USE_EXTERNAL_DEFAULT_CALLBACKS=ON) instead requires the
+ *  functions secp256k1_default_illegal_callback_fn and
+ *  secp256k1_default_error_callback_fn to be provided at link time.
  *  The library may call a default callback even before a proper callback data
  *  pointer could have been set using secp256k1_context_set_illegal_callback or
  *  secp256k1_context_set_error_callback, e.g., when the creation of a context

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -262,6 +262,17 @@ SECP256K1_API void secp256k1_selftest(void);
  *  memory allocation entirely, see secp256k1_context_static and the functions in
  *  secp256k1_preallocated.h.
  *
+ *  The macros SECP256K1_MALLOC and SECP256K1_FREE can be defined when
+ *  compiling the library to replace malloc and free, for example with
+ *  -DSECP256K1_MALLOC=my_malloc -DSECP256K1_FREE=my_free -include my_alloc.h.
+ *  The replacements do not need the full semantics of malloc and free. The
+ *  library guarantees only the following:
+ *   - SECP256K1_MALLOC(size) is called with size > 0 and must return memory
+ *     suitably aligned for any object type, or NULL on failure.
+ *   - SECP256K1_FREE(ptr, size) is called exactly once for every successful
+ *     allocation, ptr is never NULL and size is the allocated size.
+ *   - There are no other allocations and no ordering guarantees.
+ *
  *  Returns: pointer to a newly created context object.
  *  In:      flags: Always set to SECP256K1_CONTEXT_NONE (see below).
  *

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -273,6 +273,11 @@ SECP256K1_API void secp256k1_selftest(void);
  *     allocation, ptr is never NULL and size is the allocated size.
  *   - There are no other allocations and no ordering guarantees.
  *
+ *  Defining SECP256K1_NO_MALLOC instead removes all dynamic memory allocation
+ *  from the library. This function, secp256k1_context_clone, and
+ *  secp256k1_context_destroy are then not built, and secp256k1_context_static
+ *  or the functions in secp256k1_preallocated.h must be used.
+ *
  *  Returns: pointer to a newly created context object.
  *  In:      flags: Always set to SECP256K1_CONTEXT_NONE (see below).
  *

--- a/src/ecmult_gen_compute_table_impl.h
+++ b/src/ecmult_gen_compute_table_impl.h
@@ -100,9 +100,9 @@ static void secp256k1_ecmult_gen_compute_table(secp256k1_ge_storage* table, cons
     }
 
     /* Free memory. */
-    free(vs);
-    free(ds);
-    free(prec);
+    checked_free(vs, points_total * sizeof(*vs));
+    checked_free(ds, teeth * sizeof(*ds));
+    checked_free(prec, points_total * sizeof(*prec));
 }
 
 #endif /* SECP256K1_ECMULT_GEN_COMPUTE_TABLE_IMPL_H */

--- a/src/modules/silentpayments/tests_impl.h
+++ b/src/modules/silentpayments/tests_impl.h
@@ -364,10 +364,10 @@ static void test_send_api(void) {
         CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, outputs_ptrs, recipients_ptrs,
             test_num_recipients, SMALLEST_OUTPOINT, NULL, 0, p, 1) == 0);
 
-        free(outputs_ptrs);
-        free(outputs);
-        free(recipients_ptrs);
-        free(recipients);
+        checked_free(outputs_ptrs, sizeof(*outputs_ptrs) * total_recipients);
+        checked_free(outputs, sizeof(*outputs) * total_recipients);
+        checked_free(recipients_ptrs, sizeof(*recipients_ptrs) * total_recipients);
+        checked_free(recipients, sizeof(*recipients) * total_recipients);
     }
 }
 

--- a/src/precompute_ecmult.c
+++ b/src/precompute_ecmult.c
@@ -42,16 +42,16 @@ static void print_table(FILE *fp, const char *name, int window_g, const secp256k
 }
 
 static void print_two_tables(FILE *fp, int window_g) {
-    secp256k1_ge_storage* table = malloc(ECMULT_TABLE_SIZE(window_g) * sizeof(secp256k1_ge_storage));
-    secp256k1_ge_storage* table_128 = malloc(ECMULT_TABLE_SIZE(window_g) * sizeof(secp256k1_ge_storage));
+    secp256k1_ge_storage* table = checked_malloc(&default_error_callback, ECMULT_TABLE_SIZE(window_g) * sizeof(secp256k1_ge_storage));
+    secp256k1_ge_storage* table_128 = checked_malloc(&default_error_callback, ECMULT_TABLE_SIZE(window_g) * sizeof(secp256k1_ge_storage));
 
     secp256k1_ecmult_compute_two_tables(table, table_128, window_g, &secp256k1_ge_const_g);
 
     print_table(fp, "secp256k1_pre_g", window_g, table);
     print_table(fp, "secp256k1_pre_g_128", window_g, table_128);
 
-    free(table);
-    free(table_128);
+    checked_free(table, ECMULT_TABLE_SIZE(window_g) * sizeof(secp256k1_ge_storage));
+    checked_free(table_128, ECMULT_TABLE_SIZE(window_g) * sizeof(secp256k1_ge_storage));
 }
 
 int main(void) {

--- a/src/precompute_ecmult.c
+++ b/src/precompute_ecmult.c
@@ -8,6 +8,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef SECP256K1_NO_MALLOC
+    #pragma message("Ignoring SECP256K1_NO_MALLOC in precompute_ecmult.")
+    #undef SECP256K1_NO_MALLOC
+#endif
+
 #include "../include/secp256k1.h"
 
 #include "assumptions.h"

--- a/src/precompute_ecmult_gen.c
+++ b/src/precompute_ecmult_gen.c
@@ -50,7 +50,7 @@ static void print_table(FILE* fp, int blocks, int teeth) {
             fprintf(fp,"}\n");
         }
     }
-    free(table);
+    checked_free(table, blocks * points * sizeof(secp256k1_ge_storage));
 }
 
 int main(int argc, char **argv) {

--- a/src/precompute_ecmult_gen.c
+++ b/src/precompute_ecmult_gen.c
@@ -8,6 +8,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef SECP256K1_NO_MALLOC
+    #pragma message("Ignoring SECP256K1_NO_MALLOC in precompute_ecmult_gen.")
+    #undef SECP256K1_NO_MALLOC
+#endif
+
 #include "../include/secp256k1.h"
 
 #include "assumptions.h"

--- a/src/scratch.h
+++ b/src/scratch.h
@@ -23,9 +23,11 @@ typedef struct secp256k1_scratch_space_struct {
 
 typedef struct secp256k1_scratch_space_struct secp256k1_scratch_space;
 
+#ifndef SECP256K1_NO_MALLOC
 static secp256k1_scratch* secp256k1_scratch_create(const secp256k1_callback* error_callback, size_t max_size);
 
 static void secp256k1_scratch_destroy(const secp256k1_callback* error_callback, secp256k1_scratch* scratch);
+#endif
 
 /** Returns an opaque object used to "checkpoint" a scratch space. Used
  *  with `secp256k1_scratch_apply_checkpoint` to undo allocations. */

--- a/src/scratch_impl.h
+++ b/src/scratch_impl.h
@@ -10,6 +10,7 @@
 #include "util.h"
 #include "scratch.h"
 
+#ifndef SECP256K1_NO_MALLOC
 static secp256k1_scratch* secp256k1_scratch_create(const secp256k1_callback* error_callback, size_t size) {
     const size_t base_alloc = ROUND_TO_ALIGN(sizeof(secp256k1_scratch));
     void *alloc;
@@ -40,6 +41,7 @@ static void secp256k1_scratch_destroy(const secp256k1_callback* error_callback, 
         checked_free(scratch, ROUND_TO_ALIGN(sizeof(secp256k1_scratch)) + scratch->max_size);
     }
 }
+#endif /* !SECP256K1_NO_MALLOC */
 
 static size_t secp256k1_scratch_checkpoint(const secp256k1_callback* error_callback, const secp256k1_scratch* scratch) {
     if (secp256k1_memcmp_var(scratch->magic, "scratch", 8) != 0) {

--- a/src/scratch_impl.h
+++ b/src/scratch_impl.h
@@ -37,7 +37,7 @@ static void secp256k1_scratch_destroy(const secp256k1_callback* error_callback, 
         }
         VERIFY_CHECK(scratch->alloc_size == 0); /* all checkpoints should be applied */
         memset(scratch->magic, 0, sizeof(scratch->magic));
-        free(scratch);
+        checked_free(scratch, ROUND_TO_ALIGN(sizeof(secp256k1_scratch)) + scratch->max_size);
     }
 }
 

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -142,9 +142,13 @@ secp256k1_context* secp256k1_context_preallocated_create(void* prealloc, unsigne
 
 secp256k1_context* secp256k1_context_create(unsigned int flags) {
     size_t const prealloc_size = secp256k1_context_preallocated_size(flags);
-    secp256k1_context* ctx = checked_malloc(&default_error_callback, prealloc_size);
+    secp256k1_context* ctx;
+    if (EXPECT(prealloc_size == 0, 0)) {
+        return NULL;
+    }
+    ctx = checked_malloc(&default_error_callback, prealloc_size);
     if (EXPECT(secp256k1_context_preallocated_create(ctx, flags) == NULL, 0)) {
-        free(ctx);
+        checked_free(ctx, prealloc_size);
         return NULL;
     }
 
@@ -195,7 +199,7 @@ void secp256k1_context_destroy(secp256k1_context* ctx) {
     }
 
     secp256k1_context_preallocated_destroy(ctx);
-    free(ctx);
+    checked_free(ctx, sizeof(secp256k1_context));
 }
 
 void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -140,6 +140,7 @@ secp256k1_context* secp256k1_context_preallocated_create(void* prealloc, unsigne
     return ret;
 }
 
+#ifndef SECP256K1_NO_MALLOC
 secp256k1_context* secp256k1_context_create(unsigned int flags) {
     size_t const prealloc_size = secp256k1_context_preallocated_size(flags);
     secp256k1_context* ctx;
@@ -154,6 +155,7 @@ secp256k1_context* secp256k1_context_create(unsigned int flags) {
 
     return ctx;
 }
+#endif
 
 secp256k1_context* secp256k1_context_preallocated_clone(const secp256k1_context* ctx, void* prealloc) {
     secp256k1_context* ret;
@@ -166,6 +168,7 @@ secp256k1_context* secp256k1_context_preallocated_clone(const secp256k1_context*
     return ret;
 }
 
+#ifndef SECP256K1_NO_MALLOC
 secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
     secp256k1_context* ret;
     size_t prealloc_size;
@@ -178,6 +181,7 @@ secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
     ret = secp256k1_context_preallocated_clone(ctx, ret);
     return ret;
 }
+#endif
 
 void secp256k1_context_preallocated_destroy(secp256k1_context* ctx) {
     ARG_CHECK_VOID(ctx == NULL || secp256k1_context_is_proper(ctx));
@@ -190,6 +194,7 @@ void secp256k1_context_preallocated_destroy(secp256k1_context* ctx) {
     secp256k1_ecmult_gen_context_clear(&ctx->ecmult_gen_ctx);
 }
 
+#ifndef SECP256K1_NO_MALLOC
 void secp256k1_context_destroy(secp256k1_context* ctx) {
     ARG_CHECK_VOID(ctx == NULL || secp256k1_context_is_proper(ctx));
 
@@ -201,6 +206,7 @@ void secp256k1_context_destroy(secp256k1_context* ctx) {
     secp256k1_context_preallocated_destroy(ctx);
     checked_free(ctx, sizeof(secp256k1_context));
 }
+#endif
 
 void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
     /* We compare pointers instead of checking secp256k1_context_is_proper() here
@@ -238,6 +244,7 @@ void secp256k1_context_set_sha256_compression(secp256k1_context *ctx, secp256k1_
     ctx->hash_ctx.fn_sha256_compression = fn_compression;
 }
 
+#ifndef SECP256K1_NO_MALLOC
 static secp256k1_scratch_space* secp256k1_scratch_space_create(const secp256k1_context* ctx, size_t max_size) {
     VERIFY_CHECK(ctx != NULL);
     return secp256k1_scratch_create(&ctx->error_callback, max_size);
@@ -247,6 +254,7 @@ static void secp256k1_scratch_space_destroy(const secp256k1_context *ctx, secp25
     VERIFY_CHECK(ctx != NULL);
     secp256k1_scratch_destroy(&ctx->error_callback, scratch);
 }
+#endif
 
 /* Mark memory as no-longer-secret for the purpose of analysing constant-time behaviour
  *  of the software.

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -69,8 +69,8 @@ struct secp256k1_context_struct {
 static const secp256k1_context secp256k1_context_static_ = {
     { 0 },
     { secp256k1_sha256_transform },
-    { secp256k1_default_illegal_callback_fn, 0 },
-    { secp256k1_default_error_callback_fn, 0 },
+    { SECP256K1_ILLEGAL_CALLBACK_FN, 0 },
+    { SECP256K1_ERROR_CALLBACK_FN, 0 },
     0
 };
 const secp256k1_context * const secp256k1_context_static = &secp256k1_context_static_;
@@ -208,7 +208,7 @@ void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(
        it's harmless and makes testing easier. */
     ARG_CHECK_VOID(ctx != secp256k1_context_static);
     if (fun == NULL) {
-        fun = secp256k1_default_illegal_callback_fn;
+        fun = SECP256K1_ILLEGAL_CALLBACK_FN;
     }
     ctx->illegal_callback.fn = fun;
     ctx->illegal_callback.data = data;
@@ -220,7 +220,7 @@ void secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(co
        it's harmless and makes testing easier. */
     ARG_CHECK_VOID(ctx != secp256k1_context_static);
     if (fun == NULL) {
-        fun = secp256k1_default_error_callback_fn;
+        fun = SECP256K1_ERROR_CALLBACK_FN;
     }
     ctx->error_callback.fn = fun;
     ctx->error_callback.data = data;

--- a/src/tests.c
+++ b/src/tests.c
@@ -20,6 +20,9 @@
     #undef SECP256K1_ILLEGAL_CALLBACK_FN
     #undef SECP256K1_ERROR_CALLBACK_FN
 #endif
+#ifdef SECP256K1_NO_MALLOC
+    #error "The tests cannot be built with SECP256K1_NO_MALLOC"
+#endif
 #if defined(VERIFY) && defined(COVERAGE)
     #pragma message("Defining VERIFY for tests being built for coverage analysis support is meaningless.")
 #endif

--- a/src/tests.c
+++ b/src/tests.c
@@ -15,6 +15,11 @@
     #pragma message("Ignoring USE_EXTERNAL_CALLBACKS in tests.")
     #undef USE_EXTERNAL_DEFAULT_CALLBACKS
 #endif
+#ifdef SECP256K1_ILLEGAL_CALLBACK_FN
+    #pragma message("Ignoring SECP256K1_ILLEGAL_CALLBACK_FN and SECP256K1_ERROR_CALLBACK_FN in tests.")
+    #undef SECP256K1_ILLEGAL_CALLBACK_FN
+    #undef SECP256K1_ERROR_CALLBACK_FN
+#endif
 #if defined(VERIFY) && defined(COVERAGE)
     #pragma message("Defining VERIFY for tests being built for coverage analysis support is meaningless.")
 #endif

--- a/src/tests.c
+++ b/src/tests.c
@@ -206,12 +206,11 @@ static void run_static_context_tests(int use_prealloc) {
         if (use_prealloc) {
             CHECK_ILLEGAL(STATIC_CTX, secp256k1_context_preallocated_clone_size(STATIC_CTX));
             {
-                secp256k1_context *my_static_ctx = malloc(sizeof(*STATIC_CTX));
-                CHECK(my_static_ctx != NULL);
+                secp256k1_context *my_static_ctx = checked_malloc(&CTX->error_callback, sizeof(*STATIC_CTX));
                 memset(my_static_ctx, 0x2a, sizeof(*my_static_ctx));
                 CHECK_ILLEGAL(STATIC_CTX, secp256k1_context_preallocated_clone(STATIC_CTX, my_static_ctx));
                 CHECK(all_bytes_equal(my_static_ctx, 0x2a, sizeof(*my_static_ctx)));
-                free(my_static_ctx);
+                checked_free(my_static_ctx, sizeof(*STATIC_CTX));
             }
             CHECK_ILLEGAL_VOID(STATIC_CTX, secp256k1_context_preallocated_destroy(STATIC_CTX));
         } else {
@@ -252,8 +251,7 @@ static void run_proper_context_tests(int use_prealloc) {
     my_ctx_fresh = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
 
     if (use_prealloc) {
-        my_ctx_prealloc = malloc(secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
-        CHECK(my_ctx_prealloc != NULL);
+        my_ctx_prealloc = checked_malloc(&CTX->error_callback, secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
         my_ctx = secp256k1_context_preallocated_create(my_ctx_prealloc, SECP256K1_CONTEXT_NONE);
     } else {
         my_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
@@ -285,9 +283,8 @@ static void run_proper_context_tests(int use_prealloc) {
             CHECK(context_eq(ctx_tmp, my_ctx));
             secp256k1_context_preallocated_destroy(ctx_tmp);
 
-            free(my_ctx_prealloc);
-            my_ctx_prealloc = malloc(secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
-            CHECK(my_ctx_prealloc != NULL);
+            checked_free(my_ctx_prealloc, secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
+            my_ctx_prealloc = checked_malloc(&CTX->error_callback, secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
             ctx_tmp = my_ctx;
             my_ctx = secp256k1_context_preallocated_clone(my_ctx, my_ctx_prealloc);
             CHECK(context_eq(ctx_tmp, my_ctx));
@@ -296,8 +293,7 @@ static void run_proper_context_tests(int use_prealloc) {
             /* clone into a preallocated context and then again into a new non-preallocated one. */
             void *prealloc_tmp;
 
-            prealloc_tmp = malloc(secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
-            CHECK(prealloc_tmp != NULL);
+            prealloc_tmp = checked_malloc(&CTX->error_callback, secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
             ctx_tmp = my_ctx;
             my_ctx = secp256k1_context_preallocated_clone(my_ctx, prealloc_tmp);
             CHECK(context_eq(ctx_tmp, my_ctx));
@@ -307,7 +303,7 @@ static void run_proper_context_tests(int use_prealloc) {
             my_ctx = secp256k1_context_clone(my_ctx);
             CHECK(context_eq(ctx_tmp, my_ctx));
             secp256k1_context_preallocated_destroy(ctx_tmp);
-            free(prealloc_tmp);
+            checked_free(prealloc_tmp, secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
         }
     }
 
@@ -347,7 +343,7 @@ static void run_proper_context_tests(int use_prealloc) {
     /* cleanup */
     if (use_prealloc) {
         secp256k1_context_preallocated_destroy(my_ctx);
-        free(my_ctx_prealloc);
+        checked_free(my_ctx_prealloc, secp256k1_context_preallocated_size(SECP256K1_CONTEXT_NONE));
     } else {
         secp256k1_context_destroy(my_ctx);
     }
@@ -442,7 +438,7 @@ static void run_invalid_scratch_space_tests(void) {
     CHECK_ERROR(CTX, secp256k1_scratch_alloc(&CTX->error_callback, scratch, 500));
     CHECK_ERROR_VOID(CTX, secp256k1_scratch_space_destroy(CTX, scratch));
 
-    free(scratch);
+    checked_free(scratch, sizeof(*scratch));
 }
 
 /* A compression function that does nothing */
@@ -4124,7 +4120,7 @@ static void test_ge(void) {
             secp256k1_gej_add_var(&sum, &sum, &gej_shuffled[i], NULL);
         }
         CHECK(secp256k1_gej_is_infinity(&sum));
-        free(gej_shuffled);
+        checked_free(gej_shuffled, (4 * runs + 1) * sizeof(secp256k1_gej));
     }
 
     /* Test batch gej -> ge conversion without known z ratios. */
@@ -4160,8 +4156,8 @@ static void test_ge(void) {
         secp256k1_ge_set_all_gej_var(NULL, NULL, 0);
         secp256k1_ge_set_all_gej(NULL, NULL, 0);
 
-        free(ge_set_all_var);
-        free(ge_set_all);
+        checked_free(ge_set_all_var, (4 * runs + 1) * sizeof(secp256k1_ge));
+        checked_free(ge_set_all, (4 * runs + 1) * sizeof(secp256k1_ge));
     }
 
     /* Test that all elements have X coordinates on the curve. */
@@ -4217,8 +4213,8 @@ static void test_ge(void) {
         CHECK(secp256k1_ge_is_infinity(&ge[i]));
     }
 
-    free(ge);
-    free(gej);
+    checked_free(ge, sizeof(secp256k1_ge) * (1 + 4 * runs));
+    checked_free(gej, sizeof(secp256k1_gej) * (1 + 4 * runs));
 }
 
 static void test_initialized_inf(void) {
@@ -5535,8 +5531,8 @@ static void test_ecmult_multi_batching(void) {
         CHECK(secp256k1_gej_is_infinity(&r));
         secp256k1_scratch_destroy(&CTX->error_callback, scratch);
     }
-    free(sc);
-    free(pt);
+    checked_free(sc, sizeof(secp256k1_scalar) * n_points);
+    checked_free(pt, sizeof(secp256k1_ge) * n_points);
 }
 
 static void run_ecmult_multi_tests(void) {
@@ -8289,8 +8285,7 @@ static int setup(void) {
        that write to the context. The API does not support cloning the static context, so we use
        memcpy instead. The user is not supposed to copy a context but we should still ensure that
        the API functions handle copies of the static context gracefully. */
-    STATIC_CTX = malloc(sizeof(*secp256k1_context_static));
-    CHECK(STATIC_CTX != NULL);
+    STATIC_CTX = checked_malloc(&CTX->error_callback, sizeof(*secp256k1_context_static));
     memcpy(STATIC_CTX, secp256k1_context_static, sizeof(secp256k1_context));
     CHECK(!secp256k1_context_is_proper(STATIC_CTX));
     return 0;
@@ -8298,7 +8293,7 @@ static int setup(void) {
 
 /* Shutdown test environment */
 static int teardown(void) {
-    free(STATIC_CTX);
+    checked_free(STATIC_CTX, sizeof(*secp256k1_context_static));
     secp256k1_context_destroy(CTX);
     return 0;
 }

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -20,6 +20,11 @@
     #pragma message("Ignoring USE_EXTERNAL_CALLBACKS in exhaustive_tests.")
     #undef USE_EXTERNAL_DEFAULT_CALLBACKS
 #endif
+#ifdef SECP256K1_ILLEGAL_CALLBACK_FN
+    #pragma message("Ignoring SECP256K1_ILLEGAL_CALLBACK_FN and SECP256K1_ERROR_CALLBACK_FN in exhaustive_tests.")
+    #undef SECP256K1_ILLEGAL_CALLBACK_FN
+    #undef SECP256K1_ERROR_CALLBACK_FN
+#endif
 #include "secp256k1.c"
 
 #include "../include/secp256k1.h"

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -25,6 +25,9 @@
     #undef SECP256K1_ILLEGAL_CALLBACK_FN
     #undef SECP256K1_ERROR_CALLBACK_FN
 #endif
+#ifdef SECP256K1_NO_MALLOC
+    #error "The exhaustive tests cannot be built with SECP256K1_NO_MALLOC"
+#endif
 #include "secp256k1.c"
 
 #include "../include/secp256k1.h"

--- a/src/util.h
+++ b/src/util.h
@@ -169,12 +169,34 @@ static const secp256k1_callback default_error_callback = {
 #define VERIFY_CHECK(cond)
 #endif
 
+/* Memory allocation functions, overridable by defining SECP256K1_MALLOC and
+ * SECP256K1_FREE (see secp256k1_context_create for the exact guarantees). */
+#if defined(SECP256K1_MALLOC) && !defined(SECP256K1_FREE)
+#  error "SECP256K1_FREE must be defined if SECP256K1_MALLOC is defined"
+#endif
+#if !defined(SECP256K1_MALLOC) && defined(SECP256K1_FREE)
+#  error "SECP256K1_MALLOC must be defined if SECP256K1_FREE is defined"
+#endif
+#ifndef SECP256K1_MALLOC
+#  define SECP256K1_MALLOC malloc
+#  define SECP256K1_FREE(ptr, size) ((void)(size), free(ptr))
+#endif
+
 static SECP256K1_INLINE void *checked_malloc(const secp256k1_callback* cb, size_t size) {
-    void *ret = malloc(size);
+    void *ret;
+    VERIFY_CHECK(size != 0);
+    ret = SECP256K1_MALLOC(size);
     if (ret == NULL) {
         secp256k1_callback_call(cb, "Out of memory");
     }
     return ret;
+}
+
+/* size must be the size that was passed to checked_malloc for this pointer. */
+static SECP256K1_INLINE void checked_free(void *ptr, size_t size) {
+    VERIFY_CHECK(ptr != NULL);
+    VERIFY_CHECK(size != 0);
+    SECP256K1_FREE(ptr, size);
 }
 
 #if defined(__BIGGEST_ALIGNMENT__)

--- a/src/util.h
+++ b/src/util.h
@@ -103,7 +103,24 @@ static SECP256K1_INLINE void secp256k1_callback_call(const secp256k1_callback * 
     cb->fn(text, (void*)cb->data);
 }
 
-#ifndef USE_EXTERNAL_DEFAULT_CALLBACKS
+/* Default callbacks, overridable by defining SECP256K1_ILLEGAL_CALLBACK_FN and
+ * SECP256K1_ERROR_CALLBACK_FN (see secp256k1_context_set_illegal_callback). */
+#if defined(SECP256K1_ILLEGAL_CALLBACK_FN) && !defined(SECP256K1_ERROR_CALLBACK_FN)
+#  error "SECP256K1_ERROR_CALLBACK_FN must be defined if SECP256K1_ILLEGAL_CALLBACK_FN is defined"
+#endif
+#if !defined(SECP256K1_ILLEGAL_CALLBACK_FN) && defined(SECP256K1_ERROR_CALLBACK_FN)
+#  error "SECP256K1_ILLEGAL_CALLBACK_FN must be defined if SECP256K1_ERROR_CALLBACK_FN is defined"
+#endif
+#if defined(USE_EXTERNAL_DEFAULT_CALLBACKS)
+/* Deprecated, use the macros above instead. */
+#  if defined(SECP256K1_ILLEGAL_CALLBACK_FN)
+#    error "USE_EXTERNAL_DEFAULT_CALLBACKS cannot be combined with SECP256K1_ILLEGAL_CALLBACK_FN and SECP256K1_ERROR_CALLBACK_FN"
+#  endif
+void secp256k1_default_illegal_callback_fn(const char* str, void* data);
+void secp256k1_default_error_callback_fn(const char* str, void* data);
+#  define SECP256K1_ILLEGAL_CALLBACK_FN secp256k1_default_illegal_callback_fn
+#  define SECP256K1_ERROR_CALLBACK_FN secp256k1_default_error_callback_fn
+#elif !defined(SECP256K1_ILLEGAL_CALLBACK_FN)
 static void secp256k1_default_illegal_callback_fn(const char* str, void* data) {
     (void)data;
     fprintf(stderr, "[libsecp256k1] illegal argument: %s\n", str);
@@ -114,18 +131,17 @@ static void secp256k1_default_error_callback_fn(const char* str, void* data) {
     fprintf(stderr, "[libsecp256k1] internal consistency check failed: %s\n", str);
     abort();
 }
-#else
-void secp256k1_default_illegal_callback_fn(const char* str, void* data);
-void secp256k1_default_error_callback_fn(const char* str, void* data);
+#  define SECP256K1_ILLEGAL_CALLBACK_FN secp256k1_default_illegal_callback_fn
+#  define SECP256K1_ERROR_CALLBACK_FN secp256k1_default_error_callback_fn
 #endif
 
 static const secp256k1_callback default_illegal_callback = {
-    secp256k1_default_illegal_callback_fn,
+    SECP256K1_ILLEGAL_CALLBACK_FN,
     NULL
 };
 
 static const secp256k1_callback default_error_callback = {
-    secp256k1_default_error_callback_fn,
+    SECP256K1_ERROR_CALLBACK_FN,
     NULL
 };
 

--- a/src/util.h
+++ b/src/util.h
@@ -186,13 +186,18 @@ static const secp256k1_callback default_error_callback = {
 #endif
 
 /* Memory allocation functions, overridable by defining SECP256K1_MALLOC and
- * SECP256K1_FREE (see secp256k1_context_create for the exact guarantees). */
+ * SECP256K1_FREE (see secp256k1_context_create for the exact guarantees).
+ * Defining SECP256K1_NO_MALLOC removes all uses of these functions instead. */
+#if defined(SECP256K1_NO_MALLOC) && (defined(SECP256K1_MALLOC) || defined(SECP256K1_FREE))
+#  error "SECP256K1_NO_MALLOC cannot be combined with SECP256K1_MALLOC and SECP256K1_FREE"
+#endif
 #if defined(SECP256K1_MALLOC) && !defined(SECP256K1_FREE)
 #  error "SECP256K1_FREE must be defined if SECP256K1_MALLOC is defined"
 #endif
 #if !defined(SECP256K1_MALLOC) && defined(SECP256K1_FREE)
 #  error "SECP256K1_MALLOC must be defined if SECP256K1_FREE is defined"
 #endif
+#ifndef SECP256K1_NO_MALLOC
 #ifndef SECP256K1_MALLOC
 #  define SECP256K1_MALLOC malloc
 #  define SECP256K1_FREE(ptr, size) ((void)(size), free(ptr))
@@ -214,6 +219,7 @@ static SECP256K1_INLINE void checked_free(void *ptr, size_t size) {
     VERIFY_CHECK(size != 0);
     SECP256K1_FREE(ptr, size);
 }
+#endif /* !SECP256K1_NO_MALLOC */
 
 #if defined(__BIGGEST_ALIGNMENT__)
 #define ALIGNMENT __BIGGEST_ALIGNMENT__


### PR DESCRIPTION
Addresses the suggestion by real_or_random here: https://github.com/bitcoin-core/secp256k1/pull/1789#issuecomment-5313107479

Allows to override the default `malloc` and `free` at compile time using `-DSECP256K1_MALLOC=my_malloc -DSECP256K1_FREE=my_free`. With helps users that can not link against `malloc`, such as the rust-secp256k1 wasm build.

Afaict, this is complementary to #1095 and #1461: with the macros defined, the library needs nothing from `<stdlib.h>` besides `abort` in the default callbacks. But #1461 would need to keep the allocating functions enabled when `SECP256K1_MALLOC` is defined.