### PR TITLE
ecdh/ellswift/schnorrsig: return early for invalid inputs (consistent handling w.r.t. constant-time)

### DIFF
--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -45,9 +45,15 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const se
     ARG_CHECK(point != NULL);
     ARG_CHECK(scalar != NULL);
 
-    secp256k1_pubkey_load(ctx, &pt, point);
+    if (!secp256k1_pubkey_load(ctx, &pt, point)) {
+        return 0;
+    }
     is_sec_valid = secp256k1_scalar_set_b32_seckey(&s, scalar);
-    secp256k1_scalar_cmov(&s, &secp256k1_scalar_one, !is_sec_valid);
+    secp256k1_declassify(ctx, &is_sec_valid, sizeof(is_sec_valid));
+    if (!is_sec_valid) {
+        secp256k1_ge_clear(&pt);
+        return 0;
+    }
 
     secp256k1_ecmult_const(&res, &pt, &s);
     secp256k1_ge_set_gej(&pt, &res);
@@ -62,7 +68,7 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const se
         /* Use ctx-aware function by default */
         ret = ecdh_hash_function_sha256_impl(&ctx->hash_ctx, output, x, y, data);
     } else {
-        ret = hashfp(output, x, y, data);
+        ret = !!hashfp(output, x, y, data);
     }
 
     secp256k1_memclear_explicit(x, sizeof(x));
@@ -71,7 +77,7 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *output, const se
     secp256k1_ge_clear(&pt);
     secp256k1_gej_clear(&res);
 
-    return (!!ret) & is_sec_valid;
+    return ret;
 }
 
 #endif /* SECP256K1_MODULE_ECDH_MAIN_H */

--- a/src/modules/ecdh/tests_impl.h
+++ b/src/modules/ecdh/tests_impl.h
@@ -48,6 +48,15 @@ static void test_ecdh_api(void) {
     CHECK_ILLEGAL(CTX, secp256k1_ecdh(CTX, res, NULL, s_one, NULL, NULL));
     CHECK_ILLEGAL(CTX, secp256k1_ecdh(CTX, res, &point, NULL, NULL, NULL));
     CHECK(secp256k1_ecdh(CTX, res, &point, s_one, NULL, NULL) == 1);
+
+    /* Check that invalid arguments (corrupted public key, out-of-range secret key) are rejected */
+    {
+        secp256k1_pubkey zero_pk;
+        unsigned char s_zero[32] = { 0 };
+        memset(&zero_pk, 0, sizeof(zero_pk));
+        CHECK_ILLEGAL(CTX, secp256k1_ecdh(CTX, res, &zero_pk, s_one, NULL, NULL));
+        CHECK(secp256k1_ecdh(CTX, res, &point, s_zero, NULL, NULL) == 0);
+    }
 }
 
 static void test_ecdh_generator_basepoint(void) {

--- a/src/modules/ellswift/main_impl.h
+++ b/src/modules/ellswift/main_impl.h
@@ -433,7 +433,7 @@ int secp256k1_ellswift_create(const secp256k1_context *ctx, unsigned char *ell64
     secp256k1_fe t;
     secp256k1_sha256 hash;
     secp256k1_scalar seckey_scalar;
-    int ret;
+    int is_sec_valid;
     static const unsigned char zero32[32] = {0};
 
     /* Sanity check inputs. */
@@ -444,7 +444,11 @@ int secp256k1_ellswift_create(const secp256k1_context *ctx, unsigned char *ell64
     ARG_CHECK(seckey32 != NULL);
 
     /* Compute (affine) public key */
-    ret = secp256k1_ec_pubkey_create_helper(&ctx->ecmult_gen_ctx, &seckey_scalar, &p, seckey32);
+    is_sec_valid = secp256k1_ec_pubkey_create_helper(&ctx->ecmult_gen_ctx, &seckey_scalar, &p, seckey32);
+    secp256k1_declassify(ctx, &is_sec_valid, sizeof(is_sec_valid));
+    if (!is_sec_valid) {
+        return 0;
+    }
     secp256k1_declassify(ctx, &p, sizeof(p)); /* not constant time in produced pubkey */
     secp256k1_fe_normalize_var(&p.x);
     secp256k1_fe_normalize_var(&p.y);
@@ -462,11 +466,10 @@ int secp256k1_ellswift_create(const secp256k1_context *ctx, unsigned char *ell64
     secp256k1_ellswift_elligatorswift_var(ctx, ell64, &t, &p, &hash); /* puts u in ell64[0..32] */
     secp256k1_fe_get_b32(ell64 + 32, &t); /* puts t in ell64[32..64] */
 
-    secp256k1_memczero(ell64, 64, !ret);
     secp256k1_scalar_clear(&seckey_scalar);
     secp256k1_sha256_clear(&hash);
 
-    return ret;
+    return 1;
 }
 
 int secp256k1_ellswift_decode(const secp256k1_context *ctx, secp256k1_pubkey *pubkey, const unsigned char *ell64) {
@@ -554,9 +557,12 @@ int secp256k1_ellswift_xdh(const secp256k1_context *ctx, unsigned char *output, 
     secp256k1_fe_set_b32_mod(&t, theirs64 + 32);
     secp256k1_ellswift_xswiftec_frac_var(&xn, &xd, &u, &t);
 
-    /* Load private key (using one if invalid). */
+    /* Load private key (return early if invalid). */
     is_sec_valid = secp256k1_scalar_set_b32_seckey(&s, seckey32);
-    secp256k1_scalar_cmov(&s, &secp256k1_scalar_one, !is_sec_valid);
+    secp256k1_declassify(ctx, &is_sec_valid, sizeof(is_sec_valid));
+    if (!is_sec_valid) {
+        return 0;
+    }
 
     /* Compute shared X coordinate. */
     secp256k1_ecmult_const_xonly(&px, &xn, &xd, &s, 1);
@@ -569,14 +575,14 @@ int secp256k1_ellswift_xdh(const secp256k1_context *ctx, unsigned char *output, 
     } else if (hashfp == secp256k1_ellswift_xdh_hash_function_prefix) {
         ret = ellswift_xdh_hash_function_prefix_impl(&ctx->hash_ctx, output, sx, ell_a64, ell_b64, data);
     } else {
-        ret = hashfp(output, sx, ell_a64, ell_b64, data);
+        ret = !!hashfp(output, sx, ell_a64, ell_b64, data);
     }
 
     secp256k1_memclear_explicit(sx, sizeof(sx));
     secp256k1_fe_clear(&px);
     secp256k1_scalar_clear(&s);
 
-    return (!!ret) & is_sec_valid;
+    return ret;
 }
 
 #endif

--- a/src/modules/ellswift/tests_impl.h
+++ b/src/modules/ellswift/tests_impl.h
@@ -512,6 +512,7 @@ void ellswift_xdh_bad_scalar_tests(void) {
     testutil_random_scalar_order(&rand_scalar);
     secp256k1_scalar_get_b32(s_good, &rand_scalar);
 
+    CHECK(secp256k1_ellswift_create(CTX, ell_a64, s_zero, NULL) == 0);
     CHECK(secp256k1_ellswift_create(CTX, ell_a64, s_good, NULL) == 1);
 
     testrand256_test(ell_b64);

--- a/src/modules/schnorrsig/main_impl.h
+++ b/src/modules/schnorrsig/main_impl.h
@@ -128,7 +128,7 @@ static int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsi
     unsigned char nonce32[32] = { 0 };
     unsigned char pk_buf[32];
     unsigned char seckey[32];
-    int ret = 1;
+    int ret;
 
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
@@ -136,7 +136,10 @@ static int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsi
     ARG_CHECK(msg != NULL || msglen == 0);
     ARG_CHECK(keypair != NULL);
 
-    ret &= secp256k1_keypair_load(ctx, &sk, &pk, keypair);
+    if (!secp256k1_keypair_load(ctx, &sk, &pk, keypair)) {
+        return 0;
+    }
+
     /* Because we are signing for a x-only pubkey, the secret key is negated
      * before signing if the point corresponding to the secret key does not
      * have an even Y. */
@@ -150,9 +153,9 @@ static int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsi
     /* Compute nonce */
     if (noncefp == NULL || noncefp == secp256k1_nonce_function_bip340) {
         /* Use context-aware nonce function by default */
-        ret &= nonce_function_bip340_impl(&ctx->hash_ctx, nonce32, msg, msglen, seckey, pk_buf, bip340_algo, sizeof(bip340_algo), ndata);
+        ret = nonce_function_bip340_impl(&ctx->hash_ctx, nonce32, msg, msglen, seckey, pk_buf, bip340_algo, sizeof(bip340_algo), ndata);
     } else {
-        ret &= !!noncefp(nonce32, msg, msglen, seckey, pk_buf, bip340_algo, sizeof(bip340_algo), ndata);
+        ret = !!noncefp(nonce32, msg, msglen, seckey, pk_buf, bip340_algo, sizeof(bip340_algo), ndata);
     }
 
     secp256k1_scalar_set_b32(&k, nonce32, NULL);


### PR DESCRIPTION
This PR partly addresses issue #1621, handling invalid inputs consistently w.r.t. constant-time, by applying the suggested "functions are constant-time only for valid inputs" approach (number 2. in the issue), for the following modules and API functions:
* ecdh: `secp256k1_ecdh`
* ellswift: `secp256k1_ellswift_create` and `secp256k1_ellswift_xdh`
* schnorrsig: `secp256k1_schnorrsig_sign{32,_custom}`

As stated in #1621, this leads to more readable and maintainable code, getting rid of constructs like `return (!!ret) & is_sec_valid;` or intermediate `ret &= ...;` statements. Conditional assignments like `secp256k1_scalar_cmov` can be removed as well.

Tests are added for the newly introduced branches if there were none. There are still further instances to tackle (mostly the main module API functions in secp256k1.c, and potential cleanups like e.g. removing the dummy assignments in `_keypair_load`), happy to add these here or in another PR, mostly chasing Conecpt ACKs for now if this is we want to handle constant-time behavior for current and future modules.