### PR TITLE
field: Check that argument of _fe_set_int() is a constant

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -80,7 +80,7 @@ static const secp256k1_fe secp256k1_const_beta = SECP256K1_FE_CONST(
 #  define secp256k1_fe_normalize_var secp256k1_fe_impl_normalize_var
 #  define secp256k1_fe_normalizes_to_zero secp256k1_fe_impl_normalizes_to_zero
 #  define secp256k1_fe_normalizes_to_zero_var secp256k1_fe_impl_normalizes_to_zero_var
-#  define secp256k1_fe_set_int secp256k1_fe_impl_set_int
+#  define secp256k1_fe_set_int_unchecked secp256k1_fe_impl_set_int_unchecked
 #  define secp256k1_fe_is_zero secp256k1_fe_impl_is_zero
 #  define secp256k1_fe_is_odd secp256k1_fe_impl_is_odd
 #  define secp256k1_fe_cmp_var secp256k1_fe_impl_cmp_var
@@ -138,10 +138,17 @@ static int secp256k1_fe_normalizes_to_zero_var(const secp256k1_fe *r);
 
 /** Set a field element to an integer in range [0,0x7FFF].
  *
- * On input, r does not need to be initialized, a must be in [0,0x7FFF].
+ * On input, r does not need to be initialized, and a must be an integer
+ * constant expression in [0,0x7FFF].
  * On output, r represents value a, is normalized and has magnitude (a!=0).
  */
-static void secp256k1_fe_set_int(secp256k1_fe *r, int a);
+#define secp256k1_fe_set_int(r, a) ASSERT_INT_CONST_AND_DO(a, secp256k1_fe_set_int_unchecked(r, a))
+
+/** Like secp256k1_fe_set_int but a is not checked to be an integer constant expression.
+ *
+ * Should not be called directly outside of tests.
+ */
+static void secp256k1_fe_set_int_unchecked(secp256k1_fe *r, int a);
 
 /** Clear a field element to prevent leaking sensitive information. */
 static void secp256k1_fe_clear(secp256k1_fe *a);

--- a/src/field.h
+++ b/src/field.h
@@ -217,7 +217,7 @@ static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe *a);
  */
 #define secp256k1_fe_negate(r, a, m) ASSERT_INT_CONST_AND_DO(m, secp256k1_fe_negate_unchecked(r, a, m))
 
-/** Like secp256k1_fe_negate_unchecked but m is not checked to be an integer constant expression.
+/** Like secp256k1_fe_negate but m is not checked to be an integer constant expression.
  *
  * Should not be called directly outside of tests.
  */

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -256,7 +256,7 @@ static int secp256k1_fe_impl_normalizes_to_zero_var(const secp256k1_fe *r) {
     return (z0 == 0) | (z1 == 0x3FFFFFFUL);
 }
 
-SECP256K1_INLINE static void secp256k1_fe_impl_set_int(secp256k1_fe *r, int a) {
+SECP256K1_INLINE static void secp256k1_fe_impl_set_int_unchecked(secp256k1_fe *r, int a) {
     r->n[0] = a;
     r->n[1] = r->n[2] = r->n[3] = r->n[4] = r->n[5] = r->n[6] = r->n[7] = r->n[8] = r->n[9] = 0;
 }

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -198,7 +198,7 @@ static int secp256k1_fe_impl_normalizes_to_zero_var(const secp256k1_fe *r) {
     return (z0 == 0) | (z1 == 0xFFFFFFFFFFFFFULL);
 }
 
-SECP256K1_INLINE static void secp256k1_fe_impl_set_int(secp256k1_fe *r, int a) {
+SECP256K1_INLINE static void secp256k1_fe_impl_set_int_unchecked(secp256k1_fe *r, int a) {
     r->n[0] = a;
     r->n[1] = r->n[2] = r->n[3] = r->n[4] = 0;
 }

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -213,11 +213,11 @@ SECP256K1_INLINE static int secp256k1_fe_normalizes_to_zero_var(const secp256k1_
     return secp256k1_fe_impl_normalizes_to_zero_var(r);
 }
 
-static void secp256k1_fe_impl_set_int(secp256k1_fe *r, int a);
-SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe *r, int a) {
+static void secp256k1_fe_impl_set_int_unchecked(secp256k1_fe *r, int a);
+SECP256K1_INLINE static void secp256k1_fe_set_int_unchecked(secp256k1_fe *r, int a) {
     VERIFY_CHECK(0 <= a && a <= 0x7FFF);
 
-    secp256k1_fe_impl_set_int(r, a);
+    secp256k1_fe_impl_set_int_unchecked(r, a);
     r->magnitude = (a != 0);
     r->normalized = 1;
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -3324,7 +3324,7 @@ static void run_field_misc(void) {
         testutil_random_fe_non_zero(&y);
         v = testrand_bits(15);
         /* Test that fe_add_int is equivalent to fe_set_int + fe_add. */
-        secp256k1_fe_set_int(&q, v); /* q = v */
+        secp256k1_fe_set_int_unchecked(&q, v); /* q = v */
         z = x; /* z = x */
         secp256k1_fe_add(&z, &q); /* z = x+v */
         q = x; /* q = x */
@@ -3531,7 +3531,7 @@ static void run_sqrt(void) {
 
     /* Check sqrt of small squares (and their negatives) */
     for (i = 1; i <= 100; i++) {
-        secp256k1_fe_set_int(&x, i);
+        secp256k1_fe_set_int_unchecked(&x, i);
         secp256k1_fe_sqr(&s, &x);
         test_sqrt(&s, &x);
         secp256k1_fe_negate(&t, &s, 1);


### PR DESCRIPTION
Solves part of https://github.com/bitcoin-core/secp256k1/issues/1001. Overlooked in https://github.com/bitcoin-core/secp256k1/pull/1345.