### PR TITLE
Add license notice to API headers

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_H
 #define SECP256K1_H
 

--- a/include/secp256k1_ecdh.h
+++ b/include/secp256k1_ecdh.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_ECDH_H
 #define SECP256K1_ECDH_H
 

--- a/include/secp256k1_ellswift.h
+++ b/include/secp256k1_ellswift.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_ELLSWIFT_H
 #define SECP256K1_ELLSWIFT_H
 

--- a/include/secp256k1_extrakeys.h
+++ b/include/secp256k1_extrakeys.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_EXTRAKEYS_H
 #define SECP256K1_EXTRAKEYS_H
 

--- a/include/secp256k1_musig.h
+++ b/include/secp256k1_musig.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_MUSIG_H
 #define SECP256K1_MUSIG_H
 

--- a/include/secp256k1_preallocated.h
+++ b/include/secp256k1_preallocated.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_PREALLOCATED_H
 #define SECP256K1_PREALLOCATED_H
 

--- a/include/secp256k1_recovery.h
+++ b/include/secp256k1_recovery.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_RECOVERY_H
 #define SECP256K1_RECOVERY_H
 

--- a/include/secp256k1_schnorrsig.h
+++ b/include/secp256k1_schnorrsig.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_SCHNORRSIG_H
 #define SECP256K1_SCHNORRSIG_H
 

--- a/include/secp256k1_silentpayments.h
+++ b/include/secp256k1_silentpayments.h
@@ -1,3 +1,8 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_SILENTPAYMENTS_H
 #define SECP256K1_SILENTPAYMENTS_H
 


### PR DESCRIPTION
This PR attempts to resolve #412 in a pragmatic way, adding the same MIT license block we use in internal files (see e.g. in the most recent modules [ellswift](https://github.com/bitcoin-core/secp256k1/blob/a9a61831bdcd97475e200a4bdd1ebed641f7268d/src/modules/ellswift/main_impl.h#L1-L4), [musig](https://github.com/bitcoin-core/secp256k1/blob/a9a61831bdcd97475e200a4bdd1ebed641f7268d/src/modules/musig/main_impl.h#L1-L4) and [silentpayments](https://github.com/bitcoin-core/secp256k1/blob/a9a61831bdcd97475e200a4bdd1ebed641f7268d/src/modules/silentpayments/main_impl.h#L1-L4)) for the public headers. Depending on how nit-picky we are one could further refine this, e.g.:
* add a copyright line (maybe in [Bitcoin Core's style](https://github.com/bitcoin/bitcoin/blob/dc0395c5858a1d55239b82a834e5075cf2069219/src/kernel/bitcoinkernel.h#L1), e.g. `Copyright (c) 2013-present The libsecp256k1 developers`, with different starting years depending on when a module was developed/merged, or even without any year)?
* use SPDX license identifiers (e.g. `/* SPDX-License-Identifier: MIT */`) for machine readability?
* avoid mentioning the COPYING file since it's not installed? (there is still the URL though)

Probably it's not worth it to spend a lot of time on this; I guess one way to "solve" this is also to simplify leave as-is (and then still close #412 referring to that decision), but it seems at least quite common that public headers in C libraries contain some minimum copyright/licensing information.