### PR TITLE
tests: add coverage for exact-size DER signature serialization

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -6828,6 +6828,18 @@ static void test_ecdsa_end_to_end(void) {
     memset(&signature[0], 0, sizeof(signature[0]));
     CHECK(secp256k1_ecdsa_signature_parse_der(CTX, &signature[0], sig, siglen) == 1);
     CHECK(secp256k1_ecdsa_verify(CTX, &signature[0], message, &pubkey) == 1);
+    /* Serializing into a buffer of exactly the required size succeeds and
+     * yields the same encoding; one byte less fails and reports the size. */
+    {
+        unsigned char sig2[74];
+        size_t siglen2 = siglen;
+        CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, sig2, &siglen2, &signature[0]) == 1);
+        CHECK(siglen2 == siglen);
+        CHECK(secp256k1_memcmp_var(sig2, sig, siglen) == 0);
+        siglen2 = siglen - 1;
+        CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, sig2, &siglen2, &signature[0]) == 0);
+        CHECK(siglen2 == siglen);
+    }
     /* Serialize/destroy/parse DER and verify again. */
     siglen = 74;
     CHECK(secp256k1_ecdsa_signature_serialize_der(CTX, sig, &siglen, &signature[0]) == 1);


### PR DESCRIPTION
The existing tests only serialize into oversized buffers or one that is far too small, so the boundary case where the output buffer is exactly the required size was untested. Check that this succeeds with identical output, and that one byte less fails while reporting the required size.

Kills the following mutant (https://secp256k1.space/src/ecdsa_impl.h#1141): 
```diff
diff --git a/src/ecdsa_impl.h b/src/ecdsa_impl.h
index 5963877..499fe03 100644
--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -176,7 +176,7 @@ static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const
     secp256k1_scalar_get_b32(&s[1], as);
     while (lenR > 1 && rp[0] == 0 && rp[1] < 0x80) { lenR--; rp++; }
     while (lenS > 1 && sp[0] == 0 && sp[1] < 0x80) { lenS--; sp++; }
-    if (*size < 6+lenS+lenR) {
+    if (*size <= 6+lenS+lenR) {
         *size = 6 + lenS + lenR;
         return 0;
     }
```