### PR TITLE
tests: cover rejection of invalid plain seckey alongside a valid one

### DIFF
--- a/src/modules/silentpayments/tests_impl.h
+++ b/src/modules/silentpayments/tests_impl.h
@@ -273,6 +273,23 @@ static void test_send_api(void) {
     p[0] = MALFORMED_SECKEY;
     CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, NULL, 0, p, 1) == 0);
     p[0] = ALICE_SECKEY;
+    /* Check that an invalid plain secret key is caught even when it is passed alongside a valid one.
+     * With a single invalid key, the failure would also be caught by the subsequent zero-sum check,
+     * so use two keys to ensure the seckey loop itself rejects the invalid key. The invalid key is
+     * tested in both positions so that neither the first nor the last key is skipped by the check. */
+    {
+        unsigned char const *p2[2];
+        p2[0] = ALICE_SECKEY;
+        p2[1] = MALFORMED_SECKEY;
+        CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, NULL, 0, p2, 2) == 0);
+        p2[1] = secp256k1_group_order_bytes;
+        CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, NULL, 0, p2, 2) == 0);
+        p2[0] = MALFORMED_SECKEY;
+        p2[1] = ALICE_SECKEY;
+        CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, NULL, 0, p2, 2) == 0);
+        p2[0] = secp256k1_group_order_bytes;
+        CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, NULL, 0, p2, 2) == 0);
+    }
     /* Create malformed recipients by setting all of the public key bytes to zero.
      * Realistically, this would never happen since a bad public key would get caught when
      * trying to parse the public key with _ec_pubkey_parse


### PR DESCRIPTION
The existing silentpayment sender tests only pass a single invalid plain seckey, which parses to a zero scalar and is therefore also rejected by the later zero-sum check. Add a test with a valid key followed by an invalid one so that the early return in the seckey loop itself is exercised.

It kills the following mutant, the only one remaining within 229 ones :) - https://secp256k1.space/src/modules/silentpayments/main_impl.h

```diff
diff --git a/src/modules/silentpayments/main_impl.h b/src/modules/silentpayments/main_impl.h
index 415f2d2..489ec91 100644
--- a/src/modules/silentpayments/main_impl.h
+++ b/src/modules/silentpayments/main_impl.h
@@ -237,7 +237,7 @@ int secp256k1_silentpayments_sender_create_outputs(
     for (i = 0; i < n_seckeys; i++) {
         ret = secp256k1_scalar_set_b32_seckey(&addend, seckeys[i]);
         secp256k1_declassify(ctx, &ret, sizeof(ret));
-        if (!ret) {
+        if (1==0) {
             secp256k1_scalar_clear(&addend);
             secp256k1_scalar_clear(&seckey_sum_scalar);
             return 0;
```