### PR TITLE
silentpayments: drop "empty key arrays must be NULL" requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Fixed
+ - Module `silentpayments`: `secp256k1_silentpayments_sender_create_outputs` and `secp256k1_silentpayments_recipient_prevouts_summary_create` no longer require empty key arrays to be passed as `NULL`. If the corresponding size argument is 0, the array pointer is ignored. This matches the API documentation, which only states that unused arrays *can* be `NULL`, and spares callers from special-casing empty arrays.
+
 ## [0.8.0] - 2026-08-03
 
 #### Added

--- a/src/modules/silentpayments/main_impl.h
+++ b/src/modules/silentpayments/main_impl.h
@@ -210,22 +210,18 @@ int secp256k1_silentpayments_sender_create_outputs(
     ARG_CHECK(recipients != NULL);
     ARG_CHECK(n_recipients > 0);
     ARG_CHECK(outpoint_smallest36 != NULL);
-    ARG_CHECK((seckeys != NULL) || (keypairs != NULL));
-    if (keypairs != NULL) {
-        ARG_CHECK(n_keypairs > 0);
+    ARG_CHECK((n_seckeys > 0) || (n_keypairs > 0));
+    if (n_keypairs > 0) {
+        ARG_CHECK(keypairs != NULL);
         for (i = 0; i < n_keypairs; i++) {
             ARG_CHECK(keypairs[i] != NULL);
         }
-    } else {
-        ARG_CHECK(n_keypairs == 0);
     }
-    if (seckeys != NULL) {
-        ARG_CHECK(n_seckeys > 0);
+    if (n_seckeys > 0) {
+        ARG_CHECK(seckeys != NULL);
         for (i = 0; i < n_seckeys; i++) {
             ARG_CHECK(seckeys[i] != NULL);
         }
-    } else {
-        ARG_CHECK(n_seckeys == 0);
     }
     for (i = 0; i < n_recipients; i++) {
         ARG_CHECK(generated_outputs[i] != NULL);
@@ -504,22 +500,18 @@ int secp256k1_silentpayments_recipient_prevouts_summary_create(
     ARG_CHECK(prevouts_summary != NULL);
     memset(prevouts_summary, 0, sizeof(*prevouts_summary));
     ARG_CHECK(outpoint_smallest36 != NULL);
-    ARG_CHECK((pubkeys != NULL) || (xonly_pubkeys != NULL));
-    if (xonly_pubkeys != NULL) {
-        ARG_CHECK(n_xonly_pubkeys > 0);
+    ARG_CHECK((n_pubkeys > 0) || (n_xonly_pubkeys > 0));
+    if (n_xonly_pubkeys > 0) {
+        ARG_CHECK(xonly_pubkeys != NULL);
         for (i = 0; i < n_xonly_pubkeys; i++) {
             ARG_CHECK(xonly_pubkeys[i] != NULL);
         }
-    } else {
-        ARG_CHECK(n_xonly_pubkeys == 0);
     }
-    if (pubkeys != NULL) {
-        ARG_CHECK(n_pubkeys > 0);
+    if (n_pubkeys > 0) {
+        ARG_CHECK(pubkeys != NULL);
         for (i = 0; i < n_pubkeys; i++) {
             ARG_CHECK(pubkeys[i] != NULL);
         }
-    } else {
-        ARG_CHECK(n_pubkeys == 0);
     }
 
     /* Compute prevouts_pubkey_sum = A_1 + A_2 + ... + A_n.

--- a/src/modules/silentpayments/tests_impl.h
+++ b/src/modules/silentpayments/tests_impl.h
@@ -254,8 +254,13 @@ static void test_send_api(void) {
     /* Check that array arguments are verified */
     CHECK_ILLEGAL(CTX, secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, NULL, 0, NULL, 0));
     CHECK_ILLEGAL(CTX, secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 0, SMALLEST_OUTPOINT, NULL, 0, p, 1));
-    CHECK_ILLEGAL(CTX, secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, t, 0, p, 1));
-    CHECK_ILLEGAL(CTX, secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, t, 1, p, 0));
+    /* Empty key arrays can have both NULL or non-NULL as pointer value */
+    CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, NULL, 0, p, 1));
+    CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, t, 0, p, 1));
+    CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, t, 1, NULL, 0));
+    CHECK(secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, t, 1, p, 0));
+    CHECK_ILLEGAL(CTX, secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, t, 0, NULL, 1));
+    CHECK_ILLEGAL(CTX, secp256k1_silentpayments_sender_create_outputs(CTX, op, rp, 2, SMALLEST_OUTPOINT, NULL, 1, p, 0));
 
     /* Create malformed keys for Alice by using a key that will overflow */
     CHECK(secp256k1_ec_seckey_verify(CTX, secp256k1_group_order_bytes) == 0);
@@ -511,8 +516,11 @@ static void test_recipient_api(void) {
     CHECK_ILLEGAL(CTX, secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, NULL, 1, pp, 1));
     CHECK_ILLEGAL(CTX, secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, tp, 1, NULL, 1));
 
-    CHECK_ILLEGAL(CTX, secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, tp, 0, pp, 1));
-    CHECK_ILLEGAL(CTX, secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, tp, 1, pp, 0));
+    /* Empty key arrays can have both NULL or non-NULL as pointer value */
+    CHECK(secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, NULL, 0, pp, 1));
+    CHECK(secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, tp, 0, pp, 1));
+    CHECK(secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, tp, 1, NULL, 0));
+    CHECK(secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, tp, 1, pp, 0));
     CHECK_ILLEGAL(CTX, secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, NULL, 0, pp, 0));
     CHECK_ILLEGAL(CTX, secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, NULL, 0, NULL, 0));
     CHECK(secp256k1_silentpayments_recipient_prevouts_summary_create(CTX, &ps, SMALLEST_OUTPOINT, tp, 1, pp, 1));


### PR DESCRIPTION
Resolves #1930.