### PR TITLE
Clear secret-dependent variables in `_ecmult_const_xonly`

### DIFF
--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -396,6 +396,10 @@ static int secp256k1_ecmult_const_xonly(secp256k1_fe* r, const secp256k1_fe *n, 
     secp256k1_fe_inv(&i, &i);
     secp256k1_fe_mul(r, &rj.x, &i);
 
+    /* Clear local variables computed from secret scalar q */
+    secp256k1_gej_clear(&rj);
+    secp256k1_fe_clear(&i);
+
     return 1;
 }
 


### PR DESCRIPTION
While working on the refactoring PR #1933, I noticed that there is no `_gej` clearing of the point multiplication result in `_ecmult_const_xonly` (apparently this was missed back then when looking for instances in https://github.com/bitcoin-core/secp256k1/pull/1579#issuecomment-2405693607, likely because in this case there is no `_ge_set_gej` call involved).

Note that for `_ecmult_const` itself there is already a separate PR: https://github.com/bitcoin-core/secp256k1/pull/1885