### PR TITLE
tests: generate scalars_near_split_bounds instead of hardcoding

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -4645,28 +4645,27 @@ static void test_point_times_order(const secp256k1_gej *point) {
  *   - For b in [-3, -1, 1, 3]:
  *     - Output (a*LAMBDA + (ORDER+b)/2) % ORDER
  */
-static const secp256k1_scalar scalars_near_split_bounds[20] = {
-    SECP256K1_SCALAR_CONST(0xd938a566, 0x7f479e3e, 0xb5b3c7fa, 0xefdb3749, 0x3aa0585c, 0xc5ea2367, 0xe1b660db, 0x0209e6fc),
-    SECP256K1_SCALAR_CONST(0xd938a566, 0x7f479e3e, 0xb5b3c7fa, 0xefdb3749, 0x3aa0585c, 0xc5ea2367, 0xe1b660db, 0x0209e6fd),
-    SECP256K1_SCALAR_CONST(0xd938a566, 0x7f479e3e, 0xb5b3c7fa, 0xefdb3749, 0x3aa0585c, 0xc5ea2367, 0xe1b660db, 0x0209e6fe),
-    SECP256K1_SCALAR_CONST(0xd938a566, 0x7f479e3e, 0xb5b3c7fa, 0xefdb3749, 0x3aa0585c, 0xc5ea2367, 0xe1b660db, 0x0209e6ff),
-    SECP256K1_SCALAR_CONST(0x2c9c52b3, 0x3fa3cf1f, 0x5ad9e3fd, 0x77ed9ba5, 0xb294b893, 0x3722e9a5, 0x00e698ca, 0x4cf7632d),
-    SECP256K1_SCALAR_CONST(0x2c9c52b3, 0x3fa3cf1f, 0x5ad9e3fd, 0x77ed9ba5, 0xb294b893, 0x3722e9a5, 0x00e698ca, 0x4cf7632e),
-    SECP256K1_SCALAR_CONST(0x2c9c52b3, 0x3fa3cf1f, 0x5ad9e3fd, 0x77ed9ba5, 0xb294b893, 0x3722e9a5, 0x00e698ca, 0x4cf7632f),
-    SECP256K1_SCALAR_CONST(0x2c9c52b3, 0x3fa3cf1f, 0x5ad9e3fd, 0x77ed9ba5, 0xb294b893, 0x3722e9a5, 0x00e698ca, 0x4cf76330),
-    SECP256K1_SCALAR_CONST(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xd576e735, 0x57a4501d, 0xdfe92f46, 0x681b209f),
-    SECP256K1_SCALAR_CONST(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xd576e735, 0x57a4501d, 0xdfe92f46, 0x681b20a0),
-    SECP256K1_SCALAR_CONST(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xd576e735, 0x57a4501d, 0xdfe92f46, 0x681b20a1),
-    SECP256K1_SCALAR_CONST(0x7fffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xd576e735, 0x57a4501d, 0xdfe92f46, 0x681b20a2),
-    SECP256K1_SCALAR_CONST(0xd363ad4c, 0xc05c30e0, 0xa5261c02, 0x88126459, 0xf85915d7, 0x7825b696, 0xbeebc5c2, 0x833ede11),
-    SECP256K1_SCALAR_CONST(0xd363ad4c, 0xc05c30e0, 0xa5261c02, 0x88126459, 0xf85915d7, 0x7825b696, 0xbeebc5c2, 0x833ede12),
-    SECP256K1_SCALAR_CONST(0xd363ad4c, 0xc05c30e0, 0xa5261c02, 0x88126459, 0xf85915d7, 0x7825b696, 0xbeebc5c2, 0x833ede13),
-    SECP256K1_SCALAR_CONST(0xd363ad4c, 0xc05c30e0, 0xa5261c02, 0x88126459, 0xf85915d7, 0x7825b696, 0xbeebc5c2, 0x833ede14),
-    SECP256K1_SCALAR_CONST(0x26c75a99, 0x80b861c1, 0x4a4c3805, 0x1024c8b4, 0x704d760e, 0xe95e7cd3, 0xde1bfdb1, 0xce2c5a42),
-    SECP256K1_SCALAR_CONST(0x26c75a99, 0x80b861c1, 0x4a4c3805, 0x1024c8b4, 0x704d760e, 0xe95e7cd3, 0xde1bfdb1, 0xce2c5a43),
-    SECP256K1_SCALAR_CONST(0x26c75a99, 0x80b861c1, 0x4a4c3805, 0x1024c8b4, 0x704d760e, 0xe95e7cd3, 0xde1bfdb1, 0xce2c5a44),
-    SECP256K1_SCALAR_CONST(0x26c75a99, 0x80b861c1, 0x4a4c3805, 0x1024c8b4, 0x704d760e, 0xe95e7cd3, 0xde1bfdb1, 0xce2c5a45)
-};
+static void fill_scalars_near_split_bounds(secp256k1_scalar scalars20[20]) {
+    static const int a_values[] = {-2, -1, 0, 1, 2};
+    static const int b_values[] = {-3, -1, 1, 3};
+    size_t i, j;
+    for (i = 0; i < ARRAY_SIZE(a_values); ++i) {
+        for (j = 0; j < ARRAY_SIZE(b_values); ++j) {
+            secp256k1_scalar a, b;
+            secp256k1_scalar_set_int(&a, a_values[i] < 0 ? -a_values[i] : a_values[i]);
+            if (a_values[i] < 0) {
+                secp256k1_scalar_negate(&a, &a);
+            }
+            secp256k1_scalar_mul(&a, &a, &secp256k1_const_lambda);
+            secp256k1_scalar_set_int(&b, b_values[j] < 0 ? -b_values[j] : b_values[j]);
+            if (b_values[j] < 0) {
+                secp256k1_scalar_negate(&b, &b);
+            }
+            secp256k1_scalar_half(&b, &b);
+            secp256k1_scalar_add(&scalars20[i * ARRAY_SIZE(b_values) + j], &a, &b);
+        }
+    }
+}
 
 static void test_ecmult_target(const secp256k1_scalar* target, int mode) {
     /* Mode: 0=ecmult_gen, 1=ecmult, 2=ecmult_const */
@@ -4709,6 +4708,8 @@ static void test_ecmult_target(const secp256k1_scalar* target, int mode) {
 static void run_ecmult_near_split_bound(void) {
     int i;
     unsigned j;
+    secp256k1_scalar scalars_near_split_bounds[20];
+    fill_scalars_near_split_bounds(scalars_near_split_bounds);
     for (i = 0; i < 4*COUNT; ++i) {
         for (j = 0; j < ARRAY_SIZE(scalars_near_split_bounds); ++j) {
             test_ecmult_target(&scalars_near_split_bounds[j], 0);
@@ -4834,7 +4835,10 @@ static void ecmult_const_edges(void) {
     secp256k1_ge point;
     secp256k1_gej res;
     size_t i;
-    size_t cases = 1 + ARRAY_SIZE(scalars_near_split_bounds);
+    size_t cases;
+    secp256k1_scalar scalars_near_split_bounds[20];
+    fill_scalars_near_split_bounds(scalars_near_split_bounds);
+    cases = 1 + ARRAY_SIZE(scalars_near_split_bounds);
 
     /* We are trying to reach the following edge cases (variables are defined as
      * in ecmult_const_impl.h):
@@ -5994,6 +5998,8 @@ static void test_scalar_split(const secp256k1_scalar* full) {
 static void run_endomorphism_tests(void) {
     unsigned i;
     static secp256k1_scalar s;
+    secp256k1_scalar scalars_near_split_bounds[20];
+    fill_scalars_near_split_bounds(scalars_near_split_bounds);
     test_scalar_split(&secp256k1_scalar_zero);
     test_scalar_split(&secp256k1_scalar_one);
     secp256k1_scalar_negate(&s,&secp256k1_scalar_one);


### PR DESCRIPTION
tests: generate scalars_near_split_bounds instead of hardcoding

The hardcoded scalars_near_split_bounds array didn't match its documented formula (a*LAMBDA + (ORDER+b)/2) % ORDER. All 20 entries were off in the same 32-bit window, likely a transcription error.
As a result the vectors only reached ~126-bit outputs through secp256k1_scalar_split_lambda instead of the intended ~127-128-bit boundary, so the case they exist to test was never exercised.

Generate the values at runtime from the formula via fill_scalars_near_split_bounds(), which writes into a caller-provided
array rather than a file-scope static. It is called at each of the three sites that use the array, so the values can no longer drift
from their formula.

Verified the generated values reach within 1-2 units of the true k1_bound/k2_bound from the split_lambda_verify proof, confirming theexisting a/b ranges are sufficient.

Fixes #1920.