### PR TITLE
group: enforce fixed coordinate contracts

### DIFF
--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -96,8 +96,10 @@ static void secp256k1_ecmult_const_odd_multiples_table_globalz(secp256k1_ge *pre
         secp256k1_fe_cmov(&(r)->x, &(pre)[m].x, m == index); \
         secp256k1_fe_cmov(&(r)->y, &(pre)[m].y, m == index); \
     } \
+    secp256k1_fe_normalize_weak(&(r)->y); \
     secp256k1_fe_negate(&neg_y, &(r)->y, 1); \
     secp256k1_fe_cmov(&(r)->y, &neg_y, negative); \
+    SECP256K1_GE_VERIFY_OUTPUT(r); \
 } while(0)
 
 /* For K as defined in the comment of secp256k1_ecmult_const, we have several precomputed
@@ -263,6 +265,7 @@ static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, cons
 
     /* Map the result back to the secp256k1 curve from the isomorphic curve. */
     secp256k1_fe_mul(&r->z, &r->z, &global_z);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 static int secp256k1_ecmult_const_xonly(secp256k1_fe* r, const secp256k1_fe *n, const secp256k1_fe *d, const secp256k1_scalar *q, int known_on_curve) {

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -249,9 +249,12 @@ static void secp256k1_ecmult_gen_gej(const secp256k1_ecmult_gen_context *ecmult_
             }
 
             /* Set add=adds or add=-adds, in constant time, based on sign. */
-            secp256k1_ge_from_storage(&add, &adds);
+            secp256k1_fe_from_storage(&add.x, &adds.x);
+            secp256k1_fe_from_storage(&add.y, &adds.y);
+            add.infinity = 0;
             secp256k1_fe_negate(&neg, &add.y, 1);
             secp256k1_fe_cmov(&add.y, &neg, sign);
+            SECP256K1_GE_VERIFY_OUTPUT(&add);
 
             /* Add the looked up and conditionally negated value to r. */
             if (EXPECT(first, 0)) {

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -73,6 +73,7 @@
 static void secp256k1_ecmult_odd_multiples_table(size_t n, secp256k1_ge *pre_a, secp256k1_fe *zr, secp256k1_fe *z, const secp256k1_gej *a) {
     secp256k1_gej d, ai;
     secp256k1_ge d_ge;
+    secp256k1_fe y;
     size_t i;
 
     VERIFY_CHECK(!secp256k1_gej_is_infinity(a));
@@ -92,10 +93,13 @@ static void secp256k1_ecmult_odd_multiples_table(size_t n, secp256k1_ge *pre_a, 
      * In particular phi(d) is easy to represent in affine coordinates under this isomorphism.
      * This lets us use the faster secp256k1_gej_add_ge_var group addition function that we wouldn't be able to use otherwise.
      */
-    secp256k1_ge_set_xy(&d_ge, &d.x, &d.y);
+    y = d.y;
+    secp256k1_fe_normalize_weak(&y);
+    secp256k1_ge_set_xy(&d_ge, &d.x, &y);
     secp256k1_ge_set_gej_zinv(&pre_a[0], a, &d.z);
     secp256k1_gej_set_ge(&ai, &pre_a[0]);
     ai.z = a->z;
+    SECP256K1_GEJ_VERIFY_OUTPUT(&ai);
 
     /* pre_a[0] is the point (a.x*C^2, a.y*C^3, a.z*C) which is equivalent to a.
      * Set zr[0] to C, which is the ratio between the omitted z(pre_a[0]) value and a.z.
@@ -104,7 +108,9 @@ static void secp256k1_ecmult_odd_multiples_table(size_t n, secp256k1_ge *pre_a, 
 
     for (i = 1; i < n; i++) {
         secp256k1_gej_add_ge_var(&ai, &ai, &d_ge, &zr[i]);
-        secp256k1_ge_set_xy(&pre_a[i], &ai.x, &ai.y);
+        y = ai.y;
+        secp256k1_fe_normalize_weak(&y);
+        secp256k1_ge_set_xy(&pre_a[i], &ai.x, &y);
     }
 
     /* Multiply the last z-coordinate by C to undo the isomorphism.
@@ -128,7 +134,7 @@ SECP256K1_INLINE static void secp256k1_ecmult_table_get_ge(secp256k1_ge *r, cons
         *r = pre[(n-1)/2];
     } else {
         *r = pre[(-n-1)/2];
-        secp256k1_fe_negate(&(r->y), &(r->y), 1);
+        secp256k1_ge_neg(r, r);
     }
 }
 
@@ -138,18 +144,21 @@ SECP256K1_INLINE static void secp256k1_ecmult_table_get_ge_lambda(secp256k1_ge *
         secp256k1_ge_set_xy(r, &x[(n-1)/2], &pre[(n-1)/2].y);
     } else {
         secp256k1_ge_set_xy(r, &x[(-n-1)/2], &pre[(-n-1)/2].y);
-        secp256k1_fe_negate(&(r->y), &(r->y), 1);
+        secp256k1_ge_neg(r, r);
     }
 }
 
 SECP256K1_INLINE static void secp256k1_ecmult_table_get_ge_storage(secp256k1_ge *r, const secp256k1_ge_storage *pre, int n, int w) {
+    const secp256k1_ge_storage *a;
+    secp256k1_fe x, y;
     secp256k1_ecmult_table_verify(n,w);
-    if (n > 0) {
-        secp256k1_ge_from_storage(r, &pre[(n-1)/2]);
-    } else {
-        secp256k1_ge_from_storage(r, &pre[(-n-1)/2]);
-        secp256k1_fe_negate(&(r->y), &(r->y), 1);
+    a = &pre[((n > 0 ? n : -n) - 1) / 2];
+    secp256k1_fe_from_storage(&x, &a->x);
+    secp256k1_fe_from_storage(&y, &a->y);
+    if (n < 0) {
+        secp256k1_fe_negate(&y, &y, 1);
     }
+    secp256k1_ge_set_xy(r, &x, &y);
 }
 
 /** Convert a number to WNAF notation. The number becomes represented by sum(2^i * wnaf[i], i=0..bits),
@@ -360,6 +369,7 @@ static void secp256k1_ecmult_strauss_wnaf(const struct secp256k1_strauss_state *
     if (!secp256k1_gej_is_infinity(r)) {
         secp256k1_fe_mul(&r->z, &r->z, &Z);
     }
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 static void secp256k1_ecmult(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_scalar *na, const secp256k1_scalar *ng) {

--- a/src/group.h
+++ b/src/group.h
@@ -19,8 +19,16 @@ typedef struct {
     int infinity; /* whether this represents the point at infinity */
 } secp256k1_ge;
 
-#define SECP256K1_GE_CONST(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {SECP256K1_FE_CONST((a),(b),(c),(d),(e),(f),(g),(h)), SECP256K1_FE_CONST((i),(j),(k),(l),(m),(n),(o),(p)), 0}
-#define SECP256K1_GE_CONST_INFINITY {SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), 1}
+/* Group constants obey the same coordinate contracts as function outputs. */
+#ifdef VERIFY
+#define SECP256K1_GE_VERIFY_CONST(m) , (m), 0
+#else
+#define SECP256K1_GE_VERIFY_CONST(m)
+#endif
+#define SECP256K1_GE_FE_CONST(m, a, b, c, d, e, f, g, h) {SECP256K1_FE_CONST_INNER((a), (b), (c), (d), (e), (f), (g), (h)) SECP256K1_GE_VERIFY_CONST(m)}
+
+#define SECP256K1_GE_CONST(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {SECP256K1_GE_FE_CONST(SECP256K1_GE_X_MAGNITUDE_MAX, (a),(b),(c),(d),(e),(f),(g),(h)), SECP256K1_GE_FE_CONST(SECP256K1_GE_Y_MAGNITUDE_MAX, (i),(j),(k),(l),(m),(n),(o),(p)), 0}
+#define SECP256K1_GE_CONST_INFINITY {SECP256K1_GE_FE_CONST(SECP256K1_GE_X_MAGNITUDE_MAX, 0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_GE_FE_CONST(SECP256K1_GE_Y_MAGNITUDE_MAX, 0, 0, 0, 0, 0, 0, 0, 0), 1}
 
 /** A group element of the secp256k1 curve, in jacobian coordinates.
  *  Note: For exhastive test mode, secp256k1 is replaced by a small subgroup of a different curve.
@@ -32,8 +40,8 @@ typedef struct {
     int infinity; /* whether this represents the point at infinity */
 } secp256k1_gej;
 
-#define SECP256K1_GEJ_CONST(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {SECP256K1_FE_CONST((a),(b),(c),(d),(e),(f),(g),(h)), SECP256K1_FE_CONST((i),(j),(k),(l),(m),(n),(o),(p)), SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 1), 0}
-#define SECP256K1_GEJ_CONST_INFINITY {SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), 1}
+#define SECP256K1_GEJ_CONST(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {SECP256K1_GE_FE_CONST(SECP256K1_GEJ_X_MAGNITUDE_MAX, (a),(b),(c),(d),(e),(f),(g),(h)), SECP256K1_GE_FE_CONST(SECP256K1_GEJ_Y_MAGNITUDE_MAX, (i),(j),(k),(l),(m),(n),(o),(p)), SECP256K1_GE_FE_CONST(SECP256K1_GEJ_Z_MAGNITUDE_MAX, 0, 0, 0, 0, 0, 0, 0, 1), 0}
+#define SECP256K1_GEJ_CONST_INFINITY {SECP256K1_GE_FE_CONST(SECP256K1_GEJ_X_MAGNITUDE_MAX, 0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_GE_FE_CONST(SECP256K1_GEJ_Y_MAGNITUDE_MAX, 0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_GE_FE_CONST(SECP256K1_GEJ_Z_MAGNITUDE_MAX, 0, 0, 0, 0, 0, 0, 0, 0), 1}
 
 typedef struct {
     secp256k1_fe_storage x;
@@ -44,8 +52,10 @@ typedef struct {
 
 #define SECP256K1_GE_STORAGE_CONST_GET(t) SECP256K1_FE_STORAGE_CONST_GET(t.x), SECP256K1_FE_STORAGE_CONST_GET(t.y)
 
-/** Maximum allowed magnitudes for group element coordinates
- *  in affine (x, y) and jacobian (x, y, z) representation. */
+/** Fixed magnitudes of complete group elements at function boundaries.
+ *  Functions must accept these bounds regardless of how their inputs were
+ *  constructed. Outputs are checked before relaxing their metadata to these
+ *  bounds, with normalized = 0. Internal intermediate values may be tighter. */
 #define SECP256K1_GE_X_MAGNITUDE_MAX  4
 #define SECP256K1_GE_Y_MAGNITUDE_MAX  3
 #define SECP256K1_GEJ_X_MAGNITUDE_MAX 4
@@ -240,5 +250,18 @@ static void secp256k1_ge_verify(const secp256k1_ge *a);
 /** Check invariants on a Jacobian group element (no-op unless VERIFY is enabled). */
 static void secp256k1_gej_verify(const secp256k1_gej *a);
 #define SECP256K1_GEJ_VERIFY(a) secp256k1_gej_verify(a)
+
+/** Check the fixed coordinate metadata of a complete group input. */
+static void secp256k1_ge_verify_input(const secp256k1_ge *a);
+static void secp256k1_gej_verify_input(const secp256k1_gej *a);
+#define SECP256K1_GE_VERIFY_INPUT(a) secp256k1_ge_verify_input(a)
+#define SECP256K1_GEJ_VERIFY_INPUT(a) secp256k1_gej_verify_input(a)
+
+/** Check a complete output, then relax its coordinate metadata to the fixed bounds.
+ *  Does not change coordinate values. Not applicable to cleared or partial objects. */
+static void secp256k1_ge_verify_output(secp256k1_ge *r);
+static void secp256k1_gej_verify_output(secp256k1_gej *r);
+#define SECP256K1_GE_VERIFY_OUTPUT(r) secp256k1_ge_verify_output(r)
+#define SECP256K1_GEJ_VERIFY_OUTPUT(r) secp256k1_gej_verify_output(r)
 
 #endif /* SECP256K1_GROUP_H */

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -95,6 +95,52 @@ static void secp256k1_gej_verify(const secp256k1_gej *a) {
     (void)a;
 }
 
+static void secp256k1_ge_verify_input(const secp256k1_ge *a) {
+    SECP256K1_GE_VERIFY(a);
+#ifdef VERIFY
+    VERIFY_CHECK(a->x.magnitude == SECP256K1_GE_X_MAGNITUDE_MAX);
+    VERIFY_CHECK(a->x.normalized == 0);
+    VERIFY_CHECK(a->y.magnitude == SECP256K1_GE_Y_MAGNITUDE_MAX);
+    VERIFY_CHECK(a->y.normalized == 0);
+#endif
+}
+
+static void secp256k1_ge_verify_output(secp256k1_ge *r) {
+    SECP256K1_GE_VERIFY(r);
+#ifdef VERIFY
+    r->x.magnitude = SECP256K1_GE_X_MAGNITUDE_MAX;
+    r->x.normalized = 0;
+    r->y.magnitude = SECP256K1_GE_Y_MAGNITUDE_MAX;
+    r->y.normalized = 0;
+#endif
+    SECP256K1_GE_VERIFY_INPUT(r);
+}
+
+static void secp256k1_gej_verify_input(const secp256k1_gej *a) {
+    SECP256K1_GEJ_VERIFY(a);
+#ifdef VERIFY
+    VERIFY_CHECK(a->x.magnitude == SECP256K1_GEJ_X_MAGNITUDE_MAX);
+    VERIFY_CHECK(a->x.normalized == 0);
+    VERIFY_CHECK(a->y.magnitude == SECP256K1_GEJ_Y_MAGNITUDE_MAX);
+    VERIFY_CHECK(a->y.normalized == 0);
+    VERIFY_CHECK(a->z.magnitude == SECP256K1_GEJ_Z_MAGNITUDE_MAX);
+    VERIFY_CHECK(a->z.normalized == 0);
+#endif
+}
+
+static void secp256k1_gej_verify_output(secp256k1_gej *r) {
+    SECP256K1_GEJ_VERIFY(r);
+#ifdef VERIFY
+    r->x.magnitude = SECP256K1_GEJ_X_MAGNITUDE_MAX;
+    r->x.normalized = 0;
+    r->y.magnitude = SECP256K1_GEJ_Y_MAGNITUDE_MAX;
+    r->y.normalized = 0;
+    r->z.magnitude = SECP256K1_GEJ_Z_MAGNITUDE_MAX;
+    r->z.normalized = 0;
+#endif
+    SECP256K1_GEJ_VERIFY_INPUT(r);
+}
+
 SECP256K1_INLINE static void secp256k1_ge_impl_set_gej_zinv(secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zi) {
     secp256k1_fe zi2;
     secp256k1_fe zi3;
@@ -107,9 +153,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_set_gej_zinv(secp256k1_ge *r, con
     r->infinity = 0;
 }
 static void secp256k1_ge_set_gej_zinv(secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zi) {
-    SECP256K1_GEJ_VERIFY(a); SECP256K1_FE_VERIFY(zi);
+    SECP256K1_GEJ_VERIFY_INPUT(a); SECP256K1_FE_VERIFY(zi);
     secp256k1_ge_impl_set_gej_zinv(r, a, zi);
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_set_ge_zinv(secp256k1_ge *r, const secp256k1_ge *a, const secp256k1_fe *zi) {
@@ -124,9 +170,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_set_ge_zinv(secp256k1_ge *r, cons
     r->infinity = 0;
 }
 static void secp256k1_ge_set_ge_zinv(secp256k1_ge *r, const secp256k1_ge *a, const secp256k1_fe *zi) {
-    SECP256K1_GE_VERIFY(a); SECP256K1_FE_VERIFY(zi);
+    SECP256K1_GE_VERIFY_INPUT(a); SECP256K1_FE_VERIFY(zi);
     secp256k1_ge_impl_set_ge_zinv(r, a, zi);
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_set_xy(secp256k1_ge *r, const secp256k1_fe *x, const secp256k1_fe *y) {
@@ -137,14 +183,14 @@ SECP256K1_INLINE static void secp256k1_ge_impl_set_xy(secp256k1_ge *r, const sec
 static void secp256k1_ge_set_xy(secp256k1_ge *r, const secp256k1_fe *x, const secp256k1_fe *y) {
     SECP256K1_FE_VERIFY(x); SECP256K1_FE_VERIFY(y);
     secp256k1_ge_impl_set_xy(r, x, y);
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static int secp256k1_ge_impl_is_infinity(const secp256k1_ge *a) {
     return a->infinity;
 }
 static int secp256k1_ge_is_infinity(const secp256k1_ge *a) {
-    SECP256K1_GE_VERIFY(a);
+    SECP256K1_GE_VERIFY_INPUT(a);
     return secp256k1_ge_impl_is_infinity(a);
 }
 
@@ -154,9 +200,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_neg(secp256k1_ge *r, const secp25
     secp256k1_fe_negate(&r->y, &r->y, 1);
 }
 static void secp256k1_ge_neg(secp256k1_ge *r, const secp256k1_ge *a) {
-    SECP256K1_GE_VERIFY(a);
+    SECP256K1_GE_VERIFY_INPUT(a);
     secp256k1_ge_impl_neg(r, a);
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_set_gej(secp256k1_ge *r, secp256k1_gej *a) {
@@ -173,9 +219,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_set_gej(secp256k1_ge *r, secp256k
     r->y = a->y;
 }
 static void secp256k1_ge_set_gej(secp256k1_ge *r, secp256k1_gej *a) {
-    SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GEJ_VERIFY_INPUT(a);
     secp256k1_ge_impl_set_gej(r, a);
-    SECP256K1_GEJ_VERIFY(a); SECP256K1_GE_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(a); SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_set_gej_var(secp256k1_ge *r, secp256k1_gej *a) {
@@ -195,9 +241,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_set_gej_var(secp256k1_ge *r, secp
     secp256k1_ge_set_xy(r, &a->x, &a->y);
 }
 static void secp256k1_ge_set_gej_var(secp256k1_ge *r, secp256k1_gej *a) {
-    SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GEJ_VERIFY_INPUT(a);
     secp256k1_ge_impl_set_gej_var(r, a);
-    SECP256K1_GEJ_VERIFY(a); SECP256K1_GE_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(a); SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_set_all_gej(secp256k1_ge *r, const secp256k1_gej *a, size_t len) {
@@ -229,14 +275,14 @@ static void secp256k1_ge_set_all_gej(secp256k1_ge *r, const secp256k1_gej *a, si
 #ifdef VERIFY
     size_t i;
     for (i = 0; i < len; i++) {
-        SECP256K1_GEJ_VERIFY(&a[i]);
+        SECP256K1_GEJ_VERIFY_INPUT(&a[i]);
         VERIFY_CHECK(!secp256k1_gej_is_infinity(&a[i]));
     }
 #endif
     secp256k1_ge_impl_set_all_gej(r, a, len);
 #ifdef VERIFY
     for (i = 0; i < len; i++) {
-        SECP256K1_GE_VERIFY(&r[i]);
+        SECP256K1_GE_VERIFY_OUTPUT(&r[i]);
     }
 #endif
 }
@@ -286,13 +332,13 @@ static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a
 #ifdef VERIFY
     size_t i;
     for (i = 0; i < len; i++) {
-        SECP256K1_GEJ_VERIFY(&a[i]);
+        SECP256K1_GEJ_VERIFY_INPUT(&a[i]);
     }
 #endif
     secp256k1_ge_impl_set_all_gej_var(r, a, len);
 #ifdef VERIFY
     for (i = 0; i < len; i++) {
-        SECP256K1_GE_VERIFY(&r[i]);
+        SECP256K1_GE_VERIFY_OUTPUT(&r[i]);
     }
 #endif
 }
@@ -303,8 +349,6 @@ SECP256K1_INLINE static void secp256k1_ge_impl_table_set_globalz(size_t len, sec
 
     if (len > 0) {
         i = len - 1;
-        /* Ensure all y values are in weak normal form for fast negation of points */
-        secp256k1_fe_normalize_weak(&a[i].y);
         zs = zr[i];
 
         /* Work our way backwards, using the z-ratios to scale the x/y values. */
@@ -321,14 +365,14 @@ static void secp256k1_ge_table_set_globalz(size_t len, secp256k1_ge *a, const se
 #ifdef VERIFY
     size_t i;
     for (i = 0; i < len; i++) {
-        SECP256K1_GE_VERIFY(&a[i]);
+        SECP256K1_GE_VERIFY_INPUT(&a[i]);
         SECP256K1_FE_VERIFY(&zr[i]);
     }
 #endif
     secp256k1_ge_impl_table_set_globalz(len, a, zr);
 #ifdef VERIFY
     for (i = 0; i < len; i++) {
-        SECP256K1_GE_VERIFY(&a[i]);
+        SECP256K1_GE_VERIFY_OUTPUT(&a[i]);
     }
 #endif
 }
@@ -339,7 +383,7 @@ static void secp256k1_gej_set_infinity(secp256k1_gej *r) {
     secp256k1_fe_set_int(&r->y, 0);
     secp256k1_fe_set_int(&r->z, 0);
 
-    SECP256K1_GEJ_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 static void secp256k1_ge_set_infinity(secp256k1_ge *r) {
@@ -347,7 +391,7 @@ static void secp256k1_ge_set_infinity(secp256k1_ge *r) {
     secp256k1_fe_set_int(&r->x, 0);
     secp256k1_fe_set_int(&r->y, 0);
 
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 static void secp256k1_gej_clear(secp256k1_gej *r) {
@@ -379,7 +423,7 @@ static int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int o
     int ret;
     SECP256K1_FE_VERIFY(x);
     ret = secp256k1_ge_impl_set_xo_var(r, x, odd);
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
     return ret;
 }
 
@@ -390,9 +434,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_set_ge(secp256k1_gej *r, const s
    secp256k1_fe_set_int(&r->z, 1);
 }
 static void secp256k1_gej_set_ge(secp256k1_gej *r, const secp256k1_ge *a) {
-   SECP256K1_GE_VERIFY(a);
+   SECP256K1_GE_VERIFY_INPUT(a);
    secp256k1_gej_impl_set_ge(r, a);
-   SECP256K1_GEJ_VERIFY(r);
+   SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static int secp256k1_gej_impl_eq_var(const secp256k1_gej *a, const secp256k1_gej *b) {
@@ -403,7 +447,7 @@ SECP256K1_INLINE static int secp256k1_gej_impl_eq_var(const secp256k1_gej *a, co
     return secp256k1_gej_is_infinity(&tmp);
 }
 static int secp256k1_gej_eq_var(const secp256k1_gej *a, const secp256k1_gej *b) {
-    SECP256K1_GEJ_VERIFY(b); SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GEJ_VERIFY_INPUT(b); SECP256K1_GEJ_VERIFY_INPUT(a);
     return secp256k1_gej_impl_eq_var(a, b);
 }
 
@@ -415,7 +459,7 @@ SECP256K1_INLINE static int secp256k1_gej_impl_eq_ge_var(const secp256k1_gej *a,
     return secp256k1_gej_is_infinity(&tmp);
 }
 static int secp256k1_gej_eq_ge_var(const secp256k1_gej *a, const secp256k1_ge *b) {
-    SECP256K1_GEJ_VERIFY(a); SECP256K1_GE_VERIFY(b);
+    SECP256K1_GEJ_VERIFY_INPUT(a); SECP256K1_GE_VERIFY_INPUT(b);
     return secp256k1_gej_impl_eq_ge_var(a, b);
 }
 
@@ -436,7 +480,7 @@ SECP256K1_INLINE static int secp256k1_ge_impl_eq_var(const secp256k1_ge *a, cons
     return 1;
 }
 static int secp256k1_ge_eq_var(const secp256k1_ge *a, const secp256k1_ge *b) {
-    SECP256K1_GE_VERIFY(a); SECP256K1_GE_VERIFY(b);
+    SECP256K1_GE_VERIFY_INPUT(a); SECP256K1_GE_VERIFY_INPUT(b);
     return secp256k1_ge_impl_eq_var(a, b);
 }
 
@@ -448,7 +492,7 @@ SECP256K1_INLINE static int secp256k1_gej_impl_eq_x_var(const secp256k1_fe *x, c
     return secp256k1_fe_equal(&r, &a->x);
 }
 static int secp256k1_gej_eq_x_var(const secp256k1_fe *x, const secp256k1_gej *a) {
-    SECP256K1_FE_VERIFY(x); SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_FE_VERIFY(x); SECP256K1_GEJ_VERIFY_INPUT(a);
     return secp256k1_gej_impl_eq_x_var(x, a);
 }
 
@@ -461,16 +505,16 @@ SECP256K1_INLINE static void secp256k1_gej_impl_neg(secp256k1_gej *r, const secp
     secp256k1_fe_negate(&r->y, &r->y, 1);
 }
 static void secp256k1_gej_neg(secp256k1_gej *r, const secp256k1_gej *a) {
-    SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GEJ_VERIFY_INPUT(a);
     secp256k1_gej_impl_neg(r, a);
-    SECP256K1_GEJ_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static int secp256k1_gej_impl_is_infinity(const secp256k1_gej *a) {
     return a->infinity;
 }
 static int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
-    SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GEJ_VERIFY_INPUT(a);
     return secp256k1_gej_impl_is_infinity(a);
 }
 
@@ -487,7 +531,7 @@ SECP256K1_INLINE static int secp256k1_ge_impl_is_valid_var(const secp256k1_ge *a
     return secp256k1_fe_equal(&y2, &x3);
 }
 static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
-    SECP256K1_GE_VERIFY(a);
+    SECP256K1_GE_VERIFY_INPUT(a);
     return secp256k1_ge_impl_is_valid_var(a);
 }
 
@@ -523,9 +567,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_double(secp256k1_gej *r, const s
     secp256k1_fe_negate(&r->y, &r->y, 2);  /* Y3 = -(L*(X3 + T) + S^2) (3) */
 }
 SECP256K1_INLINE static void secp256k1_gej_double(secp256k1_gej *r, const secp256k1_gej *a) {
-    SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GEJ_VERIFY_INPUT(a);
     secp256k1_gej_impl_double(r, a);
-    SECP256K1_GEJ_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_gej_impl_double_var(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr) {
@@ -555,9 +599,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_double_var(secp256k1_gej *r, con
     secp256k1_gej_double(r, a);
 }
 static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr) {
-    SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GEJ_VERIFY_INPUT(a);
     secp256k1_gej_impl_double_var(r, a, rzr);
-    SECP256K1_GEJ_VERIFY(r); if (rzr != NULL) SECP256K1_FE_VERIFY(rzr);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r); if (rzr != NULL) SECP256K1_FE_VERIFY(rzr);
 }
 
 SECP256K1_INLINE static void secp256k1_gej_impl_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr) {
@@ -620,9 +664,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_add_var(secp256k1_gej *r, const 
     secp256k1_fe_add(&r->y, &h3);
 }
 static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr) {
-    SECP256K1_GEJ_VERIFY(a); SECP256K1_GEJ_VERIFY(b);
+    SECP256K1_GEJ_VERIFY_INPUT(a); SECP256K1_GEJ_VERIFY_INPUT(b);
     secp256k1_gej_impl_add_var(r, a, b, rzr);
-    SECP256K1_GEJ_VERIFY(r); if (rzr != NULL) SECP256K1_FE_VERIFY(rzr);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r); if (rzr != NULL) SECP256K1_FE_VERIFY(rzr);
 }
 
 SECP256K1_INLINE static void secp256k1_gej_impl_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, secp256k1_fe *rzr) {
@@ -683,9 +727,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_add_ge_var(secp256k1_gej *r, con
     secp256k1_fe_add(&r->y, &h3);
 }
 static void secp256k1_gej_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, secp256k1_fe *rzr) {
-    SECP256K1_GEJ_VERIFY(a); SECP256K1_GE_VERIFY(b);
+    SECP256K1_GEJ_VERIFY_INPUT(a); SECP256K1_GE_VERIFY_INPUT(b);
     secp256k1_gej_impl_add_ge_var(r, a, b, rzr);
-    SECP256K1_GEJ_VERIFY(r); if (rzr != NULL) SECP256K1_FE_VERIFY(rzr);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r); if (rzr != NULL) SECP256K1_FE_VERIFY(rzr);
 }
 
 SECP256K1_INLINE static void secp256k1_gej_impl_add_zinv_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, const secp256k1_fe *bzinv) {
@@ -752,9 +796,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_add_zinv_var(secp256k1_gej *r, c
     secp256k1_fe_add(&r->y, &h3);
 }
 static void secp256k1_gej_add_zinv_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, const secp256k1_fe *bzinv) {
-    SECP256K1_GEJ_VERIFY(a); SECP256K1_GE_VERIFY(b); SECP256K1_FE_VERIFY(bzinv);
+    SECP256K1_GEJ_VERIFY_INPUT(a); SECP256K1_GE_VERIFY_INPUT(b); SECP256K1_FE_VERIFY(bzinv);
     secp256k1_gej_impl_add_zinv_var(r, a, b, bzinv);
-    SECP256K1_GEJ_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 
@@ -891,9 +935,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_add_ge(secp256k1_gej *r, const s
     r->infinity = secp256k1_fe_normalizes_to_zero(&r->z);
 }
 static void secp256k1_gej_add_ge(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b) {
-    SECP256K1_GEJ_VERIFY(a); SECP256K1_GE_VERIFY(b);
+    SECP256K1_GEJ_VERIFY_INPUT(a); SECP256K1_GE_VERIFY_INPUT(b);
     secp256k1_gej_impl_add_ge(r, a, b);
-    SECP256K1_GEJ_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_gej_impl_rescale(secp256k1_gej *r, const secp256k1_fe *s) {
@@ -908,9 +952,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_rescale(secp256k1_gej *r, const 
     secp256k1_fe_mul(&r->z, &r->z, s);                  /* r->z *= s   */
 }
 static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *s) {
-    SECP256K1_GEJ_VERIFY(r); SECP256K1_FE_VERIFY(s);
+    SECP256K1_GEJ_VERIFY_INPUT(r); SECP256K1_FE_VERIFY(s);
     secp256k1_gej_impl_rescale(r, s);
-    SECP256K1_GEJ_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_to_storage(secp256k1_ge_storage *r, const secp256k1_ge *a) {
@@ -925,7 +969,7 @@ SECP256K1_INLINE static void secp256k1_ge_impl_to_storage(secp256k1_ge_storage *
     secp256k1_fe_to_storage(&r->y, &y);
 }
 static void secp256k1_ge_to_storage(secp256k1_ge_storage *r, const secp256k1_ge *a) {
-    SECP256K1_GE_VERIFY(a);
+    SECP256K1_GE_VERIFY_INPUT(a);
     secp256k1_ge_impl_to_storage(r, a);
 }
 
@@ -934,7 +978,7 @@ static void secp256k1_ge_from_storage(secp256k1_ge *r, const secp256k1_ge_storag
     secp256k1_fe_from_storage(&r->y, &a->y);
     r->infinity = 0;
 
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_gej_impl_cmov(secp256k1_gej *r, const secp256k1_gej *a, int flag) {
@@ -945,9 +989,9 @@ SECP256K1_INLINE static void secp256k1_gej_impl_cmov(secp256k1_gej *r, const sec
     r->infinity ^= (r->infinity ^ a->infinity) & flag;
 }
 SECP256K1_INLINE static void secp256k1_gej_cmov(secp256k1_gej *r, const secp256k1_gej *a, int flag) {
-    SECP256K1_GEJ_VERIFY(r); SECP256K1_GEJ_VERIFY(a);
+    SECP256K1_GEJ_VERIFY_INPUT(r); SECP256K1_GEJ_VERIFY_INPUT(a);
     secp256k1_gej_impl_cmov(r, a, flag);
-    SECP256K1_GEJ_VERIFY(r);
+    SECP256K1_GEJ_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_storage_cmov(secp256k1_ge_storage *r, const secp256k1_ge_storage *a, int flag) {
@@ -961,9 +1005,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_mul_lambda(secp256k1_ge *r, const
     secp256k1_fe_mul(&r->x, &r->x, &secp256k1_const_beta);
 }
 static void secp256k1_ge_mul_lambda(secp256k1_ge *r, const secp256k1_ge *a) {
-    SECP256K1_GE_VERIFY(a);
+    SECP256K1_GE_VERIFY_INPUT(a);
     secp256k1_ge_impl_mul_lambda(r, a);
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static int secp256k1_ge_impl_is_in_correct_subgroup(const secp256k1_ge* ge) {
@@ -987,7 +1031,7 @@ SECP256K1_INLINE static int secp256k1_ge_impl_is_in_correct_subgroup(const secp2
 #endif
 }
 static int secp256k1_ge_is_in_correct_subgroup(const secp256k1_ge* ge) {
-    SECP256K1_GE_VERIFY(ge);
+    SECP256K1_GE_VERIFY_INPUT(ge);
     return secp256k1_ge_impl_is_in_correct_subgroup(ge);
 }
 
@@ -1040,7 +1084,7 @@ SECP256K1_INLINE static void secp256k1_ge_impl_to_bytes(unsigned char *buf, cons
     memcpy(buf, &s, 64);
 }
 static void secp256k1_ge_to_bytes(unsigned char *buf, const secp256k1_ge *a) {
-    SECP256K1_GE_VERIFY(a);
+    SECP256K1_GE_VERIFY_INPUT(a);
     secp256k1_ge_impl_to_bytes(buf, a);
 }
 
@@ -1053,7 +1097,7 @@ SECP256K1_INLINE static void secp256k1_ge_impl_from_bytes(secp256k1_ge *r, const
 }
 static void secp256k1_ge_from_bytes(secp256k1_ge *r, const unsigned char *buf) {
     secp256k1_ge_impl_from_bytes(r, buf);
-    SECP256K1_GE_VERIFY(r);
+    SECP256K1_GE_VERIFY_OUTPUT(r);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_to_bytes_ext(unsigned char *data, const secp256k1_ge *ge) {
@@ -1064,7 +1108,7 @@ SECP256K1_INLINE static void secp256k1_ge_impl_to_bytes_ext(unsigned char *data,
     }
 }
 static void secp256k1_ge_to_bytes_ext(unsigned char *data, const secp256k1_ge *ge) {
-    SECP256K1_GE_VERIFY(ge);
+    SECP256K1_GE_VERIFY_INPUT(ge);
     secp256k1_ge_impl_to_bytes_ext(data, ge);
 }
 
@@ -1078,7 +1122,7 @@ SECP256K1_INLINE static void secp256k1_ge_impl_from_bytes_ext(secp256k1_ge *ge, 
 }
 static void secp256k1_ge_from_bytes_ext(secp256k1_ge *ge, const unsigned char *data) {
     secp256k1_ge_impl_from_bytes_ext(ge, data);
-    SECP256K1_GE_VERIFY(ge);
+    SECP256K1_GE_VERIFY_OUTPUT(ge);
 }
 
 SECP256K1_INLINE static int secp256k1_ge_impl_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size) {
@@ -1103,7 +1147,7 @@ SECP256K1_INLINE static int secp256k1_ge_impl_parse(secp256k1_ge *elem, const un
 static int secp256k1_ge_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size) {
     int ret = secp256k1_ge_impl_parse(elem, pub, size);
     if (ret) {
-        SECP256K1_GE_VERIFY(elem);
+        SECP256K1_GE_VERIFY_OUTPUT(elem);
     }
     return ret;
 }
@@ -1117,9 +1161,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_serialize33(secp256k1_ge *elem, u
     secp256k1_fe_get_b32(&pub33[1], &elem->x);
 }
 static void secp256k1_ge_serialize33(secp256k1_ge *elem, unsigned char *pub33) {
-    SECP256K1_GE_VERIFY(elem);
+    SECP256K1_GE_VERIFY_INPUT(elem);
     secp256k1_ge_impl_serialize33(elem, pub33);
-    SECP256K1_GE_VERIFY(elem);
+    SECP256K1_GE_VERIFY_OUTPUT(elem);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_serialize65(secp256k1_ge *elem, unsigned char *pub65) {
@@ -1132,9 +1176,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_serialize65(secp256k1_ge *elem, u
     secp256k1_fe_get_b32(&pub65[33], &elem->y);
 }
 static void secp256k1_ge_serialize65(secp256k1_ge *elem, unsigned char *pub65) {
-    SECP256K1_GE_VERIFY(elem);
+    SECP256K1_GE_VERIFY_INPUT(elem);
     secp256k1_ge_impl_serialize65(elem, pub65);
-    SECP256K1_GE_VERIFY(elem);
+    SECP256K1_GE_VERIFY_OUTPUT(elem);
 }
 
 SECP256K1_INLINE static void secp256k1_ge_impl_serialize_ext33(unsigned char *out33, secp256k1_ge *ge) {
@@ -1146,9 +1190,9 @@ SECP256K1_INLINE static void secp256k1_ge_impl_serialize_ext33(unsigned char *ou
     }
 }
 static void secp256k1_ge_serialize_ext33(unsigned char *out33, secp256k1_ge *ge) {
-    SECP256K1_GE_VERIFY(ge);
+    SECP256K1_GE_VERIFY_INPUT(ge);
     secp256k1_ge_impl_serialize_ext33(out33, ge);
-    SECP256K1_GE_VERIFY(ge);
+    SECP256K1_GE_VERIFY_OUTPUT(ge);
 }
 
 SECP256K1_INLINE static int secp256k1_ge_impl_parse_ext33(secp256k1_ge *ge, const unsigned char *in33) {
@@ -1166,7 +1210,7 @@ SECP256K1_INLINE static int secp256k1_ge_impl_parse_ext33(secp256k1_ge *ge, cons
 static int secp256k1_ge_parse_ext33(secp256k1_ge *ge, const unsigned char *in33) {
     int ret = secp256k1_ge_impl_parse_ext33(ge, in33);
     if (ret) {
-        SECP256K1_GE_VERIFY(ge);
+        SECP256K1_GE_VERIFY_OUTPUT(ge);
     }
     return ret;
 }

--- a/src/modules/ellswift/main_impl.h
+++ b/src/modules/ellswift/main_impl.h
@@ -373,9 +373,12 @@ static void secp256k1_ellswift_xelligatorswift_var(const secp256k1_context *ctx,
  * one.
  */
 static void secp256k1_ellswift_elligatorswift_var(const secp256k1_context *ctx, unsigned char *u32, secp256k1_fe *t, const secp256k1_ge *p, const secp256k1_sha256 *hasher) {
+    secp256k1_fe y = p->y;
+    SECP256K1_GE_VERIFY_INPUT(p);
+    secp256k1_fe_normalize_var(&y);
     secp256k1_ellswift_xelligatorswift_var(ctx, u32, t, &p->x, hasher);
     secp256k1_fe_normalize_var(t);
-    if (secp256k1_fe_is_odd(t) != secp256k1_fe_is_odd(&p->y)) {
+    if (secp256k1_fe_is_odd(t) != secp256k1_fe_is_odd(&y)) {
         secp256k1_fe_negate(t, t, 1);
         secp256k1_fe_normalize_var(t);
     }
@@ -446,8 +449,6 @@ int secp256k1_ellswift_create(const secp256k1_context *ctx, unsigned char *ell64
     /* Compute (affine) public key */
     ret = secp256k1_ec_pubkey_create_helper(&ctx->ecmult_gen_ctx, &seckey_scalar, &p, seckey32);
     secp256k1_declassify(ctx, &p, sizeof(p)); /* not constant time in produced pubkey */
-    secp256k1_fe_normalize_var(&p.x);
-    secp256k1_fe_normalize_var(&p.y);
 
     /* Set up hasher state. The used RNG is H(seckey32 || "\x00"*32 [|| auxrnd32] || cnt++),
      * using BIP340 tagged hash with tag "secp256k1_ellswift_create". */

--- a/src/modules/ellswift/tests_impl.h
+++ b/src/modules/ellswift/tests_impl.h
@@ -211,6 +211,7 @@ void ellswift_decoding_test_vectors_tests(void) {
         ret = secp256k1_pubkey_load(CTX, &ge, &pubkey);
         CHECK(ret);
         CHECK(fe_equal(&testcase->x, &ge.x));
+        secp256k1_fe_normalize_var(&ge.y);
         CHECK(secp256k1_fe_is_odd(&ge.y) == testcase->odd_y);
     }
 }

--- a/src/modules/extrakeys/main_impl.h
+++ b/src/modules/extrakeys/main_impl.h
@@ -59,6 +59,7 @@ int secp256k1_xonly_pubkey_serialize(const secp256k1_context* ctx, unsigned char
     if (!secp256k1_xonly_pubkey_load(ctx, &pk, pubkey)) {
         return 0;
     }
+    secp256k1_fe_normalize_var(&pk.x);
     secp256k1_fe_get_b32(output32, &pk.x);
     return 1;
 }
@@ -91,15 +92,17 @@ int secp256k1_xonly_pubkey_cmp(const secp256k1_context* ctx, const secp256k1_xon
 
 /** Keeps a group element as is if it has an even Y and otherwise negates it.
  *  y_parity is set to 0 in the former case and to 1 in the latter case.
- *  Requires that the coordinates of r are normalized. */
+ *  Accepts a complete group element and returns one with fixed metadata. */
 static int secp256k1_extrakeys_ge_even_y(secp256k1_ge *r) {
     int y_parity = 0;
     VERIFY_CHECK(!secp256k1_ge_is_infinity(r));
 
+    secp256k1_fe_normalize_var(&r->y);
     if (secp256k1_fe_is_odd(&r->y)) {
         secp256k1_fe_negate(&r->y, &r->y, 1);
         y_parity = 1;
     }
+    SECP256K1_GE_VERIFY_OUTPUT(r);
     return y_parity;
 }
 

--- a/src/modules/extrakeys/tests_impl.h
+++ b/src/modules/extrakeys/tests_impl.h
@@ -55,6 +55,9 @@ static void test_xonly_pubkey(void) {
     CHECK(pk_parity == 1);
     CHECK(secp256k1_pubkey_load(CTX, &pk1, &pk) == 1);
     CHECK(secp256k1_pubkey_load(CTX, &pk2, (secp256k1_pubkey *) &xonly_pk) == 1);
+    secp256k1_fe_normalize_weak(&pk1.x);
+    secp256k1_fe_normalize_weak(&pk1.y);
+    secp256k1_fe_normalize_weak(&pk2.y);
     CHECK(secp256k1_fe_equal(&pk1.x, &pk2.x) == 1);
     secp256k1_fe_negate(&y, &pk2.y, 1);
     CHECK(secp256k1_fe_equal(&pk1.y, &y) == 1);

--- a/src/modules/musig/keyagg_impl.h
+++ b/src/modules/musig/keyagg_impl.h
@@ -101,8 +101,7 @@ static void secp256k1_musig_keyaggcoef_sha256(secp256k1_sha256 *sha) {
 /* Compute KeyAgg coefficient which is constant 1 for the second pubkey and
  * otherwise tagged_hash(pks_hash, pk) where pks_hash is the hash of public keys.
  * second_pk is the point at infinity in case there is no second_pk. Assumes
- * that pk is not the point at infinity and that the Y-coordinates of pk and
- * second_pk are normalized. */
+ * that pk is not the point at infinity. */
 static void secp256k1_musig_keyaggcoef_internal(const secp256k1_hash_ctx *hash_ctx, secp256k1_scalar *r, const unsigned char *pks_hash, secp256k1_ge *pk, const secp256k1_ge *second_pk) {
     VERIFY_CHECK(!secp256k1_ge_is_infinity(pk));
 
@@ -123,8 +122,7 @@ static void secp256k1_musig_keyaggcoef_internal(const secp256k1_hash_ctx *hash_c
     }
 }
 
-/* Assumes that pk is not the point at infinity and that the Y-coordinates of pk
- * and cache_i->second_pk are normalized. */
+/* Assumes that pk is not the point at infinity. */
 static void secp256k1_musig_keyaggcoef(const secp256k1_hash_ctx *hash_ctx, secp256k1_scalar *r, const secp256k1_keyagg_cache_internal *cache_i, secp256k1_ge *pk) {
     secp256k1_musig_keyaggcoef_internal(hash_ctx, r, cache_i->pks_hash, pk, &cache_i->second_pk);
 }
@@ -196,7 +194,6 @@ int secp256k1_musig_pubkey_agg(const secp256k1_context* ctx, secp256k1_xonly_pub
         return 0;
     }
     secp256k1_ge_set_gej(&pkp, &pkj);
-    secp256k1_fe_normalize_var(&pkp.y);
     /* The resulting public key is infinity with negligible probability */
     VERIFY_CHECK(!secp256k1_ge_is_infinity(&pkp));
     if (keyagg_cache != NULL) {

--- a/src/modules/musig/session_impl.h
+++ b/src/modules/musig/session_impl.h
@@ -372,6 +372,7 @@ static int secp256k1_musig_nonce_gen_internal(const secp256k1_context* ctx, secp
             return 0;
         }
         /* The loaded point cache_i.pk can not be the point at infinity. */
+        secp256k1_fe_normalize_var(&cache_i.pk.x);
         secp256k1_fe_get_b32(aggpk_ser, &cache_i.pk.x);
         aggpk_ser_ptr = aggpk_ser;
     }
@@ -573,6 +574,7 @@ int secp256k1_musig_nonce_process(const secp256k1_context* ctx, secp256k1_musig_
     if (!secp256k1_keyagg_cache_load(ctx, &cache_i, keyagg_cache)) {
         return 0;
     }
+    secp256k1_fe_normalize_var(&cache_i.pk.x);
     secp256k1_fe_get_b32(agg_pk32, &cache_i.pk.x);
 
     if (!secp256k1_musig_aggnonce_load(ctx, aggnonce_pts, aggnonce)) {
@@ -587,6 +589,7 @@ int secp256k1_musig_nonce_process(const secp256k1_context* ctx, secp256k1_musig_
     if (!secp256k1_scalar_is_zero(&cache_i.tweak)) {
         secp256k1_scalar e_tmp;
         secp256k1_scalar_mul(&e_tmp, &session_i.challenge, &cache_i.tweak);
+        secp256k1_fe_normalize_var(&cache_i.pk.y);
         if (secp256k1_fe_is_odd(&cache_i.pk.y)) {
             secp256k1_scalar_negate(&e_tmp, &e_tmp);
         }
@@ -634,8 +637,7 @@ int secp256k1_musig_partial_sign(const secp256k1_context* ctx, secp256k1_musig_p
         secp256k1_musig_partial_sign_clear(&sk, k);
         return 0;
     }
-    ARG_CHECK(secp256k1_fe_equal(&pk.x, &keypair_pk.x)
-              && secp256k1_fe_equal(&pk.y, &keypair_pk.y));
+    ARG_CHECK(secp256k1_ge_eq_var(&pk, &keypair_pk));
     if (!secp256k1_keyagg_cache_load(ctx, &cache_i, keyagg_cache)) {
         secp256k1_musig_partial_sign_clear(&sk, k);
         return 0;
@@ -644,6 +646,7 @@ int secp256k1_musig_partial_sign(const secp256k1_context* ctx, secp256k1_musig_p
     /* Negate sk if secp256k1_fe_is_odd(&cache_i.pk.y)) XOR cache_i.parity_acc.
      * This corresponds to the line "Let d = g⋅gacc⋅d' mod n" in the
      * specification. */
+    secp256k1_fe_normalize_var(&cache_i.pk.y);
     if ((secp256k1_fe_is_odd(&cache_i.pk.y)
          != cache_i.parity_acc)) {
         secp256k1_scalar_negate(&sk, &sk);
@@ -716,6 +719,7 @@ int secp256k1_musig_partial_sig_verify(const secp256k1_context* ctx, const secp2
     /* Negate e if secp256k1_fe_is_odd(&cache_i.pk.y)) XOR cache_i.parity_acc.
      * This corresponds to the line "Let g' = g⋅gacc mod n" and the multiplication "g'⋅e"
      * in the specification. */
+    secp256k1_fe_normalize_var(&cache_i.pk.y);
     if (secp256k1_fe_is_odd(&cache_i.pk.y)
             != cache_i.parity_acc) {
         secp256k1_scalar_negate(&e, &e);

--- a/src/modules/musig/tests_impl.h
+++ b/src/modules/musig/tests_impl.h
@@ -817,6 +817,7 @@ static void musig_test_vectors_noncegen(void) {
             secp256k1_keyagg_cache_internal cache_i;
             secp256k1_xonly_pubkey aggpk;
             memset(&cache_i, 0, sizeof(cache_i));
+            secp256k1_ge_set_infinity(&cache_i.second_pk);
             CHECK(secp256k1_xonly_pubkey_parse(CTX, &aggpk, c->aggpk));
             CHECK(secp256k1_xonly_pubkey_load(CTX, &cache_i.pk, &aggpk));
             secp256k1_keyagg_cache_save(&keyagg_cache, &cache_i);

--- a/src/modules/schnorrsig/main_impl.h
+++ b/src/modules/schnorrsig/main_impl.h
@@ -140,11 +140,13 @@ static int secp256k1_schnorrsig_sign_internal(const secp256k1_context* ctx, unsi
     /* Because we are signing for a x-only pubkey, the secret key is negated
      * before signing if the point corresponding to the secret key does not
      * have an even Y. */
+    secp256k1_fe_normalize_var(&pk.y);
     if (secp256k1_fe_is_odd(&pk.y)) {
         secp256k1_scalar_negate(&sk, &sk);
     }
 
     secp256k1_scalar_get_b32(seckey, &sk);
+    secp256k1_fe_normalize_var(&pk.x);
     secp256k1_fe_get_b32(pk_buf, &pk.x);
 
     /* Compute nonce */
@@ -235,7 +237,9 @@ int secp256k1_schnorrsig_verify(const secp256k1_context* ctx, const unsigned cha
     }
 
     /* Compute e. */
+    secp256k1_fe_normalize_var(&pk.x);
     secp256k1_fe_get_b32(buf, &pk.x);
+    SECP256K1_GE_VERIFY_OUTPUT(&pk);
     secp256k1_schnorrsig_challenge(&ctx->hash_ctx, &e, &sig64[0], msg, msglen, buf);
 
     /* Compute rj =  s*G + (-e)*pkj */

--- a/src/modules/silentpayments/main_impl.h
+++ b/src/modules/silentpayments/main_impl.h
@@ -175,7 +175,6 @@ static int secp256k1_silentpayments_create_output_pubkey(const secp256k1_context
         secp256k1_scalar_clear(&t_k_scalar);
         return 0;
     }
-    secp256k1_fe_normalize_var(&output_ge.y);
     secp256k1_extrakeys_ge_even_y(&output_ge);
     secp256k1_xonly_pubkey_save(output_xonly, &output_ge);
 
@@ -251,6 +250,7 @@ int secp256k1_silentpayments_sender_create_outputs(
             secp256k1_scalar_clear(&seckey_sum_scalar);
             return 0;
         }
+        secp256k1_fe_normalize_var(&addend_point.y);
         if (secp256k1_fe_is_odd(&addend_point.y)) {
             secp256k1_scalar_negate(&addend, &addend);
         }
@@ -703,7 +703,6 @@ int secp256k1_silentpayments_recipient_scan_outputs(
         secp256k1_ge_neg(&unlabeled_output_negated_ge, &unlabeled_output_ge);
 
         found_idx = -1;
-        secp256k1_fe_normalize_var(&unlabeled_output_ge.y);
         secp256k1_extrakeys_ge_even_y(&unlabeled_output_ge);
         secp256k1_xonly_pubkey_save(&unlabeled_output_xonly, &unlabeled_output_ge);
         for (j = 0; j < n_tx_outputs; j++) {

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -253,7 +253,7 @@ static SECP256K1_INLINE void secp256k1_declassify(const secp256k1_context* ctx, 
 
 static int secp256k1_pubkey_load(const secp256k1_context* ctx, secp256k1_ge* ge, const secp256k1_pubkey* pubkey) {
     secp256k1_ge_from_bytes(ge, pubkey->data);
-    ARG_CHECK(!secp256k1_fe_is_zero(&ge->x));
+    ARG_CHECK(!secp256k1_fe_normalizes_to_zero_var(&ge->x));
     return 1;
 }
 

--- a/src/tests.c
+++ b/src/tests.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include <time.h>
+#include <signal.h>
 
 #ifdef USE_EXTERNAL_DEFAULT_CALLBACKS
     #pragma message("Ignoring USE_EXTERNAL_CALLBACKS in tests.")
@@ -3942,6 +3943,284 @@ static void run_hsort_tests(void) {
 
 /***** GROUP TESTS *****/
 
+/* Vary the actual limbs, not just the verification metadata. n == 0 keeps
+ * the normalized representation; n > 0 adds a multiple of the modulus. */
+static void test_group_fe_magnitude(secp256k1_fe *r, int n) {
+    secp256k1_fe zero;
+    secp256k1_fe_normalize(r);
+    if (n == 0) return;
+    secp256k1_fe_set_int(&zero, 0);
+    secp256k1_fe_negate(&zero, &zero, 0);
+    secp256k1_fe_mul_int_unchecked(&zero, n - 1);
+    secp256k1_fe_add(r, &zero);
+}
+
+static void check_ge_contract(const secp256k1_ge *a) {
+    SECP256K1_GE_VERIFY(a);
+#ifdef VERIFY
+    CHECK(a->x.magnitude == 4 && a->y.magnitude == 3);
+    CHECK(a->x.normalized == 0 && a->y.normalized == 0);
+#endif
+}
+
+static void check_gej_contract(const secp256k1_gej *a) {
+    SECP256K1_GEJ_VERIFY(a);
+#ifdef VERIFY
+    CHECK(a->x.magnitude == 4 && a->y.magnitude == 4 && a->z.magnitude == 1);
+    CHECK(a->x.normalized == 0 && a->y.normalized == 0 && a->z.normalized == 0);
+#endif
+}
+
+static void run_group_magnitude(void) {
+    const secp256k1_ge inf = SECP256K1_GE_CONST_INFINITY;
+    const secp256k1_gej infj = SECP256K1_GEJ_CONST_INFINITY;
+    const secp256k1_fe noncanonical_one = SECP256K1_FE_CONST(
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xfffffffe, 0xfffffc30);
+    secp256k1_ge a, before, b, arr[3];
+    secp256k1_gej aj, bj, beforej, jarr[3];
+    secp256k1_ge_storage storage;
+    secp256k1_fe scale, ratios[3];
+    unsigned char expected[65], serialized[65], zeros[33] = { 0 };
+    int infinity, x, y, z, flag;
+    size_t len;
+
+    check_ge_contract(&secp256k1_ge_const_g);
+    check_ge_contract(&inf);
+    check_gej_contract(&infj);
+    CHECK(!secp256k1_ge_eq_var(&inf, &secp256k1_ge_const_g));
+    CHECK(!secp256k1_ge_eq_var(&secp256k1_ge_const_g, &inf));
+    a = secp256k1_ge_const_g;
+    secp256k1_ge_serialize65(&a, expected);
+    check_ge_contract(&a);
+    for (infinity = 0; infinity < 2; ++infinity) {
+        for (x = 0; x <= 4; ++x) {
+            for (y = 0; y <= 3; ++y) {
+                a = infinity ? inf : secp256k1_ge_const_g;
+                test_group_fe_magnitude(&a.x, x);
+                test_group_fe_magnitude(&a.y, y);
+                before = a;
+                SECP256K1_GE_VERIFY_OUTPUT(&a);
+                check_ge_contract(&a);
+                CHECK(secp256k1_memcmp_var(a.x.n, before.x.n, sizeof(a.x.n)) == 0);
+                CHECK(secp256k1_memcmp_var(a.y.n, before.y.n, sizeof(a.y.n)) == 0);
+                CHECK(a.infinity == before.infinity);
+                SECP256K1_GE_VERIFY_OUTPUT(&a);
+                CHECK(secp256k1_memcmp_var(a.x.n, before.x.n, sizeof(a.x.n)) == 0);
+                CHECK(secp256k1_memcmp_var(a.y.n, before.y.n, sizeof(a.y.n)) == 0);
+                CHECK(secp256k1_ge_eq_var(&a, infinity ? &inf : &secp256k1_ge_const_g));
+                secp256k1_ge_neg(&b, &a);
+                check_ge_contract(&b);
+                secp256k1_ge_neg(&b, &b);
+                check_ge_contract(&b);
+                CHECK(secp256k1_ge_eq_var(&a, &b));
+                secp256k1_gej_set_ge(&aj, &a);
+                check_gej_contract(&aj);
+                secp256k1_ge_set_gej_var(&b, &aj);
+                check_ge_contract(&b);
+                check_gej_contract(&aj);
+                CHECK(secp256k1_ge_eq_var(&a, &b));
+                secp256k1_ge_set_gej(&b, &aj);
+                check_ge_contract(&b);
+                check_gej_contract(&aj);
+                CHECK(secp256k1_ge_eq_var(&a, &b));
+                if (!infinity) {
+                    secp256k1_ge_serialize65(&a, serialized);
+                    check_ge_contract(&a);
+                    CHECK(secp256k1_memcmp_var(expected, serialized, 65) == 0);
+                    secp256k1_ge_to_storage(&storage, &a);
+                    secp256k1_ge_from_storage(&b, &storage);
+                    check_ge_contract(&b);
+                    CHECK(secp256k1_ge_eq_var(&a, &b));
+                }
+            }
+        }
+        for (x = 0; x <= 4; ++x) {
+            for (y = 0; y <= 4; ++y) {
+                for (z = 0; z < 2; ++z) {
+                    secp256k1_gej_set_ge(&aj, infinity ? &inf : &secp256k1_ge_const_g);
+                    test_group_fe_magnitude(&aj.x, x);
+                    test_group_fe_magnitude(&aj.y, y);
+                    /* p+1 exercises a noncanonical magnitude-1 z, which adding
+                     * zero in test_group_fe_magnitude cannot produce. */
+                    if (z) aj.z = noncanonical_one;
+                    beforej = aj;
+                    SECP256K1_GEJ_VERIFY_OUTPUT(&aj);
+                    check_gej_contract(&aj);
+                    CHECK(secp256k1_memcmp_var(aj.x.n, beforej.x.n, sizeof(aj.x.n)) == 0);
+                    CHECK(secp256k1_memcmp_var(aj.y.n, beforej.y.n, sizeof(aj.y.n)) == 0);
+                    CHECK(secp256k1_memcmp_var(aj.z.n, beforej.z.n, sizeof(aj.z.n)) == 0);
+                    CHECK(aj.infinity == beforej.infinity);
+                    CHECK(secp256k1_gej_eq_ge_var(&aj, infinity ? &inf : &secp256k1_ge_const_g));
+                    secp256k1_gej_double(&bj, &aj);
+                    check_gej_contract(&bj);
+                    secp256k1_gej_add_var(&beforej, &aj, &aj, NULL);
+                    check_gej_contract(&beforej);
+                    CHECK(secp256k1_gej_eq_var(&bj, &beforej));
+                    secp256k1_gej_neg(&bj, &aj);
+                    check_gej_contract(&bj);
+                    secp256k1_gej_add_var(&bj, &bj, &aj, NULL);
+                    check_gej_contract(&bj);
+                    CHECK(secp256k1_gej_is_infinity(&bj));
+                    for (flag = 0; flag < 2; ++flag) {
+                        bj = infj;
+                        secp256k1_gej_cmov(&bj, &aj, flag);
+                        check_gej_contract(&bj);
+                        CHECK(secp256k1_gej_eq_var(&bj, flag ? &aj : &infj));
+                    }
+                }
+            }
+        }
+    }
+
+    secp256k1_fe_set_int(&scale, 3);
+    for (len = 0; len < 3; ++len) {
+        secp256k1_gej_set_ge(&jarr[len], &secp256k1_ge_const_g);
+        secp256k1_gej_rescale(&jarr[len], &scale);
+        check_gej_contract(&jarr[len]);
+        ratios[len] = secp256k1_fe_one;
+    }
+    for (len = 0; len <= 3; ++len) {
+        size_t i;
+        secp256k1_ge_set_all_gej(arr, jarr, len);
+        for (i = 0; i < len; ++i) {
+            check_ge_contract(&arr[i]);
+            CHECK(secp256k1_ge_eq_var(&arr[i], &secp256k1_ge_const_g));
+        }
+        secp256k1_ge_table_set_globalz(len, arr, ratios);
+        for (i = 0; i < len; ++i) {
+            check_ge_contract(&arr[i]);
+            CHECK(secp256k1_ge_eq_var(&arr[i], &secp256k1_ge_const_g));
+        }
+    }
+    for (x = 0; x < 8; ++x) {
+        size_t i;
+        for (i = 0; i < 3; ++i) {
+            secp256k1_gej_set_ge(&jarr[i], (x & (1 << i)) ? &inf : &secp256k1_ge_const_g);
+        }
+        secp256k1_ge_set_all_gej_var(arr, jarr, 3);
+        for (i = 0; i < 3; ++i) {
+            check_ge_contract(&arr[i]);
+            CHECK(secp256k1_gej_eq_ge_var(&jarr[i], &arr[i]));
+        }
+    }
+    CHECK(secp256k1_ge_parse(&a, expected, 65));
+    check_ge_contract(&a);
+    secp256k1_ge_serialize33(&a, serialized);
+    check_ge_contract(&a);
+    CHECK(secp256k1_ge_parse_ext33(&b, serialized));
+    check_ge_contract(&b);
+    CHECK(secp256k1_ge_eq_var(&a, &b));
+    CHECK(secp256k1_ge_parse_ext33(&a, zeros));
+    check_ge_contract(&a);
+    secp256k1_ge_serialize_ext33(serialized, &a);
+    check_ge_contract(&a);
+    CHECK(secp256k1_memcmp_var(serialized, zeros, 33) == 0);
+    /* Failed parsing need not initialize the output. */
+    memset(&a, 0xa5, sizeof(a));
+    CHECK(!secp256k1_ge_parse(&a, zeros, 0));
+    memset(serialized, 0xff, 33);
+    serialized[0] = SECP256K1_TAG_PUBKEY_EVEN;
+    CHECK(!secp256k1_ge_parse_ext33(&a, serialized));
+    secp256k1_ge_clear(&a);
+    secp256k1_gej_clear(&aj);
+    CHECK(all_bytes_equal(&a, 0, sizeof(a)));
+    CHECK(all_bytes_equal(&aj, 0, sizeof(aj)));
+}
+
+static void run_group_magnitude_tables(void) {
+    secp256k1_ge table[ECMULT_CONST_TABLE_SIZE], expected, actual;
+    secp256k1_ge_storage storage[ECMULT_CONST_TABLE_SIZE];
+    secp256k1_fe lambda_x[ECMULT_CONST_TABLE_SIZE];
+    secp256k1_gej acc, twice;
+    int i, sign;
+    unsigned int selector;
+
+    secp256k1_gej_set_ge(&acc, &secp256k1_ge_const_g);
+    secp256k1_gej_double(&twice, &acc);
+    for (i = 0; i < ECMULT_CONST_TABLE_SIZE; ++i) {
+        secp256k1_gej tmp = acc;
+        secp256k1_ge_set_gej_var(&table[i], &tmp);
+        test_group_fe_magnitude(&table[i].x, 4);
+        test_group_fe_magnitude(&table[i].y, 3);
+        SECP256K1_GE_VERIFY_OUTPUT(&table[i]);
+        secp256k1_ge_to_storage(&storage[i], &table[i]);
+        secp256k1_fe_mul(&lambda_x[i], &table[i].x, &secp256k1_const_beta);
+        secp256k1_gej_add_var(&acc, &acc, &twice, NULL);
+    }
+    for (i = 0; i < ECMULT_CONST_TABLE_SIZE; ++i) {
+        for (sign = -1; sign <= 1; sign += 2) {
+            int n = sign * (2 * i + 1);
+            expected = table[i];
+            if (sign < 0) secp256k1_ge_neg(&expected, &expected);
+            secp256k1_ecmult_table_get_ge(&actual, table, n, ECMULT_CONST_GROUP_SIZE + 1);
+            check_ge_contract(&actual);
+            CHECK(secp256k1_ge_eq_var(&actual, &expected));
+            secp256k1_ecmult_table_get_ge_storage(&actual, storage, n, ECMULT_CONST_GROUP_SIZE + 1);
+            check_ge_contract(&actual);
+            CHECK(secp256k1_ge_eq_var(&actual, &expected));
+            secp256k1_ge_mul_lambda(&expected, &expected);
+            secp256k1_ecmult_table_get_ge_lambda(&actual, table, lambda_x, n, ECMULT_CONST_GROUP_SIZE + 1);
+            check_ge_contract(&actual);
+            CHECK(secp256k1_ge_eq_var(&actual, &expected));
+        }
+    }
+    for (selector = 0; selector < (1U << ECMULT_CONST_GROUP_SIZE); ++selector) {
+        int n = 2 * (int)selector + 1 - (1 << ECMULT_CONST_GROUP_SIZE);
+        secp256k1_ecmult_table_get_ge_storage(&expected, storage, n, ECMULT_CONST_GROUP_SIZE + 1);
+        ECMULT_CONST_TABLE_GET_GE(&actual, table, selector);
+        check_ge_contract(&actual);
+        CHECK(secp256k1_ge_eq_var(&actual, &expected));
+    }
+}
+
+#if defined(VERIFY) && defined(SUPPORTS_CONCURRENCY)
+static void run_group_magnitude_reject(void) {
+    int coord, failure;
+    secp256k1_ge a = secp256k1_ge_const_g;
+    secp256k1_gej aj;
+    secp256k1_gej_set_ge(&aj, &a);
+    check_ge_contract(&a);
+    check_gej_contract(&aj);
+    for (coord = 0; coord < 5; ++coord) {
+        for (failure = 0; failure < 6; ++failure) {
+            pid_t child;
+            int status;
+            if (failure == 3 && coord != 4) continue;
+            fflush(NULL);
+            child = fork();
+            CHECK(child != -1);
+            if (child == 0) {
+                secp256k1_fe *f = coord == 0 ? &a.x : coord == 1 ? &a.y :
+                    coord == 2 ? &aj.x : coord == 3 ? &aj.y : &aj.z;
+                CHECK(freopen("/dev/null", "w", stderr) != NULL);
+                if (failure == 0 || failure == 3) {
+                    if (failure == 0) f->magnitude--;
+                    else f->normalized = 1;
+                    if (coord < 2) SECP256K1_GE_VERIFY_INPUT(&a);
+                    else SECP256K1_GEJ_VERIFY_INPUT(&aj);
+                } else {
+                    if (failure == 1) f->magnitude++;
+                    else if (failure == 2) { f->magnitude = 2; f->normalized = 1; }
+                    else {
+                        /* These limbs fit every relaxed output bound, but not
+                         * the original magnitude or normalization claim. */
+                        secp256k1_fe_get_bounds(f, 1);
+                        if (failure == 4) f->magnitude = 0;
+                        else f->normalized = 1;
+                    }
+                    if (coord < 2) SECP256K1_GE_VERIFY_OUTPUT(&a);
+                    else SECP256K1_GEJ_VERIFY_OUTPUT(&aj);
+                }
+                _exit(EXIT_SUCCESS);
+            }
+            CHECK(waitpid(child, &status, 0) == child);
+            CHECK(WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT);
+        }
+    }
+}
+#endif
+
 /* This compares jacobian points including their Z, not just their geometric meaning. */
 static int gej_xyz_equals_gej(const secp256k1_gej *a, const secp256k1_gej *b) {
     secp256k1_gej a2;
@@ -4191,7 +4470,9 @@ static void test_ge(void) {
     for (i = 0; i < 4 * runs + 1; i++) {
         int odd;
         testutil_random_ge_test(&ge[i]);
+        secp256k1_fe_normalize(&ge[i].x);
         odd = secp256k1_fe_is_odd(&ge[i].x);
+        SECP256K1_GE_VERIFY_OUTPUT(&ge[i]);
         CHECK(odd == 0 || odd == 1);
         /* randomly set half the points to infinity */
         if (odd == i % 2) {
@@ -4222,6 +4503,7 @@ static void test_ge(void) {
 }
 
 static void test_initialized_inf(void) {
+    const secp256k1_fe zero = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0);
     secp256k1_ge p;
     secp256k1_gej pj, npj, infj1, infj2, infj3;
     secp256k1_fe zinv;
@@ -4233,22 +4515,22 @@ static void test_initialized_inf(void) {
 
     secp256k1_gej_add_var(&infj1, &pj, &npj, NULL);
     CHECK(secp256k1_gej_is_infinity(&infj1));
-    CHECK(secp256k1_fe_is_zero(&infj1.x));
-    CHECK(secp256k1_fe_is_zero(&infj1.y));
-    CHECK(secp256k1_fe_is_zero(&infj1.z));
+    CHECK(secp256k1_memcmp_var(infj1.x.n, zero.n, sizeof(zero.n)) == 0);
+    CHECK(secp256k1_memcmp_var(infj1.y.n, zero.n, sizeof(zero.n)) == 0);
+    CHECK(secp256k1_memcmp_var(infj1.z.n, zero.n, sizeof(zero.n)) == 0);
 
     secp256k1_gej_add_ge_var(&infj2, &npj, &p, NULL);
     CHECK(secp256k1_gej_is_infinity(&infj2));
-    CHECK(secp256k1_fe_is_zero(&infj2.x));
-    CHECK(secp256k1_fe_is_zero(&infj2.y));
-    CHECK(secp256k1_fe_is_zero(&infj2.z));
+    CHECK(secp256k1_memcmp_var(infj2.x.n, zero.n, sizeof(zero.n)) == 0);
+    CHECK(secp256k1_memcmp_var(infj2.y.n, zero.n, sizeof(zero.n)) == 0);
+    CHECK(secp256k1_memcmp_var(infj2.z.n, zero.n, sizeof(zero.n)) == 0);
 
     secp256k1_fe_set_int(&zinv, 1);
     secp256k1_gej_add_zinv_var(&infj3, &npj, &p, &zinv);
     CHECK(secp256k1_gej_is_infinity(&infj3));
-    CHECK(secp256k1_fe_is_zero(&infj3.x));
-    CHECK(secp256k1_fe_is_zero(&infj3.y));
-    CHECK(secp256k1_fe_is_zero(&infj3.z));
+    CHECK(secp256k1_memcmp_var(infj3.x.n, zero.n, sizeof(zero.n)) == 0);
+    CHECK(secp256k1_memcmp_var(infj3.y.n, zero.n, sizeof(zero.n)) == 0);
+    CHECK(secp256k1_memcmp_var(infj3.z.n, zero.n, sizeof(zero.n)) == 0);
 
 
 }
@@ -4440,14 +4722,14 @@ static void test_group_decompress(const secp256k1_fe* x) {
     CHECK(res_even == res_odd);
 
     if (res_even) {
+        /* No infinity allowed. */
+        CHECK(!secp256k1_ge_is_infinity(&ge_even));
+        CHECK(!secp256k1_ge_is_infinity(&ge_odd));
+
         secp256k1_fe_normalize_var(&ge_odd.x);
         secp256k1_fe_normalize_var(&ge_even.x);
         secp256k1_fe_normalize_var(&ge_odd.y);
         secp256k1_fe_normalize_var(&ge_even.y);
-
-        /* No infinity allowed. */
-        CHECK(!secp256k1_ge_is_infinity(&ge_even));
-        CHECK(!secp256k1_ge_is_infinity(&ge_odd));
 
         /* Check that the x coordinates check out. */
         CHECK(secp256k1_fe_equal(&ge_even.x, x));
@@ -4495,6 +4777,8 @@ static void test_pre_g_table(const secp256k1_ge_storage * pre_g, size_t n) {
     secp256k1_gej_double_var(&g2, &g2, NULL);
     secp256k1_ge_set_gej_var(&gg, &g2);
     for (i = 1; i < n; ++i) {
+        secp256k1_fe_normalize_weak(&p.x);
+        secp256k1_fe_normalize_weak(&p.y);
         secp256k1_fe_negate(&dpx, &p.x, 1); secp256k1_fe_add(&dpx, &gg.x); secp256k1_fe_normalize_weak(&dpx);
         secp256k1_fe_negate(&dpy, &p.y, 1); secp256k1_fe_add(&dpy, &gg.y); secp256k1_fe_normalize_weak(&dpy);
         /* Check that p is not equal to gg */
@@ -4502,6 +4786,7 @@ static void test_pre_g_table(const secp256k1_ge_storage * pre_g, size_t n) {
 
         secp256k1_ge_from_storage(&q, &pre_g[i]);
         CHECK(secp256k1_ge_is_valid_var(&q));
+        secp256k1_fe_normalize_weak(&q.x);
 
         secp256k1_fe_negate(&dqx, &q.x, 1); secp256k1_fe_add(&dqx, &gg.x);
         dqy = q.y; secp256k1_fe_add(&dqy, &gg.y);
@@ -8207,6 +8492,11 @@ static const struct tf_test_entry tests_field[] = {
 };
 
 static const struct tf_test_entry tests_group[] = {
+    CASE(group_magnitude),
+    CASE(group_magnitude_tables),
+#if defined(VERIFY) && defined(SUPPORTS_CONCURRENCY)
+    CASE(group_magnitude_reject),
+#endif
     CASE(ge),
     CASE(gej),
     CASE(group_decompress),

--- a/src/tests_exhaustive.c
+++ b/src/tests_exhaustive.c
@@ -111,7 +111,9 @@ static void test_exhaustive_addition(const secp256k1_ge *group, const secp256k1_
             if (secp256k1_gej_is_infinity(&groupj[j])) {
                 secp256k1_ge_set_infinity(&zless_gej);
             } else {
-                secp256k1_ge_set_xy(&zless_gej, &groupj[j].x, &groupj[j].y);
+                secp256k1_fe y = groupj[j].y;
+                secp256k1_fe_normalize_weak(&y);
+                secp256k1_ge_set_xy(&zless_gej, &groupj[j].x, &y);
             }
             secp256k1_gej_add_zinv_var(&tmp, &groupj[i], &zless_gej, &fe_inv);
             CHECK(secp256k1_gej_eq_ge_var(&tmp, &group[(i + j) % EXHAUSTIVE_TEST_ORDER]));

--- a/src/testutil.h
+++ b/src/testutil.h
@@ -78,22 +78,27 @@ static void testutil_random_fe_non_zero_test(secp256k1_fe *fe) {
 
 static void testutil_random_ge_x_magnitude(secp256k1_ge *ge) {
     testutil_random_fe_magnitude(&ge->x, SECP256K1_GE_X_MAGNITUDE_MAX);
+    SECP256K1_GE_VERIFY_OUTPUT(ge);
 }
 
 static void testutil_random_ge_y_magnitude(secp256k1_ge *ge) {
     testutil_random_fe_magnitude(&ge->y, SECP256K1_GE_Y_MAGNITUDE_MAX);
+    SECP256K1_GE_VERIFY_OUTPUT(ge);
 }
 
 static void testutil_random_gej_x_magnitude(secp256k1_gej *gej) {
     testutil_random_fe_magnitude(&gej->x, SECP256K1_GEJ_X_MAGNITUDE_MAX);
+    SECP256K1_GEJ_VERIFY_OUTPUT(gej);
 }
 
 static void testutil_random_gej_y_magnitude(secp256k1_gej *gej) {
     testutil_random_fe_magnitude(&gej->y, SECP256K1_GEJ_Y_MAGNITUDE_MAX);
+    SECP256K1_GEJ_VERIFY_OUTPUT(gej);
 }
 
 static void testutil_random_gej_z_magnitude(secp256k1_gej *gej) {
     testutil_random_fe_magnitude(&gej->z, SECP256K1_GEJ_Z_MAGNITUDE_MAX);
+    SECP256K1_GEJ_VERIFY_OUTPUT(gej);
 }
 
 static void testutil_random_ge_test(secp256k1_ge *ge) {
@@ -102,6 +107,7 @@ static void testutil_random_ge_test(secp256k1_ge *ge) {
         testutil_random_fe_test(&fe);
         if (secp256k1_ge_set_xo_var(ge, &fe, testrand_bits(1))) {
             secp256k1_fe_normalize(&ge->y);
+            SECP256K1_GE_VERIFY_OUTPUT(ge);
             break;
         }
     } while(1);


### PR DESCRIPTION
Refs #1001, building on #1923.

Group operations currently inherit coordinate metadata that can be tighter than their advertised bounds, so successful VERIFY tests can depend on the caller that constructed a point. Require complete `ge`/`gej` inputs to have exactly the affine `(4,3)` or Jacobian `(4,4,1)` magnitude bounds, and publish those bounds at complete outputs after checking the original metadata and actual field limbs. This makes checking each operation against its declared input bounds sufficient, provided its reachable paths are exercised.

The contract also fixes `normalized = 0`: preserving an accidentally normalized input/output would leave the same dependence between callers. That deliberately extends the magnitude-only proposal and requires explicit normalization before parity, serialization and zero checks in several modules. Multiplication tables normalize where a tighter field bound is needed, and complete points are published after direct coordinate construction and the final Z adjustments; partial scratch values and failed parse outputs remain outside the complete-point contract, and clearing still wipes all bytes. Boxed bare-field arithmetic is deferred.

The `group_magnitude`, `group_magnitude_tables` and `group_magnitude_reject` test targets exercise physical representations and unchanged values/limbs, infinity, aliasing, conversions, parsing, serialization, clearing, signed table selection, and rejection of invalid input/output metadata. On POSIX/VERIFY builds, the 26 rejection cases include actual limbs inconsistent with their original claims, so relaxing metadata cannot hide invalid fields; initialized infinity coordinates are checked for exact zero limbs.

Validation of the final source tree:

- ARM64 Clang, default backend, all modules/examples: 242/242 tests at 64 iterations, with `-Werror -pedantic-errors`.
- Native x86_64 Clang: upstream `ci/ci.sh` with int128, assembly, all modules/examples, 64 iterations, warnings as errors, symbol checking, benchmark smoke tests, Valgrind ctime checks, and byte-identical regenerated precomputation/test vectors.
- Native x86_64 int64/10x26, ASan+UBSan, no assembly: 240/240 tests at 16 iterations.
- Fresh LLVM instrumentation preserving VERIFY: 150/150 instrumented changed production lines; 152/152 group branch outcomes after merging matching locations across VERIFY/noverify/exhaustive binaries and filtering assertion/preprocessor/void lines. Raw `group_impl.h` coverage is 99.66% lines and 71.24% branches; the filtered count is not raw branch coverage.
- Additional local parent/patch differential checks: 1,030 keygen/ECDSA/recovery/Schnorr cases and 256 expanded module scenarios plus tweak boundaries, byte-identical across parent Release, patch Release and patched int64 ASan/UBSan builds. The expanded corpus covers ECDH, ElligatorSwift, extrakeys, MuSig and Silent Payments. Mutation checks also exercise the sensitivity of the new assertions.

The subprocess rejection tests require POSIX `fork`; they are not enabled on every platform.

Native x86_64, AMD EPYC 9R14, Ubuntu 24.04, Clang 18 Release with x86_64 assembly: ten alternating parent/patch pairs, 10,000 iterations per internal sample. Medians of reported round averages, in microseconds:

| Operation | Parent | Patch | Change |
|---|---:|---:|---:|
| ecdh | 35.1 | 35.3 | +0.57% |
| ellswift_ecdh | 38 | 38.3 | +0.79% |
| ellswift_encode | 17.6 | 17.6 | +0.00% |
| ellswift_decode | 7.78 | 7.77 | -0.13% |
| ellswift_keygen | 34.4 | 34.4 | +0.00% |
| ec_keygen | 16.8 | 16.8 | +0.00% |
| ecdsa_sign | 22.7 | 22.7 | +0.00% |
| ecdsa_verify | 36.6 | 36.7 | +0.27% |
| ecdsa_recover | 37.8 | 37.9 | +0.26% |
| schnorrsig_sign | 17.8 | 17.8 | +0.00% |
| schnorrsig_verify | 37.1 | 37.2 | +0.27% |

ECDH and ElligatorSwift ECDH show small measured increases; this is not a zero-overhead claim. The measurements are specific to this configuration, with finite sampling and rounded benchmark output.

<details>
<summary>Reproduction commands</summary>

All modules are enabled (including optional recovery). The ordinary suite and the focused new tests can be run with:

```sh
cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DCMAKE_C_FLAGS='-Werror -pedantic-errors' \
  -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_EXAMPLES=ON
cmake --build build -j2
SECP256K1_TEST_ITERS=64 ctest --test-dir build --output-on-failure
build/bin/tests --target=group_magnitude --target=group_magnitude_tables \
  --target=group_magnitude_reject --iterations=16
```

For the 10x26 sanitizer configuration, additionally select `SECP256K1_TEST_OVERRIDE_WIDE_MULTIPLY=int64`, `SECP256K1_ASM=OFF`, `SECP256K1_BUILD_CTIME_TESTS=OFF`, and append `-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer` to `CMAKE_C_FLAGS`.

The native benchmarks use identical Clang Release configurations on parent and patch, with `SECP256K1_ASM=x86_64` and recovery enabled. Run ten pairs, alternating which revision runs first:

```sh
SECP256K1_BENCH_ITERS=10000 build/bin/bench ecdh ellswift keygen sign verify recover
```

Each invocation performs ten internal samples per operation. Results in the table are medians of the ten reported round averages; the machine ran no other validation work during measurement.

</details>

One behavior difference for corrupted opaque pubkeys outside the API contract: an X storage value equal to the field modulus now invokes the illegal-argument callback instead of passing the old zero check.

Implementation and validation used AI assistance under human direction; the checks reported here were executed, and are finite evidence rather than a proof of correctness or constant-time behavior on every platform.
